### PR TITLE
fix: restore full semantic review in tn-quality-check

### DIFF
--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -34,9 +34,8 @@ const DEEP_ISSUE_ID_HINT =
   'Do NOT output text without a tool call or the session will end prematurely.';
 
 const TN_QUALITY_CHECK_HINT =
-  'Run the MCP mechanical checks (fix_trailing_newlines, check_tn_quality) and write the quality report. ' +
-  'Do NOT read the ULT, UST, or notes files for manual semantic review — the mechanical checks cover what matters. ' +
-  'Keep the conversation short: run checks, fix any auto-fixable issues, write the report, done.';
+  'Run the MCP mechanical checks (fix_trailing_newlines, check_tn_quality), then do the full semantic review (Steps 3-4), and write the quality report. ' +
+  'Keep the conversation short: run checks, fix issues, write the report, done.';
 
 // Ranges where the chapter intro is written by the human editor — skip automatically.
 // PSA 42-123: Books 2-4 handled by Benjamin; 119-123 is a subset but listed explicitly.


### PR DESCRIPTION
## Summary
- Removes the line in `TN_QUALITY_CHECK_HINT` that told the model to skip Steps 3-4 (semantic review)
- Quality-check will now run its full workflow including antithetical parallelism filtering (3d), quote scope checks (3i), and other semantic rules

## Why
The hint had been optimized for speed but inadvertently disabled all semantic filtering. This caused antithetical parallelism notes and other issues that should have been caught and removed to pass through to delivery.

## Test plan
- [ ] Trigger a notes run and confirm tn-quality-check conversation is longer than recent fast runs (Steps 3-4 visible in output)
- [ ] Confirm antithetical parallelism notes are removed before delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)