### PR TITLE
feat(pipeline): preserve temp files for 30 days

### DIFF
--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -19,7 +19,7 @@ const { recordMetrics, getCumulativeTokens, recordRunSummary } = require('./usag
 const { door43Push, checkConflictingBranches, REPO_MAP, getRepoFilename } = require('./door43-push');
 const { setPendingMerge } = require('./pending-merges');
 const { getCheckpoint, setCheckpoint, clearCheckpoint } = require('./pipeline-checkpoints');
-const { buildGenerateContext, buildUstContext, cleanupPipelineDir } = require('./pipeline-context');
+const { buildGenerateContext, buildUstContext } = require('./pipeline-context');
 
 const LOG_DIR = path.resolve(__dirname, '../logs');
 const REQUIRED_INITIAL_PIPELINE_FILES = [
@@ -936,12 +936,9 @@ async function generatePipeline(route, message) {
       resume: null,
     });
 
-    // Clean up pipeline working directory
-    if (genPipeDir) {
-      cleanupPipelineDir(genPipeDir);
-      genPipeDir = null;
-      genContextPath = null;
-    }
+    // Pipeline working directory is preserved for debugging (cleaned up after 30 days)
+    genPipeDir = null;
+    genContextPath = null;
   }
 
   if (abortForOutage) {

--- a/src/index.js
+++ b/src/index.js
@@ -174,11 +174,21 @@ const METRICS_FILE = require('path').resolve(__dirname, '../data/metrics/usage.j
 require('fs').mkdirSync(require('path').dirname(METRICS_FILE), { recursive: true });
 startResourceMonitor(METRICS_FILE);
 
-// Clean up stale pipeline working directories from crashed runs
+// Clean up pipeline working directories older than 30 days on startup
 try {
   const { cleanupStalePipelineDirs } = require('./pipeline-context');
   cleanupStalePipelineDirs();
 } catch (_) { /* non-fatal */ }
+
+// Weekly cleanup: remove pipeline dirs older than 30 days
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+setInterval(() => {
+  try {
+    const { cleanupStalePipelineDirs } = require('./pipeline-context');
+    cleanupStalePipelineDirs();
+    console.log('[bot] Weekly pipeline cleanup complete');
+  } catch (_) { /* non-fatal */ }
+}, WEEK_MS).unref();
 
 process.on('unhandledRejection', (reason) => {
   console.error('[bot] Unhandled promise rejection:', reason);

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -23,7 +23,7 @@ const { door43Push, checkConflictingBranches, REPO_MAP, getRepoFilename } = requ
 const { setPendingMerge } = require('./pending-merges');
 const { mergeTsvs } = require('./workspace-tools/tsv-tools');
 const { getCheckpoint, setCheckpoint, clearCheckpoint } = require('./pipeline-checkpoints');
-const { buildNotesContext, updateContextArtifacts, cleanupPipelineDir, readContext, writeContext } = require('./pipeline-context');
+const { buildNotesContext, updateContextArtifacts, readContext, writeContext } = require('./pipeline-context');
 const { checkUltEdits } = require('./check-ult-edits');
 const { getVerseCount } = require('./verse-counts');
 
@@ -1734,12 +1734,9 @@ async function notesPipeline(route, message) {
       resume: null,
     });
 
-    // Clean up pipeline working directory now that the chapter is done
-    if (pipeDir) {
-      cleanupPipelineDir(pipeDir);
-      pipeDir = null;
-      contextPath = null;
-    }
+    // Pipeline working directory is preserved for debugging (cleaned up after 30 days)
+    pipeDir = null;
+    contextPath = null;
 
     // Notify user only after merge is confirmed
     if (chapterCount > 1) {

--- a/src/pipeline-context.js
+++ b/src/pipeline-context.js
@@ -67,16 +67,34 @@ function buildPipeDirName(book, chapter, verseStart, verseEnd) {
 }
 
 /**
+ * Archive a pipeline directory by renaming it with a timestamp suffix.
+ * e.g. tmp/pipeline/HAB-01 → tmp/pipeline/HAB-01-20260410-153045
+ */
+function archivePipelineDir(absPath, dirName) {
+  const ts = new Date().toISOString().replace(/\.\d+Z$/, '').replace(/[-:T]/g, '');
+  const formattedTs = `${ts.slice(0, 8)}-${ts.slice(8, 14)}`;
+  const archivePath = path.join(path.dirname(absPath), `${dirName}-${formattedTs}`);
+  try {
+    fs.renameSync(absPath, archivePath);
+  } catch (_) {
+    // If rename fails (e.g. cross-device), fall back to deletion
+    fs.rmSync(absPath, { recursive: true, force: true });
+  }
+}
+
+/**
  * Create a per-chapter pipeline working directory.
  * Returns the path relative to CSKILLBP_DIR.
+ * When reset=true and the directory already exists, it is archived with a
+ * timestamp suffix so previous run data is preserved for debugging.
  */
 function createPipelineDir({ book, chapter, verseStart, verseEnd, reset = true }) {
   const dirName = buildPipeDirName(book, chapter, verseStart, verseEnd);
   const relPath = `tmp/pipeline/${dirName}`;
   const absPath = path.resolve(CSKILLBP_DIR, relPath);
-  // Clean any stale directory from a previous run when requested.
+  // Archive any stale directory from a previous run instead of deleting it.
   if (reset && fs.existsSync(absPath)) {
-    fs.rmSync(absPath, { recursive: true, force: true });
+    archivePipelineDir(absPath, dirName);
   }
   fs.mkdirSync(absPath, { recursive: true });
   return relPath;
@@ -158,8 +176,9 @@ function extractChapterToDir(dirPath, { sourceFile, chapter, targetFilename }) {
 }
 
 /**
- * Clean up a pipeline working directory.
- * Guarded to only remove directories under tmp/pipeline/.
+ * Archive a pipeline working directory by renaming it with a timestamp suffix.
+ * Guarded to only touch directories under tmp/pipeline/.
+ * Pipeline files are preserved for 30 days to aid debugging.
  */
 function cleanupPipelineDir(dirPath) {
   if (!dirPath || !dirPath.startsWith('tmp/pipeline/')) {
@@ -168,15 +187,19 @@ function cleanupPipelineDir(dirPath) {
   }
   const absPath = path.resolve(CSKILLBP_DIR, dirPath);
   if (fs.existsSync(absPath)) {
-    fs.rmSync(absPath, { recursive: true, force: true });
+    const dirName = path.basename(absPath);
+    archivePipelineDir(absPath, dirName);
   }
 }
 
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
 /**
- * Clean up stale pipeline directories older than maxAgeMs.
- * Call on bot startup to prevent disk buildup from crashed runs.
+ * Clean up stale pipeline directories older than maxAgeMs (default: 30 days).
+ * Call on bot startup and weekly to prevent disk buildup.
+ * Scans all dirs in tmp/pipeline/ — both active run dirs and timestamped archives.
  */
-function cleanupStalePipelineDirs(maxAgeMs = 24 * 60 * 60 * 1000) {
+function cleanupStalePipelineDirs(maxAgeMs = THIRTY_DAYS_MS) {
   const pipelineRoot = path.resolve(CSKILLBP_DIR, 'tmp/pipeline');
   if (!fs.existsSync(pipelineRoot)) return;
   const now = Date.now();
@@ -192,7 +215,7 @@ function cleanupStalePipelineDirs(maxAgeMs = 24 * 60 * 60 * 1000) {
     } catch (_) { /* skip if stat fails */ }
   }
   if (cleaned > 0) {
-    console.log(`[pipeline-context] Cleaned ${cleaned} stale pipeline dir(s)`);
+    console.log(`[pipeline-context] Cleaned ${cleaned} stale pipeline dir(s) (>${Math.round(maxAgeMs / 86400000)}d old)`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Pipeline working dirs are archived with a timestamp suffix instead of being deleted after each successful run
- Stale cleanup threshold raised from 24h to 30 days; weekly cleanup timer added to `index.js`
- Browse previous runs at `/workspace/tmp/pipeline/` on the host

Closes #3

## Test plan
- [ ] Run a notes pipeline chapter, verify `tmp/pipeline/{BOOK}-{CH}/` persists after completion
- [ ] Run the same chapter again, verify the old dir is renamed to `{BOOK}-{CH}-YYYYMMDD-HHmmss/`
- [ ] Restart the bot, verify dirs <30d old are not cleaned up on startup
- [ ] Confirm weekly cleanup timer fires (check logs after 7 days, or temporarily lower `WEEK_MS` for testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)