### PR TITLE
feat(api-runner): rebuild OpenAI native pipeline and harden provider runtimes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@anthropic-ai/sdk": "^0.74.0",
         "@google/genai": "^1.46.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@openai/agents": "^0.8.3",
         "ccusage": "^18.0.10",
         "dotenv": "^17.2.4",
         "fast-glob": "^3.3.3",
@@ -512,6 +513,72 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@openai/agents": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.8.3.tgz",
+      "integrity": "sha512-VmUywYNVaOuBOOv5hdH6tj3UjU3ZOkvM5WyRyEgRXEVkYbISkZuVWlnzEtiZkQ3lWjp0M8GGtKfSq2Dbr5DaQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.8.3",
+        "@openai/agents-openai": "0.8.3",
+        "@openai/agents-realtime": "0.8.3",
+        "debug": "^4.4.0",
+        "openai": "^6.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-core": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.8.3.tgz",
+      "integrity": "sha512-UWRwtGF4t+MkT2xMWTHuEUI2xgp58bKvMYN0rQu6rB9zWtiP0aY5tCXlWUdPKhpPlM/X68u6eUN7qDitqrf50g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "openai": "^6.26.0"
+      },
+      "optionalDependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@openai/agents-openai": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.8.3.tgz",
+      "integrity": "sha512-n5bsRfVDINupkeSh/E/lRoGWUi9xVSRpf6muRjnEckIO0pmCG3NzKO+FQVhiyFA3c8i2vrn28SXF/ZdGcG4+vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.8.3",
+        "debug": "^4.4.0",
+        "openai": "^6.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-realtime": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.8.3.tgz",
+      "integrity": "sha512-no5AdAfYM5V/1u32OEQpP+VOJP/Y/JyTCVOvcgAdSKIV43ZG82f72pxbB0B2aFRdLZwC7C6sDgCJz6pbp+TjRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.8.3",
+        "@types/ws": "^8.18.1",
+        "debug": "^4.4.0",
+        "ws": "^8.18.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -590,6 +657,15 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@anthropic-ai/sdk": "^0.74.0",
     "@google/genai": "^1.46.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@openai/agents": "^0.8.3",
     "ccusage": "^18.0.10",
     "dotenv": "^17.2.4",
     "fast-glob": "^3.3.3",

--- a/scripts/test-providers-zec3.js
+++ b/scripts/test-providers-zec3.js
@@ -1,0 +1,650 @@
+#!/usr/bin/env node
+// scripts/test-providers-zec3.js
+//
+// Multi-provider API pipeline test for Zechariah 3.
+//
+// Mirrors the non-Zulip portion of `src/api-runner/api-pipeline.js`:
+//   1. `api generate zec 3` equivalent  -> initial-pipeline + align-all-parallel
+//   2. `api write notes zec 3 --skip-per` equivalent -> preprocess + tn-writer + tn-quality-check
+// and snapshots the resulting artifacts into /srv/bot/workspace/test/zec-03/<provider>-api/.
+//
+// Does NOT touch Zulip and does NOT push to Door43.
+
+const fs = require('fs');
+const path = require('path');
+
+if (!process.env.CSKILLBP_DIR) {
+  process.env.CSKILLBP_DIR = '/srv/bot/workspace';
+}
+
+const APP_ROOT = '/srv/bot/app';
+const SRC = path.join(APP_ROOT, 'src');
+const WORKSPACE = '/srv/bot/workspace';
+const TEST_ROOT = path.join(WORKSPACE, 'test/zec-03');
+const STEP_ORDER = ['initial', 'align', 'prep', 'tn-writer', 'tn-qc', 'snapshot'];
+const SUPPORTED_PROVIDERS = ['claude', 'openai', 'gemini', 'xai'];
+const REQUIRED_ARTIFACT_KEYS = ['ult', 'ultAligned', 'ust', 'ustAligned', 'issues', 'notes'];
+
+const { runCustom, runSkill } = require(path.join(SRC, 'api-runner/runner'));
+const { getProviderConfig, resolveProviderModel } = require(path.join(SRC, 'api-runner/provider-config'));
+const { getProviderSystemAppend } = require(path.join(SRC, 'api-runner/provider-nudges'));
+const { buildNotesContext, readContext, writeContext } = require(path.join(SRC, 'pipeline-context'));
+const {
+  extractAlignmentData,
+  prepareNotes,
+  fillOrigQuotes,
+  resolveGlQuotes,
+  flagNarrowQuotes,
+  generateIds,
+} = require(path.join(SRC, 'workspace-tools/tn-tools'));
+const { checkPrerequisites, CSKILLBP_DIR } = require(path.join(SRC, 'pipeline-utils'));
+
+function patchConsoleWithTimestamps() {
+  const ts = () => new Date().toISOString().slice(11, 19);
+  for (const level of ['log', 'warn', 'error']) {
+    const original = console[level].bind(console);
+    console[level] = (...args) => original(`[${ts()}]`, ...args);
+  }
+}
+
+function parseArgs(argv) {
+  const out = {
+    provider: null,
+    opusModel: null,
+    sonnetModel: null,
+    resumeFrom: null,
+    keepOutput: false,
+    book: 'ZEC',
+    chapter: 3,
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--provider': out.provider = argv[++i]; break;
+      case '--opus-model': out.opusModel = argv[++i]; break;
+      case '--sonnet-model': out.sonnetModel = argv[++i]; break;
+      case '--resume-from': out.resumeFrom = argv[++i]; break;
+      case '--keep-output': out.keepOutput = true; break;
+      case '--book': out.book = String(argv[++i] || '').toUpperCase(); break;
+      case '--chapter': out.chapter = parseInt(argv[++i], 10); break;
+      default: throw new Error(`Unknown arg: ${arg}`);
+    }
+  }
+
+  if (!out.provider) throw new Error('--provider is required');
+  if (!SUPPORTED_PROVIDERS.includes(out.provider)) {
+    throw new Error(`Unknown provider: ${out.provider}`);
+  }
+  if (out.resumeFrom && !STEP_ORDER.includes(out.resumeFrom)) {
+    throw new Error(`--resume-from must be one of: ${STEP_ORDER.join(', ')}`);
+  }
+  if (!Number.isInteger(out.chapter) || out.chapter <= 0) {
+    throw new Error('--chapter must be a positive integer');
+  }
+  return out;
+}
+
+function classifyError(err) {
+  const message = String(err && err.message ? err.message : err || '').toLowerCase();
+  if (/401|unauthor|api[ _-]?key|invalid_api_key|forbidden|permission/.test(message)) return 'auth';
+  if (/429|rate.?limit|quota|too many requests/.test(message)) return 'rate-limit';
+  if (/503|overloaded|high demand|service unavailable|temporarily unavailable/.test(message)) return 'overload';
+  if (/fetch failed|network|socket hang up|econnreset|etimedout|enotfound|eai_again/.test(message)) return 'transport';
+  if (/timeout|timed out|deadline/.test(message)) return 'timeout';
+  if (/model.*(not[ _-]?found|does not exist|invalid)|unknown model|404/.test(message)) return 'model-not-found';
+  if (/no .*usfm|0 items|empty|missing/.test(message)) return 'bad-output';
+  return 'unknown';
+}
+
+function chapterTag(book, chapter) {
+  const width = book.toUpperCase() === 'PSA' ? 3 : 2;
+  return `${book.toUpperCase()}-${String(chapter).padStart(width, '0')}`;
+}
+
+function outputPaths(book, chapter) {
+  const tag = chapterTag(book, chapter);
+  return {
+    ult: path.join(WORKSPACE, `output/AI-ULT/${book}/${tag}.usfm`),
+    ultAligned: path.join(WORKSPACE, `output/AI-ULT/${book}/${tag}-aligned.usfm`),
+    ust: path.join(WORKSPACE, `output/AI-UST/${book}/${tag}.usfm`),
+    ustAligned: path.join(WORKSPACE, `output/AI-UST/${book}/${tag}-aligned.usfm`),
+    issues: path.join(WORKSPACE, `output/issues/${book}/${tag}.tsv`),
+    notes: path.join(WORKSPACE, `output/notes/${book}/${tag}.tsv`),
+  };
+}
+
+function destPaths(provider, book, chapter) {
+  const tag = chapterTag(book, chapter);
+  const dir = path.join(TEST_ROOT, `${provider}-api`);
+  return {
+    dir,
+    ult: path.join(dir, `${tag}.usfm`),
+    ultAligned: path.join(dir, `${tag}-aligned.usfm`),
+    ust: path.join(dir, `${tag}-UST.usfm`),
+    ustAligned: path.join(dir, `${tag}-UST-aligned.usfm`),
+    issues: path.join(dir, `${tag}-issues.tsv`),
+    notes: path.join(dir, `${tag}-notes.tsv`),
+    models: path.join(dir, 'MODELS.md'),
+  };
+}
+
+function getHarnessModels(provider, overrides = {}) {
+  const cfg = getProviderConfig(provider);
+  return {
+    opus: overrides.opusModel || resolveProviderModel(provider, 'opus') || cfg.defaultModel,
+    sonnet: overrides.sonnetModel || resolveProviderModel(provider, 'sonnet') || cfg.defaultModel,
+  };
+}
+
+function clearOutput(book, chapter) {
+  const tag = chapterTag(book, chapter);
+  for (const subdir of [`output/AI-ULT/${book}`, `output/AI-UST/${book}`, `output/issues/${book}`, `output/notes/${book}`]) {
+    const dir = path.join(WORKSPACE, subdir);
+    if (!fs.existsSync(dir)) continue;
+    for (const file of fs.readdirSync(dir)) {
+      if (file.startsWith(tag)) fs.rmSync(path.join(dir, file), { force: true });
+    }
+  }
+}
+
+function clearSnapshot(provider, book, chapter) {
+  const tag = chapterTag(book, chapter);
+  const dst = destPaths(provider, book, chapter);
+  if (!fs.existsSync(dst.dir)) return;
+  for (const file of fs.readdirSync(dst.dir)) {
+    if (file === 'MODELS.md' || file.startsWith(tag)) {
+      fs.rmSync(path.join(dst.dir, file), { force: true });
+    }
+  }
+}
+
+function copyIfExists(src, dst) {
+  if (!fs.existsSync(src)) return false;
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.copyFileSync(src, dst);
+  return true;
+}
+
+function validateRequiredArtifacts(paths) {
+  const missing = [];
+  const empty = [];
+  for (const key of REQUIRED_ARTIFACT_KEYS) {
+    const artifactPath = paths[key];
+    if (!artifactPath || !fs.existsSync(artifactPath)) {
+      missing.push({ key, path: artifactPath || null });
+      continue;
+    }
+    if (fs.statSync(artifactPath).size === 0) {
+      empty.push({ key, path: artifactPath });
+    }
+  }
+  return {
+    ok: missing.length === 0 && empty.length === 0,
+    missing,
+    empty,
+  };
+}
+
+async function runGeminiSmokeGate({ provider, model, thinking = 'medium' }) {
+  if (provider !== 'gemini') return [];
+
+  const observations = [];
+
+  console.log(`\n[gemini-smoke] plain prompt model=${model}`);
+  const plainResult = await runCustom(
+    'You are a smoke-test assistant. Respond with exactly OK.',
+    'Return OK only.',
+    {
+      provider,
+      model,
+      thinking,
+      cwd: APP_ROOT,
+      maxTurns: 3,
+      timeout: 5,
+      toolChoice: 'none',
+      lockProvider: true,
+      verbose: false,
+    }
+  );
+  if (!plainResult.finalText || !/\bok\b/i.test(plainResult.finalText.trim())) {
+    throw new Error(`Gemini smoke plain prompt returned unexpected text: ${plainResult.finalText || '(empty)'}`);
+  }
+  observations.push(`Gemini smoke plain prompt OK on ${model}`);
+
+  console.log(`\n[gemini-smoke] tool round-trip model=${model}`);
+  const toolResult = await runCustom(
+    [
+      'You are running a Gemini tool smoke test.',
+      'Before answering, call the Read tool exactly once on package.json with offset 1 and limit 1.',
+      'After the tool result, reply with one line that begins with "tool-ok:".',
+    ].join(' '),
+    'Use the required tool call, then reply in the requested format.',
+    {
+      provider,
+      model,
+      thinking,
+      cwd: APP_ROOT,
+      maxTurns: 6,
+      timeout: 5,
+      toolChoice: 'auto',
+      lockProvider: true,
+      verbose: false,
+    }
+  );
+  const usedTool = (toolResult._messages || []).some((message) => (
+    message.role === 'assistant'
+      && Array.isArray(message.toolCalls)
+      && message.toolCalls.length > 0
+  ));
+  const receivedToolResult = (toolResult._messages || []).some((message) => (
+    message.role === 'tool'
+      && Array.isArray(message.results)
+      && message.results.length > 0
+  ));
+  if (!usedTool || !receivedToolResult) {
+    throw new Error('Gemini smoke tool prompt did not complete a tool round-trip');
+  }
+  if (!toolResult.finalText || !/^tool-ok:/i.test(toolResult.finalText.trim())) {
+    throw new Error(`Gemini smoke tool prompt returned unexpected text: ${toolResult.finalText || '(empty)'}`);
+  }
+  observations.push(`Gemini smoke tool round-trip OK on ${model}`);
+
+  return observations;
+}
+
+function snapshotPartials(out, dst) {
+  copyIfExists(out.ult, dst.ult);
+  copyIfExists(out.ultAligned, dst.ultAligned);
+  copyIfExists(out.ust, dst.ust);
+  copyIfExists(out.ustAligned, dst.ustAligned);
+  copyIfExists(out.issues, dst.issues);
+  copyIfExists(out.notes, dst.notes);
+}
+
+function writeModelsMd({ provider, opusModel, sonnetModel, book, chapter, steps, observations, failed, durationMs, dstDir, dst }) {
+  const lines = [];
+  lines.push(`# ${provider.toUpperCase()} API run — ${book} ${chapter}`);
+  lines.push('');
+  lines.push(`Run timestamp: ${new Date().toISOString()}`);
+  lines.push(`Wall-clock: ${(durationMs / 60000).toFixed(2)} min`);
+  lines.push(`Status: **${failed ? 'FAILED' : 'completed'}**`);
+  if (failed) {
+    lines.push(`Failed step: \`${failed.step}\``);
+    lines.push(`Error class: \`${failed.klass}\``);
+    lines.push(`Error message: ${failed.message.slice(0, 500)}`);
+  }
+  lines.push('');
+  lines.push('## Provider & models');
+  lines.push('');
+  lines.push(`- Provider: \`${provider}\``);
+  lines.push(`- Opus-tier model (initial-pipeline, tn-writer): \`${opusModel}\``);
+  lines.push(`- Sonnet-tier model (alignment, tn-quality-check): \`${sonnetModel}\``);
+  lines.push('- Thinking level: medium');
+  lines.push('');
+  lines.push('## Per-step results');
+  lines.push('');
+  lines.push('| Step | Model | OK | Turns | Input tok | Output tok | Cost | Duration | Error |');
+  lines.push('|---|---|---|---|---|---|---|---|---|');
+
+  for (const step of steps) {
+    const cost = step.cost == null ? '—' : `$${step.cost.toFixed(4)}`;
+    const duration = step.durationMs == null ? '—' : `${(step.durationMs / 1000).toFixed(1)}s`;
+    lines.push(
+      `| ${step.step} | ${step.model || '—'} | ${step.ok ? 'yes' : 'NO'} | `
+      + `${step.turns ?? '—'} | ${step.inputTokens ?? '—'} | ${step.outputTokens ?? '—'} | `
+      + `${cost} | ${duration} | ${step.error ? step.error.slice(0, 80) : ''} |`
+    );
+  }
+
+  const totalCost = steps.reduce((sum, step) => sum + (step.cost || 0), 0);
+  const totalInput = steps.reduce((sum, step) => sum + (step.inputTokens || 0), 0);
+  const totalOutput = steps.reduce((sum, step) => sum + (step.outputTokens || 0), 0);
+  lines.push('');
+  lines.push(`**Totals**: input ${totalInput}, output ${totalOutput}, est. cost $${totalCost.toFixed(4)}`);
+  lines.push('');
+  lines.push('## Run observations');
+  lines.push('');
+  if (observations.length === 0) lines.push('- (none)');
+  else for (const observation of observations) lines.push(`- ${observation}`);
+  lines.push('');
+
+  fs.mkdirSync(dstDir, { recursive: true });
+  fs.writeFileSync(dst.models, lines.join('\n'));
+}
+
+async function runProvider(opts) {
+  const { provider, book, chapter } = opts;
+  const { opus: opusModel, sonnet: sonnetModel } = getHarnessModels(provider, opts);
+  const startWall = Date.now();
+  const steps = [];
+  const observations = [];
+  const dst = destPaths(provider, book, chapter);
+  const out = outputPaths(book, chapter);
+  const resumeIdx = opts.resumeFrom ? STEP_ORDER.indexOf(opts.resumeFrom) : 0;
+  fs.mkdirSync(dst.dir, { recursive: true });
+
+  function shouldRun(step) {
+    return STEP_ORDER.indexOf(step) >= resumeIdx;
+  }
+
+  function recordStep(name, model, result, errorMessage) {
+    const entry = {
+      step: name,
+      model,
+      ok: !errorMessage,
+      error: errorMessage || null,
+      turns: result?.turns ?? null,
+      inputTokens: result?.inputTokens ?? null,
+      outputTokens: result?.outputTokens ?? null,
+      cost: typeof result?.cost === 'number' ? result.cost : null,
+      durationMs: result?.durationMs ?? null,
+    };
+    steps.push(entry);
+    return entry;
+  }
+
+  function fail(step, model, error) {
+    const message = String(error && error.message ? error.message : error);
+    const klass = classifyError(error);
+    recordStep(step, model, null, message);
+    writeModelsMd({
+      provider,
+      opusModel,
+      sonnetModel,
+      book,
+      chapter,
+      steps,
+      observations,
+      failed: { step, klass, message },
+      durationMs: Date.now() - startWall,
+      dstDir: dst.dir,
+      dst,
+    });
+    snapshotPartials(out, dst);
+    console.error(`\n[FAILURE] ${JSON.stringify({
+      provider,
+      failedStep: step,
+      errorClass: klass,
+      message: message.slice(0, 500),
+    })}\n`);
+    if (error && error.stack) console.error(error.stack);
+    process.exitCode = 2;
+    throw error;
+  }
+
+  if (!opts.keepOutput && resumeIdx === 0) {
+    clearOutput(book, chapter);
+    clearSnapshot(provider, book, chapter);
+    console.log(`[clear] removed prior output and snapshot for ${chapterTag(book, chapter)}`);
+  }
+
+  const baseOpts = {
+    thinking: 'medium',
+    cwd: WORKSPACE,
+    verbose: false,
+    lockProvider: true,
+  };
+
+  if (provider === 'gemini') {
+    try {
+      observations.push(...await runGeminiSmokeGate({
+        provider,
+        model: opusModel,
+        thinking: baseOpts.thinking,
+      }));
+    } catch (error) {
+      fail('gemini-smoke', opusModel, error);
+    }
+  }
+
+  if (shouldRun('initial')) {
+    console.log(`\n[initial-pipeline] provider=${provider} model=${opusModel}`);
+    let result;
+    try {
+      result = await runSkill('initial-pipeline', `${book} ${chapter} user TEST`, {
+        ...baseOpts,
+        provider,
+        model: opusModel,
+        maxTurns: 100,
+        timeout: 30,
+        systemAppend: getProviderSystemAppend(provider, 'initial-pipeline', { book, chapter }),
+      });
+    } catch (error) {
+      fail('initial-pipeline', opusModel, error);
+    }
+    const entry = recordStep('initial-pipeline', opusModel, result);
+    if (entry.turns >= 100) observations.push('initial-pipeline hit maxTurns (100) — model may have been struggling');
+    if (!fs.existsSync(out.ult)) observations.push(`MISSING after initial-pipeline: ${out.ult}`);
+    if (!fs.existsSync(out.ust)) observations.push(`MISSING after initial-pipeline: ${out.ust}`);
+    if (!fs.existsSync(out.issues)) observations.push(`MISSING after initial-pipeline: ${out.issues}`);
+  }
+
+  if (shouldRun('align')) {
+    console.log(`\n[align-all-parallel] provider=${provider} model=${sonnetModel}`);
+    let result;
+    try {
+      result = await runSkill('align-all-parallel', `${book} ${chapter} --ult --ust`, {
+        ...baseOpts,
+        provider,
+        model: sonnetModel,
+        maxTurns: 50,
+        timeout: 30,
+        systemAppend: getProviderSystemAppend(provider, 'align-all-parallel', { book, chapter }),
+      });
+    } catch (error) {
+      fail('align-all-parallel', sonnetModel, error);
+    }
+    const entry = recordStep('align-all-parallel', sonnetModel, result);
+    if (entry.turns >= 50) observations.push('align-all-parallel hit maxTurns (50)');
+    const missingAligned = [out.ultAligned, out.ustAligned].filter((artifactPath) => !fs.existsSync(artifactPath));
+    for (const artifactPath of missingAligned) observations.push(`MISSING after alignment: ${artifactPath}`);
+    if (missingAligned.length > 0) {
+      fail('align-all-parallel', sonnetModel, new Error(`Alignment phase failed: missing aligned output(s): ${missingAligned.join(', ')}`));
+    }
+  }
+
+  let contextPath;
+  if (shouldRun('prep')) {
+    console.log('\n[notes-context] building');
+    if (!fs.existsSync(out.issues)) {
+      fail('notes-prep', null, new Error(`issues TSV missing for --skip-per: ${out.issues}`));
+    }
+
+    const prereqs = checkPrerequisites(book, chapter);
+    const issuesRel = prereqs.resolved['issues TSV'];
+    const ultPlainRel = prereqs.resolved['AI-ULT'];
+    const alignedUltRel = ultPlainRel ? ultPlainRel.replace(/\.usfm$/, '-aligned.usfm') : null;
+    const ctxResult = await buildNotesContext({ book, chapter, issuesPath: issuesRel });
+    contextPath = ctxResult.contextPath;
+
+    if (alignedUltRel && fs.existsSync(path.resolve(CSKILLBP_DIR, alignedUltRel))) {
+      const context = readContext(ctxResult.dirPath);
+      context.sources.ultAligned = alignedUltRel;
+      writeContext(ctxResult.dirPath, context);
+    }
+
+    const context = readContext(ctxResult.dirPath);
+    const hasAligned = !!(
+      context.sources
+      && context.sources.ultAligned
+      && fs.existsSync(path.resolve(CSKILLBP_DIR, context.sources.ultAligned))
+    );
+    if (hasAligned) {
+      extractAlignmentData({ alignedUsfm: context.sources.ultAligned, output: context.runtime.alignmentData });
+    } else {
+      observations.push('preprocessing ran without aligned ULT — orig_quote / gl_quote resolution will be skipped');
+    }
+
+    const prepResult = prepareNotes({
+      inputTsv: issuesRel,
+      ultUsfm: context.sources.ultPlain || context.sources.ult,
+      ustUsfm: context.sources.ustPlain || context.sources.ust,
+      alignedUsfm: context.sources.ultAligned,
+      output: context.runtime.preparedNotes,
+      alignmentJson: context.runtime.alignmentData,
+    });
+    const match = prepResult.match(/^Prepared (\d+) items/);
+    const prepCount = match ? parseInt(match[1], 10) : 0;
+    if (prepCount === 0) {
+      fail('notes-prep', null, new Error('prepareNotes produced 0 items — issues TSV may be malformed'));
+    }
+    observations.push(`preprocessing: ${prepCount} items`);
+
+    if (hasAligned) {
+      fillOrigQuotes({ preparedJson: context.runtime.preparedNotes, alignmentJson: context.runtime.alignmentData });
+      resolveGlQuotes({ preparedJson: context.runtime.preparedNotes, alignmentJson: context.runtime.alignmentData });
+    }
+    flagNarrowQuotes({ preparedJson: context.runtime.preparedNotes });
+
+    const preparedPath = path.resolve(CSKILLBP_DIR, context.runtime.preparedNotes);
+    const preparedData = JSON.parse(fs.readFileSync(preparedPath, 'utf8'));
+    const missingIds = (preparedData.items || []).filter((item) => !item.id);
+    if (missingIds.length > 0) {
+      const idBlock = await generateIds({ book: preparedData.book || book, count: missingIds.length });
+      const newIds = idBlock.split('\n').filter(Boolean);
+      let index = 0;
+      for (const item of preparedData.items || []) {
+        if (!item.id) item.id = newIds[index++] || '';
+      }
+      fs.writeFileSync(preparedPath, JSON.stringify(preparedData, null, 2));
+    }
+
+    recordStep('notes-prep', null, {
+      turns: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+      durationMs: 0,
+    });
+  } else {
+    const tag = chapterTag(book, chapter);
+    const pipelineRoot = path.join(WORKSPACE, 'tmp/pipeline');
+    if (fs.existsSync(pipelineRoot)) {
+      const candidates = fs.readdirSync(pipelineRoot).filter((name) => name === tag).sort().reverse();
+      if (candidates[0]) contextPath = `tmp/pipeline/${candidates[0]}/context.json`;
+    }
+    if (!contextPath) {
+      throw new Error(`Cannot resume after prep — no pipeline dir found for ${tag}`);
+    }
+  }
+
+  if (shouldRun('tn-writer')) {
+    console.log(`\n[tn-writer] provider=${provider} model=${opusModel}`);
+    let result;
+    try {
+      result = await runSkill('tn-writer', `${book} ${chapter} --context ${contextPath}`, {
+        ...baseOpts,
+        provider,
+        model: opusModel,
+        maxTurns: 150,
+        timeout: 45,
+      });
+    } catch (error) {
+      fail('tn-writer', opusModel, error);
+    }
+    const entry = recordStep('tn-writer', opusModel, result);
+    if (entry.turns >= 150) observations.push('tn-writer hit maxTurns (150)');
+    if (!fs.existsSync(out.notes)) observations.push(`MISSING after tn-writer: ${out.notes}`);
+  }
+
+  if (shouldRun('tn-qc')) {
+    console.log(`\n[tn-quality-check] provider=${provider} model=${sonnetModel}`);
+    let result;
+    try {
+      result = await runSkill('tn-quality-check', `${book} ${chapter} --context ${contextPath}`, {
+        ...baseOpts,
+        provider,
+        model: sonnetModel,
+        maxTurns: 60,
+        timeout: 20,
+      });
+    } catch (error) {
+      fail('tn-quality-check', sonnetModel, error);
+    }
+    recordStep('tn-quality-check', sonnetModel, result);
+  }
+
+  if (shouldRun('snapshot')) {
+    console.log(`\n[snapshot] copying output -> ${dst.dir}`);
+    copyIfExists(out.ult, dst.ult);
+    copyIfExists(out.ultAligned, dst.ultAligned);
+    copyIfExists(out.ust, dst.ust);
+    copyIfExists(out.ustAligned, dst.ustAligned);
+    copyIfExists(out.issues, dst.issues);
+    copyIfExists(out.notes, dst.notes);
+
+    for (const [label, artifactPath] of Object.entries({
+      'ULT plain': dst.ult,
+      'ULT aligned': dst.ultAligned,
+      'UST plain': dst.ust,
+      'UST aligned': dst.ustAligned,
+      issues: dst.issues,
+      notes: dst.notes,
+    })) {
+      if (!fs.existsSync(artifactPath)) {
+        observations.push(`MISSING in snapshot: ${label}`);
+        continue;
+      }
+      const size = fs.statSync(artifactPath).size;
+      if (size === 0) observations.push(`EMPTY in snapshot: ${label}`);
+      else if (label === 'notes' && size < 1000) observations.push(`SHORT notes file (${size} bytes) — likely truncated`);
+    }
+
+    const artifactCheck = validateRequiredArtifacts(dst);
+    if (!artifactCheck.ok) {
+      const problems = [
+        ...artifactCheck.missing.map(({ key, path: artifactPath }) => `${key}:missing:${artifactPath || '(unset)'}`),
+        ...artifactCheck.empty.map(({ key, path: artifactPath }) => `${key}:empty:${artifactPath}`),
+      ];
+      fail('snapshot', null, new Error(`Required snapshot artifacts missing or empty: ${problems.join(', ')}`));
+    }
+  }
+
+  writeModelsMd({
+    provider,
+    opusModel,
+    sonnetModel,
+    book,
+    chapter,
+    steps,
+    observations,
+    durationMs: Date.now() - startWall,
+    dstDir: dst.dir,
+    dst,
+  });
+
+  console.log(`\n[done] ${provider} run finished in ${((Date.now() - startWall) / 60000).toFixed(1)} min`);
+  console.log(`[done] artifacts: ${dst.dir}`);
+}
+
+async function main() {
+  patchConsoleWithTimestamps();
+  const opts = parseArgs(process.argv);
+  if (!process.env.BOT_SECRETS_DIR) {
+    process.env.BOT_SECRETS_DIR = '/srv/bot/config/secrets';
+  }
+  await runProvider(opts);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[fatal]', error.message);
+    if (process.exitCode === undefined || process.exitCode === 0) process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  REQUIRED_ARTIFACT_KEYS,
+  classifyError,
+  chapterTag,
+  clearOutput,
+  clearSnapshot,
+  destPaths,
+  getHarnessModels,
+  outputPaths,
+  parseArgs,
+  runGeminiSmokeGate,
+  runProvider,
+  validateRequiredArtifacts,
+};

--- a/scripts/test-providers-zec3.js
+++ b/scripts/test-providers-zec3.js
@@ -28,6 +28,7 @@ const REQUIRED_ARTIFACT_KEYS = ['ult', 'ultAligned', 'ust', 'ustAligned', 'issue
 const { runCustom, runSkill } = require(path.join(SRC, 'api-runner/runner'));
 const { getProviderConfig, resolveProviderModel } = require(path.join(SRC, 'api-runner/provider-config'));
 const { getProviderSystemAppend } = require(path.join(SRC, 'api-runner/provider-nudges'));
+const { DEFAULT_RUNTIME, resolveRuntime } = require(path.join(SRC, 'api-runner/runtime-config'));
 const { buildNotesContext, readContext, writeContext } = require(path.join(SRC, 'pipeline-context'));
 const {
   extractAlignmentData,
@@ -50,6 +51,7 @@ function patchConsoleWithTimestamps() {
 function parseArgs(argv) {
   const out = {
     provider: null,
+    runtime: DEFAULT_RUNTIME,
     opusModel: null,
     sonnetModel: null,
     resumeFrom: null,
@@ -62,6 +64,7 @@ function parseArgs(argv) {
     const arg = argv[i];
     switch (arg) {
       case '--provider': out.provider = argv[++i]; break;
+      case '--runtime': out.runtime = argv[++i]; break;
       case '--opus-model': out.opusModel = argv[++i]; break;
       case '--sonnet-model': out.sonnetModel = argv[++i]; break;
       case '--resume-from': out.resumeFrom = argv[++i]; break;
@@ -76,6 +79,7 @@ function parseArgs(argv) {
   if (!SUPPORTED_PROVIDERS.includes(out.provider)) {
     throw new Error(`Unknown provider: ${out.provider}`);
   }
+  out.runtime = resolveRuntime(out.provider, out.runtime);
   if (out.resumeFrom && !STEP_ORDER.includes(out.resumeFrom)) {
     throw new Error(`--resume-from must be one of: ${STEP_ORDER.join(', ')}`);
   }
@@ -114,9 +118,14 @@ function outputPaths(book, chapter) {
   };
 }
 
-function destPaths(provider, book, chapter) {
+function destDirName(provider, runtime = DEFAULT_RUNTIME) {
+  if (provider === 'openai' && runtime === 'openai-native') return 'openai-native';
+  return `${provider}-api`;
+}
+
+function destPaths(provider, book, chapter, runtime = DEFAULT_RUNTIME) {
   const tag = chapterTag(book, chapter);
-  const dir = path.join(TEST_ROOT, `${provider}-api`);
+  const dir = path.join(TEST_ROOT, destDirName(provider, runtime));
   return {
     dir,
     ult: path.join(dir, `${tag}.usfm`),
@@ -137,24 +146,39 @@ function getHarnessModels(provider, overrides = {}) {
   };
 }
 
-function clearOutput(book, chapter) {
+function getCleanupTargets(book, chapter, provider, runtime = DEFAULT_RUNTIME) {
   const tag = chapterTag(book, chapter);
-  for (const subdir of [`output/AI-ULT/${book}`, `output/AI-UST/${book}`, `output/issues/${book}`, `output/notes/${book}`]) {
-    const dir = path.join(WORKSPACE, subdir);
-    if (!fs.existsSync(dir)) continue;
-    for (const file of fs.readdirSync(dir)) {
-      if (file.startsWith(tag)) fs.rmSync(path.join(dir, file), { force: true });
-    }
-  }
+  const dst = destPaths(provider, book, chapter, runtime);
+  return [
+    path.join(WORKSPACE, `output/AI-ULT/${book}/${tag}.usfm`),
+    path.join(WORKSPACE, `output/AI-ULT/${book}/${tag}-aligned.usfm`),
+    path.join(WORKSPACE, `output/AI-UST/${book}/${tag}.usfm`),
+    path.join(WORKSPACE, `output/AI-UST/${book}/${tag}-aligned.usfm`),
+    path.join(WORKSPACE, `output/AI-UST/${book}/${tag}-alignment.json`),
+    path.join(WORKSPACE, `output/AI-UST/hints/${book}/${tag}.json`),
+    path.join(WORKSPACE, `output/issues/${book}/${tag}.tsv`),
+    path.join(WORKSPACE, `output/notes/${book}/${tag}.tsv`),
+    path.join(WORKSPACE, `output/quality/${book}/${tag}.json`),
+    path.join(WORKSPACE, `output/quality/${book}/${tag}-quality.md`),
+    path.join(WORKSPACE, `tmp/alignments/${book}/${tag}-mapping.json`),
+    path.join(WORKSPACE, `tmp/alignments/${book}/${tag}-ult-fixed.json`),
+    path.join(WORKSPACE, `tmp/alignments/${book}/${tag}-ult.json`),
+    path.join(WORKSPACE, `tmp/alignments/${book}/${tag}-ust.json`),
+    path.join(WORKSPACE, `tmp/${tag}-alignment-mapping.json`),
+    path.join(WORKSPACE, `tmp/pipeline/${tag}`),
+    path.join(WORKSPACE, `tmp/pipeline-${tag}`),
+    dst.dir,
+  ];
 }
 
-function clearSnapshot(provider, book, chapter) {
-  const tag = chapterTag(book, chapter);
-  const dst = destPaths(provider, book, chapter);
-  if (!fs.existsSync(dst.dir)) return;
-  for (const file of fs.readdirSync(dst.dir)) {
-    if (file === 'MODELS.md' || file.startsWith(tag)) {
-      fs.rmSync(path.join(dst.dir, file), { force: true });
+function clearOutput(book, chapter, provider, runtime = DEFAULT_RUNTIME) {
+  for (const target of getCleanupTargets(book, chapter, provider, runtime)) {
+    if (!fs.existsSync(target)) continue;
+    const stat = fs.statSync(target);
+    if (stat.isDirectory()) {
+      fs.rmSync(target, { recursive: true, force: true });
+    } else {
+      fs.rmSync(target, { force: true });
     }
   }
 }
@@ -186,7 +210,7 @@ function validateRequiredArtifacts(paths) {
   };
 }
 
-async function runGeminiSmokeGate({ provider, model, thinking = 'medium' }) {
+async function runGeminiSmokeGate({ provider, runtime = DEFAULT_RUNTIME, model, thinking = 'medium' }) {
   if (provider !== 'gemini') return [];
 
   const observations = [];
@@ -197,6 +221,7 @@ async function runGeminiSmokeGate({ provider, model, thinking = 'medium' }) {
     'Return OK only.',
     {
       provider,
+      runtime,
       model,
       thinking,
       cwd: APP_ROOT,
@@ -222,6 +247,7 @@ async function runGeminiSmokeGate({ provider, model, thinking = 'medium' }) {
     'Use the required tool call, then reply in the requested format.',
     {
       provider,
+      runtime,
       model,
       thinking,
       cwd: APP_ROOT,
@@ -262,9 +288,10 @@ function snapshotPartials(out, dst) {
   copyIfExists(out.notes, dst.notes);
 }
 
-function writeModelsMd({ provider, opusModel, sonnetModel, book, chapter, steps, observations, failed, durationMs, dstDir, dst }) {
+function writeModelsMd({ provider, runtime = DEFAULT_RUNTIME, opusModel, sonnetModel, book, chapter, steps, observations, failed, durationMs, dstDir, dst }) {
   const lines = [];
-  lines.push(`# ${provider.toUpperCase()} API run — ${book} ${chapter}`);
+  const runtimeLabel = runtime === 'openai-native' ? 'native' : 'API';
+  lines.push(`# ${provider.toUpperCase()} ${runtimeLabel} run — ${book} ${chapter}`);
   lines.push('');
   lines.push(`Run timestamp: ${new Date().toISOString()}`);
   lines.push(`Wall-clock: ${(durationMs / 60000).toFixed(2)} min`);
@@ -278,6 +305,7 @@ function writeModelsMd({ provider, opusModel, sonnetModel, book, chapter, steps,
   lines.push('## Provider & models');
   lines.push('');
   lines.push(`- Provider: \`${provider}\``);
+  lines.push(`- Runtime: \`${runtime}\``);
   lines.push(`- Opus-tier model (initial-pipeline, tn-writer): \`${opusModel}\``);
   lines.push(`- Sonnet-tier model (alignment, tn-quality-check): \`${sonnetModel}\``);
   lines.push('- Thinking level: medium');
@@ -314,12 +342,12 @@ function writeModelsMd({ provider, opusModel, sonnetModel, book, chapter, steps,
 }
 
 async function runProvider(opts) {
-  const { provider, book, chapter } = opts;
+  const { provider, runtime, book, chapter } = opts;
   const { opus: opusModel, sonnet: sonnetModel } = getHarnessModels(provider, opts);
   const startWall = Date.now();
   const steps = [];
   const observations = [];
-  const dst = destPaths(provider, book, chapter);
+  const dst = destPaths(provider, book, chapter, runtime);
   const out = outputPaths(book, chapter);
   const resumeIdx = opts.resumeFrom ? STEP_ORDER.indexOf(opts.resumeFrom) : 0;
   fs.mkdirSync(dst.dir, { recursive: true });
@@ -350,6 +378,7 @@ async function runProvider(opts) {
     recordStep(step, model, null, message);
     writeModelsMd({
       provider,
+      runtime,
       opusModel,
       sonnetModel,
       book,
@@ -374,12 +403,12 @@ async function runProvider(opts) {
   }
 
   if (!opts.keepOutput && resumeIdx === 0) {
-    clearOutput(book, chapter);
-    clearSnapshot(provider, book, chapter);
+    clearOutput(book, chapter, provider, runtime);
     console.log(`[clear] removed prior output and snapshot for ${chapterTag(book, chapter)}`);
   }
 
   const baseOpts = {
+    runtime,
     thinking: 'medium',
     cwd: WORKSPACE,
     verbose: false,
@@ -390,6 +419,7 @@ async function runProvider(opts) {
     try {
       observations.push(...await runGeminiSmokeGate({
         provider,
+        runtime,
         model: opusModel,
         thinking: baseOpts.thinking,
       }));
@@ -603,6 +633,7 @@ async function runProvider(opts) {
 
   writeModelsMd({
     provider,
+    runtime,
     opusModel,
     sonnetModel,
     book,
@@ -639,8 +670,9 @@ module.exports = {
   classifyError,
   chapterTag,
   clearOutput,
-  clearSnapshot,
+  destDirName,
   destPaths,
+  getCleanupTargets,
   getHarnessModels,
   outputPaths,
   parseArgs,

--- a/src/api-runner/README.md
+++ b/src/api-runner/README.md
@@ -72,7 +72,7 @@ Claude API path also supports aliases through config:
 Cross-provider equivalents are handled with the same alias keys per provider:
 - OpenAI example: `sonnet -> gpt-5.3`
 - Gemini example: `sonnet -> gemini-2.5-pro`
-- xAI example: `sonnet -> grok-4-1-fast-reasoning`
+- xAI example: `opus -> grok-4.20-reasoning`, `sonnet -> grok-4.20-reasoning`
 
 This alias resolution is API-runner-only and does not alter the existing Claude SDK path (`opus`/`sonnet`/`haiku`).
 

--- a/src/api-runner/README.md
+++ b/src/api-runner/README.md
@@ -5,6 +5,7 @@ This module provides a multi-provider, tool-using runner that is parallel to the
 It is intentionally additive:
 - Existing SDK routes and pipelines remain unchanged.
 - API runner is used only when `route.type` is `api` or when directly invoking its CLI.
+- Runtime selection is explicit: existing runs stay on `generic-api` unless a route or CLI call opts into `openai-native`.
 
 ## Contents
 
@@ -16,6 +17,7 @@ It is intentionally additive:
 - `api-pipeline.js` - Zulip pipeline entry point for `type: "api"`
 - `cli.js` - standalone local/ops entry point
 - `providers/` - model provider integrations
+- `openai-native.js` - OpenAI Agents SDK runtime for OpenAI-native execution
 
 ## Route Usage
 
@@ -33,16 +35,26 @@ Example Zulip command:
 
 `api generate LAM 2:4-5 --provider openai`
 
+Route/runtime note:
+- `route.runtime` is optional.
+- Supported values: `generic-api`, `openai-native`
+- `openai-native` is only valid with `provider: "openai"`
+
 ## CLI Usage
 
 Run from `app/`:
 
 ```bash
 node src/api-runner/cli.js --provider openai --skill ULT-gen --prompt "LAM 2:4-5"
+node src/api-runner/cli.js --provider openai --runtime openai-native --skill ULT-gen --prompt "LAM 2:4-5"
 node src/api-runner/cli.js --provider gemini --skill ULT-gen --prompt "LAM 2:4-5"
 node src/api-runner/cli.js --provider claude --skill ULT-gen --prompt "LAM 2:4-5"
 node src/api-runner/cli.js --provider openai --skill ULT-gen --prompt "LAM 2:4-5" --dry-run
 ```
+
+Runtime behavior:
+- `generic-api` uses the existing provider-agnostic tool loop.
+- `openai-native` uses the OpenAI Agents SDK with Responses-backed sessions and the same repo tool inventory.
 
 Supported providers:
 - `claude`
@@ -114,6 +126,7 @@ Quick checks:
 ```bash
 node src/api-runner/cli.js --provider claude --skill ULT-gen --prompt "LAM 2:4-5" --dry-run
 node src/api-runner/cli.js --provider openai --skill ULT-gen --prompt "LAM 2:4-5" --dry-run
+node src/api-runner/cli.js --provider openai --runtime openai-native --skill ULT-gen --prompt "LAM 2:4-5" --dry-run
 node src/api-runner/cli.js --provider gemini --skill ULT-gen --prompt "LAM 2:4-5" --dry-run
 node src/test-pipeline.js "api generate LAM 2:4-5" --provider openai --dry-run
 ```

--- a/src/api-runner/agent-loop.js
+++ b/src/api-runner/agent-loop.js
@@ -2,7 +2,7 @@
 // Provider-agnostic: works with any provider module (gemini, openai, claude)
 
 const { executeTool, TOOL_SCHEMAS, toGeminiTools, toOpenAITools, toClaudeTools } = require('./tools');
-const { getProviderConfig, resolveXaiModel } = require('./provider-config');
+const { getFallbackModel, getProviderConfig, resolveXaiModel } = require('./provider-config');
 const { isAgentTool } = require('./agent-tools');
 const { MAX_DEPTH } = require('./team-manager');
 
@@ -64,6 +64,7 @@ async function runAgentLoop({
   toolChoice,
   depth = 0,
   apiKeyResolver,
+  lockProvider = false,
 }) {
   const providerMod = PROVIDERS[providerName]();
 
@@ -104,6 +105,7 @@ async function runAgentLoop({
   let activeToolChoice = toolChoice;
   const startTime = Date.now();
   const deadline = startTime + timeoutMs;
+  const attemptedModels = new Set();
 
   // Build agent context for agent tools (allows sub-agent spawning)
   const agentContext = {
@@ -116,6 +118,7 @@ async function runAgentLoop({
       apiKey,
       apiKeyResolver,
       depth,
+      lockProvider,
     },
     runAgentLoopFn: runAgentLoop,
   };
@@ -135,32 +138,58 @@ async function runAgentLoop({
 
     let response;
     const maxRetries = 3;
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        response = await providerMod.sendRequest({
-          model: resolvedModel,
-          system,
-          messages,
-          tools,
-          thinking: resolvedThinking,
-          apiKey,
-          baseUrl,
-          toolChoice: activeToolChoice,
-        });
-        break; // success
-      } catch (err) {
-        const isTransient = /503|502|500|529|overloaded|unavailable|service\s+temporarily|fetch\s+failed|network|ECONNRESET|ETIMEDOUT|ENOTFOUND/i.test(err.message);
-        const isRateLimit = /429|rate.?limit|too.many.requests/i.test(err.message);
-        const shouldRetry = (isTransient || isRateLimit) && attempt < maxRetries;
-        if (shouldRetry) {
-          const delayMs = isRateLimit ? 60000 : 15000 * attempt;
-          console.warn(`[agent-loop] ${depthPrefix}Turn ${turns} attempt ${attempt} failed (${err.message.slice(0, 80)}...) — retrying in ${delayMs / 1000}s`);
-          await new Promise(r => setTimeout(r, delayMs));
-        } else {
+    let modelForTurn = resolvedModel;
+    while (true) {
+      attemptedModels.add(modelForTurn || providerMod.DEFAULT_MODEL);
+      let fallbackTriggered = false;
+      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+          response = await providerMod.sendRequest({
+            providerName,
+            model: modelForTurn,
+            system,
+            messages,
+            tools,
+            thinking: resolvedThinking,
+            apiKey,
+            baseUrl,
+            toolChoice: activeToolChoice,
+          });
+          resolvedModel = modelForTurn;
+          break;
+        } catch (err) {
+          const isTransient = /503|502|500|529|overloaded|unavailable|service\s+temporarily|fetch\s+failed|network|ECONNRESET|ETIMEDOUT|ENOTFOUND/i.test(err.message);
+          const isRateLimit = /429|rate.?limit|too.many.requests/i.test(err.message);
+          const shouldRetry = (isTransient || isRateLimit) && attempt < maxRetries;
+          if (shouldRetry) {
+            const delayMs = isRateLimit ? 60000 : 15000 * attempt;
+            console.warn(`[agent-loop] ${depthPrefix}Turn ${turns} attempt ${attempt} failed (${err.message.slice(0, 80)}...) — retrying in ${delayMs / 1000}s`);
+            await new Promise(r => setTimeout(r, delayMs));
+            continue;
+          }
+
+          const fallbackModel = (isTransient || isRateLimit)
+            ? getFallbackModel(providerName, modelForTurn || providerMod.DEFAULT_MODEL, attemptedModels)
+            : null;
+          if (fallbackModel) {
+            console.warn(`[agent-loop] ${depthPrefix}Switching ${providerName} model from ${modelForTurn || providerMod.DEFAULT_MODEL} to fallback ${fallbackModel} after API failures`);
+            modelForTurn = fallbackModel;
+            if (providerName === 'xai') {
+              const xaiConfig = getProviderConfig('xai');
+              if (!xaiConfig.reasoningEffortModels.includes(modelForTurn)) {
+                resolvedThinking = undefined;
+              }
+            }
+            fallbackTriggered = true;
+            break;
+          }
+
           console.error(`[agent-loop] ${depthPrefix}API error on turn ${turns}: ${err.message}`);
           throw err;
         }
       }
+      if (response) break;
+      if (!fallbackTriggered) break;
     }
 
     totalInputTokens += response.usage.inputTokens;

--- a/src/api-runner/agent-loop.js
+++ b/src/api-runner/agent-loop.js
@@ -65,14 +65,15 @@ async function runAgentLoop({
   depth = 0,
   apiKeyResolver,
   lockProvider = false,
+  toolSchemas,
 }) {
   const providerMod = PROVIDERS[providerName]();
 
   // Determine which tools are available at this depth
   // Sub-agents at max depth don't get agent tools (prevents infinite recursion)
-  let schemas = TOOL_SCHEMAS;
+  let schemas = toolSchemas || TOOL_SCHEMAS;
   if (depth >= MAX_DEPTH) {
-    schemas = TOOL_SCHEMAS.filter(s => !isAgentTool(s.name));
+    schemas = schemas.filter(s => !isAgentTool(s.name));
   }
   const tools = getToolsForProvider(providerName, schemas);
 

--- a/src/api-runner/api-pipeline.js
+++ b/src/api-runner/api-pipeline.js
@@ -5,7 +5,7 @@ const path = require('path');
 const { door43Push } = require('../door43-push');
 const { getDoor43Username, normalizeBookName, buildBranchName, discoverFreshOutput, checkPrerequisites, CSKILLBP_DIR } = require('../pipeline-utils');
 const { buildNotesContext, readContext, writeContext } = require('../pipeline-context');
-const { extractAlignmentData, prepareNotes, fillOrigQuotes, resolveGlQuotes, flagNarrowQuotes } = require('../workspace-tools/tn-tools');
+const { extractAlignmentData, prepareNotes, fillOrigQuotes, resolveGlQuotes, flagNarrowQuotes, generateIds } = require('../workspace-tools/tn-tools');
 const { checkUltEdits } = require('../check-ult-edits');
 
 function parseRegexLiteral(literal) {
@@ -199,6 +199,19 @@ async function apiPipeline(route, message) {
       }
 
       flagNarrowQuotes({ preparedJson: ctx.runtime.preparedNotes });
+
+      const prepPath = path.resolve(CSKILLBP_DIR, ctx.runtime.preparedNotes);
+      const prepData = JSON.parse(fs.readFileSync(prepPath, 'utf8'));
+      const needsId = (prepData.items || []).filter((item) => !item.id);
+      if (needsId.length > 0) {
+        const idStr = await generateIds({ book: prepData.book || book, count: needsId.length });
+        const newIds = idStr.split('\n').filter(Boolean);
+        let idx = 0;
+        for (const item of prepData.items || []) {
+          if (!item.id) item.id = newIds[idx++] || '';
+        }
+        fs.writeFileSync(prepPath, JSON.stringify(prepData, null, 2));
+      }
 
       // 5. tn-writer (Opus by default)
       await reply(`Preprocessing done (${prepCount} items). Running tn-writer...`);

--- a/src/api-runner/api-pipeline.js
+++ b/src/api-runner/api-pipeline.js
@@ -288,11 +288,13 @@ async function apiPipeline(route, message) {
           thinking: 'medium',
           maxTurns: 50,
           cwd: selectedCwd,
+          systemAppend: getProviderSystemAppend(provider, 'align-all-parallel', { book, chapter }),
         });
 
         const tag = `${book}-${String(chapter).padStart(book === 'PSA' ? 3 : 2, '0')}`;
-        const ultAligned = discoverFreshOutput('output/AI-ULT', book, new RegExp(`^${tag}-.*-aligned\\.usfm$`), startTime);
-        const ustAligned = discoverFreshOutput('output/AI-UST', book, new RegExp(`^${tag}-.*-aligned\\.usfm$`), startTime);
+        const alignedPattern = new RegExp(`^${tag}(?:-.*)?-aligned\\.usfm$`);
+        const ultAligned = discoverFreshOutput('output/AI-ULT', book, alignedPattern, startTime);
+        const ustAligned = discoverFreshOutput('output/AI-UST', book, alignedPattern, startTime);
 
         if (!ultAligned && !ustAligned) {
           throw new Error('Alignment phase failed: no aligned USFM files were produced.');

--- a/src/api-runner/api-pipeline.js
+++ b/src/api-runner/api-pipeline.js
@@ -7,6 +7,7 @@ const { getDoor43Username, normalizeBookName, buildBranchName, discoverFreshOutp
 const { buildNotesContext, readContext, writeContext } = require('../pipeline-context');
 const { extractAlignmentData, prepareNotes, fillOrigQuotes, resolveGlQuotes, flagNarrowQuotes, generateIds } = require('../workspace-tools/tn-tools');
 const { checkUltEdits } = require('../check-ult-edits');
+const { getProviderSystemAppend } = require('./provider-nudges');
 
 function parseRegexLiteral(literal) {
   if (typeof literal !== 'string') return null;
@@ -252,6 +253,7 @@ async function apiPipeline(route, message) {
     await reply(`Running **${skillName}** via **${provider}** for \`${prompt}\`...`);
 
     const startTime = Date.now();
+    const skillContext = parseBookChapterUser(prompt, message.sender_email);
     const result = await runSkill(skillName, prompt, {
       provider,
       model,
@@ -262,6 +264,7 @@ async function apiPipeline(route, message) {
       verbose: !!route.verbose,
       dryRun: isDryRun,
       toolChoice: route.toolChoice,
+      systemAppend: getProviderSystemAppend(provider, skillName, skillContext),
     });
 
     await removeReaction(msgId, 'working_on_it');

--- a/src/api-runner/api-pipeline.js
+++ b/src/api-runner/api-pipeline.js
@@ -36,6 +36,11 @@ function parseProviderFromMessage(content) {
   return match ? match[1].toLowerCase() : null;
 }
 
+function parseRuntimeFromMessage(content) {
+  const match = String(content || '').match(/--runtime\s+([a-z0-9_-]+)/i);
+  return match ? match[1].toLowerCase() : null;
+}
+
 /**
  * Extract book, chapter, and Door43 username from the prompt string.
  * Example: "zec 3 user benjamin-test" -> { book: "ZEC", chapter: 3, username: "benjamin-test" }
@@ -69,6 +74,7 @@ async function apiPipeline(route, message) {
   if (args) prompt = `${args} ${prompt}`.trim();
 
   const provider = parseProviderFromMessage(message.content) || route.provider || 'openai';
+  const runtime = parseRuntimeFromMessage(message.content) || route.runtime || null;
   const model = route.model || null;
   let selectedCwd = route.cwd || '/workspace';
   const primarySkillPath = path.join(selectedCwd, '.claude', 'skills', skillName, 'SKILL.md');
@@ -143,7 +149,7 @@ async function apiPipeline(route, message) {
           await reply(`AI artifacts found with human edits — running post-edit-review...`);
           issueResult = await runSkill('post-edit-review',
             `--issues ${issuesPath} --context ${contextPath}`,
-            { provider, model: 'sonnet', thinking: 'medium', maxTurns: 60, timeout: 20, cwd: selectedCwd });
+            { provider, runtime, model: 'sonnet', thinking: 'medium', maxTurns: 60, timeout: 20, cwd: selectedCwd });
           await reply(`post-edit-review done (turns: ${issueResult.turns}, cost: $${(issueResult.cost || 0).toFixed(4)}).`);
         } else {
           await reply(`AI artifacts found, no human edits — using existing issues TSV.`);
@@ -152,7 +158,7 @@ async function apiPipeline(route, message) {
         await reply(`No AI artifacts (missing: ${prereqs.missing.join(', ')}) — running deep-issue-id...`);
         issueResult = await runSkill('deep-issue-id',
           `${book} ${chapter} --context ${contextPath}`,
-          { provider, model: route.model || null, thinking: 'medium', maxTurns: 100, timeout: 30, cwd: selectedCwd });
+          { provider, runtime, model: route.model || null, thinking: 'medium', maxTurns: 100, timeout: 30, cwd: selectedCwd });
         await reply(`deep-issue-id done (turns: ${issueResult.turns}, cost: $${(issueResult.cost || 0).toFixed(4)}).`);
 
         // Re-resolve issues path now that deep-issue-id has written it
@@ -218,13 +224,13 @@ async function apiPipeline(route, message) {
       await reply(`Preprocessing done (${prepCount} items). Running tn-writer...`);
       const writerResult = await runSkill('tn-writer',
         `${book} ${chapter} --context ${contextPath}`,
-        { provider, model: route.model || null, thinking: 'medium', maxTurns: route.maxTurns || 150, timeout: route.timeout || 45, cwd: selectedCwd, toolChoice: route.toolChoice });
+        { provider, runtime, model: route.model || null, thinking: 'medium', maxTurns: route.maxTurns || 150, timeout: route.timeout || 45, cwd: selectedCwd, toolChoice: route.toolChoice });
       await reply(`tn-writer done (turns: ${writerResult.turns}, cost: $${(writerResult.cost || 0).toFixed(4)}). Running tn-quality-check...`);
 
       // 6. tn-quality-check (Sonnet)
       const qcResult = await runSkill('tn-quality-check',
         `${book} ${chapter} --context ${contextPath}`,
-        { provider, model: 'sonnet', thinking: 'medium', maxTurns: 60, timeout: 20, cwd: selectedCwd });
+        { provider, runtime, model: 'sonnet', thinking: 'medium', maxTurns: 60, timeout: 20, cwd: selectedCwd });
       await reply(`tn-quality-check done (turns: ${qcResult.turns}, cost: $${(qcResult.cost || 0).toFixed(4)}).`);
 
       // 7. door43-push (TN)
@@ -250,12 +256,14 @@ async function apiPipeline(route, message) {
     }
 
     // --- Normal single-skill flow ---
-    await reply(`Running **${skillName}** via **${provider}** for \`${prompt}\`...`);
+    const runtimeLabel = runtime ? ` via **${runtime}**` : '';
+    await reply(`Running **${skillName}** via **${provider}**${runtimeLabel} for \`${prompt}\`...`);
 
     const startTime = Date.now();
     const skillContext = parseBookChapterUser(prompt, message.sender_email);
     const result = await runSkill(skillName, prompt, {
       provider,
+      runtime,
       model,
       thinking: route.thinking || 'medium',
       maxTurns: route.maxTurns || 100,
@@ -284,6 +292,7 @@ async function apiPipeline(route, message) {
         const alignRef = `${book} ${chapter} --ult --ust`; // always align both for now
         const alignResult = await runSkill('align-all-parallel', alignRef, {
           provider,
+          runtime,
           model: 'sonnet', // use sonnet for alignment as it's cheaper/faster
           thinking: 'medium',
           maxTurns: 50,
@@ -329,7 +338,7 @@ async function apiPipeline(route, message) {
   } catch (error) {
     await removeReaction(msgId, 'working_on_it');
     await addReaction(msgId, 'warning');
-    await reply(`API run failed for **${skillName}** via **${provider}**: ${error.message}`);
+    await reply(`API run failed for **${skillName}** via **${provider}**${runtime ? ` / **${runtime}**` : ''}: ${error.message}`);
   }
 }
 

--- a/src/api-runner/cli.js
+++ b/src/api-runner/cli.js
@@ -7,6 +7,7 @@
 const path = require('path');
 const { readSecret } = require('../secrets');
 const { getProviderNames, getProviderConfig } = require('./provider-config');
+const { DEFAULT_RUNTIME, VALID_RUNTIMES, resolveRuntime } = require('./runtime-config');
 
 // Load env from bot config
 try {
@@ -28,6 +29,7 @@ try {
 function parseArgs(argv) {
   const args = {
     provider: 'gemini',
+    runtime: DEFAULT_RUNTIME,
     model: null,
     thinking: 'medium',
     skill: null,
@@ -45,6 +47,7 @@ function parseArgs(argv) {
     const arg = argv[i];
     switch (arg) {
       case '--provider': args.provider = argv[++i]; break;
+      case '--runtime': args.runtime = argv[++i]; break;
       case '--model': args.model = argv[++i]; break;
       case '--thinking': args.thinking = argv[++i]; break;
       case '--skill': args.skill = argv[++i]; break;
@@ -75,6 +78,7 @@ function parseArgs(argv) {
 
 function printUsage() {
   const providerList = getProviderNames().join(', ');
+  const runtimeList = Array.from(VALID_RUNTIMES).join(', ');
   console.log(`
 Multi-Provider API Runner for Workspace Skills
 
@@ -83,6 +87,7 @@ Usage:
 
 Options:
   --provider <name>     Provider: ${providerList} (default: gemini)
+  --runtime <name>      Runtime: ${runtimeList} (default: ${DEFAULT_RUNTIME})
   --model <id>          Model ID (provider-specific, default: provider flagship)
   --thinking <level>    Thinking level: low, medium, high, max (default: medium)
   --skill <name>        Single skill name from workspace
@@ -138,6 +143,13 @@ async function main() {
     process.exit(1);
   }
 
+  try {
+    args.runtime = resolveRuntime(args.provider, args.runtime);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+
   // Check API key
   const providerConfig = getProviderConfig(args.provider);
   const apiKey = readSecret(providerConfig.secretName, providerConfig.envName);
@@ -148,6 +160,7 @@ async function main() {
 
   const opts = {
     provider: args.provider,
+    runtime: args.runtime,
     model: args.model,
     thinking: args.thinking,
     toolChoice: args.toolChoice,
@@ -158,7 +171,7 @@ async function main() {
     dryRun: args.dryRun,
   };
 
-  console.log(`[cli] Provider: ${args.provider}, Model: ${args.model || '(default)'}, Thinking: ${args.thinking}`);
+  console.log(`[cli] Provider: ${args.provider}, Runtime: ${args.runtime}, Model: ${args.model || '(default)'}, Thinking: ${args.thinking}`);
   console.log(`[cli] ${args.skill ? `Skill: ${args.skill}` : `Pipeline: ${args.pipeline}`}`);
   console.log(`[cli] Prompt: ${args.prompt}`);
   console.log('');

--- a/src/api-runner/openai-native-stage-runner.js
+++ b/src/api-runner/openai-native-stage-runner.js
@@ -1,0 +1,365 @@
+const fs = require('fs');
+const path = require('path');
+
+const { runAgentLoop } = require('./agent-loop');
+const { buildSkillPrompt } = require('./prompt-builder');
+const { getProviderConfig, resolveProviderModel } = require('./provider-config');
+const { getToolSchemas } = require('./tools');
+const { normalizeBookName } = require('../pipeline-utils');
+const { buildGenerateContext } = require('../pipeline-context');
+const { getProviderSystemAppend } = require('./provider-nudges');
+const { createAlignedUsfm, mergeAlignedUsfm } = require('../workspace-tools/usfm-tools');
+
+const OPENAI_TOOL_SCHEMAS = getToolSchemas({ excludeAgentTools: true });
+const OPENAI_DEFAULT_MODEL = getProviderConfig('openai').defaultModel;
+
+const STAGE_PRESETS = {
+  'ULT-gen': { model: 'opus', thinking: 'medium', maxTurns: 60, timeout: 20, toolChoice: 'auto' },
+  'deep-issue-id': { model: 'opus', thinking: 'medium', maxTurns: 80, timeout: 20, toolChoice: 'auto' },
+  'UST-gen': { model: 'opus', thinking: 'medium', maxTurns: 70, timeout: 25, toolChoice: 'auto' },
+  'ULT-alignment': { model: 'sonnet', thinking: 'medium', maxTurns: 40, timeout: 20, toolChoice: 'auto' },
+  'UST-alignment': { model: 'sonnet', thinking: 'medium', maxTurns: 50, timeout: 20, toolChoice: 'auto' },
+  'tn-writer': { model: 'opus', thinking: 'medium', maxTurns: 150, timeout: 45, toolChoice: 'auto' },
+  'tn-quality-check': { model: 'sonnet', thinking: 'medium', maxTurns: 60, timeout: 20, toolChoice: 'auto' },
+};
+
+function chapterTag(book, chapter) {
+  const width = String(book).toUpperCase() === 'PSA' ? 3 : 2;
+  return `${String(book).toUpperCase()}-${String(chapter).padStart(width, '0')}`;
+}
+
+function parseBookChapter(prompt) {
+  const match = String(prompt || '').match(/^([a-z0-9]{2,5}|[a-z]+)\s+(\d+)/i);
+  if (!match) {
+    throw new Error(`Could not parse book/chapter from prompt: "${prompt}"`);
+  }
+
+  const book = normalizeBookName(match[1]);
+  const chapter = parseInt(match[2], 10);
+  if (!book || !Number.isInteger(chapter)) {
+    throw new Error(`Invalid book/chapter in prompt: "${prompt}"`);
+  }
+
+  return { book, chapter };
+}
+
+function buildCanonicalPaths(cwd, book, chapter) {
+  const tag = chapterTag(book, chapter);
+  return {
+    ult: path.join(cwd, `output/AI-ULT/${book}/${tag}.usfm`),
+    ultAligned: path.join(cwd, `output/AI-ULT/${book}/${tag}-aligned.usfm`),
+    ust: path.join(cwd, `output/AI-UST/${book}/${tag}.usfm`),
+    ustAligned: path.join(cwd, `output/AI-UST/${book}/${tag}-aligned.usfm`),
+    issues: path.join(cwd, `output/issues/${book}/${tag}.tsv`),
+    notes: path.join(cwd, `output/notes/${book}/${tag}.tsv`),
+    qualityJson: path.join(cwd, `output/quality/${book}/${tag}.json`),
+    qualityMd: path.join(cwd, `output/quality/${book}/${tag}-quality.md`),
+  };
+}
+
+function verifyOutputFile(filePath, label) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`${label} missing: ${path.relative('/srv/bot/workspace', filePath)}`);
+  }
+  const stat = fs.statSync(filePath);
+  if (stat.size === 0) {
+    throw new Error(`${label} empty: ${path.relative('/srv/bot/workspace', filePath)}`);
+  }
+}
+
+function countVersesInUsfm(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const matches = content.match(/^\\v\s+\d+/gm);
+  return matches ? matches.length : 0;
+}
+
+function findHebrewSourceRelPath(cwd, book) {
+  const hebrewDir = path.join(cwd, 'data/hebrew_bible');
+  const match = fs.readdirSync(hebrewDir).find((name) => name.endsWith(`-${book}.usfm`));
+  if (!match) {
+    throw new Error(`Hebrew source file not found for ${book}`);
+  }
+  return path.join('data/hebrew_bible', match);
+}
+
+function finalizeAlignmentOutputs({ cwd, book, chapter, sourceRelPath, outputRelPath, ust = false }) {
+  const tag = chapterTag(book, chapter);
+  const mappingDirRel = path.join('tmp', 'zec03_alignments');
+  const mappingDirAbs = path.join(cwd, mappingDirRel);
+  if (!fs.existsSync(mappingDirAbs)) {
+    throw new Error(`Alignment mapping directory missing: ${mappingDirRel}`);
+  }
+
+  const mappingFiles = fs.readdirSync(mappingDirAbs)
+    .filter((name) => name.startsWith(`${tag}-v`) && name.endsWith('.json'))
+    .sort();
+
+  if (mappingFiles.length === 0) {
+    throw new Error(`No alignment mapping JSON files found for ${tag}`);
+  }
+
+  const hebrewRelPath = findHebrewSourceRelPath(cwd, book);
+  const partials = [];
+
+  for (const fileName of mappingFiles) {
+    const verseMatch = fileName.match(/-v(\d+)-v\d+\.json$/);
+    const verse = verseMatch ? parseInt(verseMatch[1], 10) : null;
+    const mappingRelPath = path.join(mappingDirRel, fileName);
+    const partialRelPath = path.join(mappingDirRel, fileName.replace(/\.json$/, ust ? '.ust.aligned.usfm' : '.ult.aligned.usfm'));
+    const result = createAlignedUsfm({
+      hebrew: hebrewRelPath,
+      mapping: mappingRelPath,
+      source: sourceRelPath,
+      output: partialRelPath,
+      chapter,
+      verse,
+      ust,
+    });
+
+    if (String(result).startsWith('Error')) {
+      throw new Error(result);
+    }
+    partials.push(partialRelPath);
+  }
+
+  const mergeResult = mergeAlignedUsfm({
+    parts: partials,
+    output: outputRelPath,
+  });
+
+  if (String(mergeResult).startsWith('Error')) {
+    throw new Error(mergeResult);
+  }
+}
+
+function summarizeStageResults(label, results) {
+  const totals = results.reduce((sum, result) => {
+    sum.turns += result.turns || 0;
+    sum.inputTokens += result.inputTokens || 0;
+    sum.outputTokens += result.outputTokens || 0;
+    sum.cost += result.cost || 0;
+    sum.durationMs += result.durationMs || 0;
+    return sum;
+  }, {
+    turns: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cost: 0,
+    durationMs: 0,
+  });
+
+  return {
+    ...totals,
+    finalText: `${label} complete.`,
+    steps: results.map((result) => ({
+      skill: result.skill,
+      turns: result.turns,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      cost: result.cost,
+      durationMs: result.durationMs,
+    })),
+  };
+}
+
+function seedIssueStageArtifacts(cwd, dirPath) {
+  const alignmentPath = path.join(cwd, dirPath, 'alignment_data.json');
+  fs.mkdirSync(path.dirname(alignmentPath), { recursive: true });
+  if (!fs.existsSync(alignmentPath)) {
+    fs.writeFileSync(alignmentPath, JSON.stringify({ alignments: [] }, null, 2));
+  }
+}
+
+function resolveStagePreset(skillName, opts = {}) {
+  const preset = STAGE_PRESETS[skillName] || {};
+  return {
+    model: opts.model || preset.model || OPENAI_DEFAULT_MODEL,
+    thinking: opts.thinking || preset.thinking || 'medium',
+    maxTurns: opts.maxTurns || preset.maxTurns || 100,
+    timeout: opts.timeout || preset.timeout || 30,
+    toolChoice: opts.toolChoice || preset.toolChoice || 'auto',
+  };
+}
+
+async function executeNativeStage(skillName, prompt, opts = {}) {
+  const cwd = opts.cwd || '/srv/bot/workspace';
+  const preset = resolveStagePreset(skillName, opts);
+  const system = buildSkillPrompt(skillName, {
+    cwd,
+    toolSchemas: OPENAI_TOOL_SCHEMAS,
+  }) + buildSystemAppend(skillName, prompt, opts);
+
+  if (opts.dryRun) {
+    return {
+      skill: skillName,
+      turns: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+      durationMs: 0,
+      finalText: `(dry run) ${skillName}`,
+    };
+  }
+
+  const result = await runAgentLoop({
+    provider: 'openai',
+    model: preset.model,
+    system,
+    userMessage: prompt,
+    maxTurns: preset.maxTurns,
+    timeoutMs: preset.timeout * 60 * 1000,
+    cwd,
+    thinking: preset.thinking,
+    apiKey: opts.apiKey,
+    apiKeyResolver: opts.apiKeyResolver,
+    toolChoice: preset.toolChoice,
+    lockProvider: true,
+    toolSchemas: OPENAI_TOOL_SCHEMAS,
+  });
+
+  return {
+    ...result,
+    skill: skillName,
+    model: resolveProviderModel('openai', preset.model),
+  };
+}
+
+function buildSystemAppend(skillName, prompt, opts) {
+  let extra = '';
+  try {
+    const { book, chapter } = parseBookChapter(prompt);
+    extra = getProviderSystemAppend('openai', skillName, { book, chapter });
+  } catch {
+    extra = '';
+  }
+
+  const bounded = [
+    'CRITICAL: Agent/team delegation tools are unavailable in this run.',
+    'Do not attempt TeamCreate, Agent, SendMessage, TaskCreate, or TaskGet.',
+    'Complete the task directly using the available file, verse-data, and workspace tools.',
+  ].join('\n');
+
+  const appended = opts.systemAppend ? `\n\n${opts.systemAppend}` : '';
+  return `\n\n${bounded}${extra ? `\n\n${extra}` : ''}${appended}`;
+}
+
+async function runInitialPipeline(prompt, opts = {}) {
+  const { book, chapter } = parseBookChapter(prompt);
+  const cwd = opts.cwd || '/srv/bot/workspace';
+  const outputs = buildCanonicalPaths(cwd, book, chapter);
+  const stageResults = [];
+
+  const ultPrompt = `${book} ${chapter}`;
+  const ultResult = await executeNativeStage('ULT-gen', ultPrompt, opts);
+  verifyOutputFile(outputs.ult, 'ULT output');
+  stageResults.push(ultResult);
+
+  const { dirPath, contextPath } = buildGenerateContext({
+    book,
+    chapter,
+    ultPath: path.relative(cwd, outputs.ult),
+    issuesPath: null,
+    ultFullPath: path.relative(cwd, outputs.ult),
+  });
+  seedIssueStageArtifacts(cwd, dirPath);
+
+  const issuePrompt = `${book} ${chapter} --context ${contextPath}`;
+  const issueResult = await executeNativeStage('deep-issue-id', issuePrompt, {
+    ...opts,
+    systemAppend: [
+      'Use the context file as authoritative for current generated sources.',
+      'If sources.ultFull points to a chapter-level generated file, read that file directly instead of expecting a full-book fetch.',
+      'Perform the issue-identification work yourself in one pass and write the canonical TSV to output/issues.',
+    ].join('\n'),
+  });
+  verifyOutputFile(outputs.issues, 'Issues TSV');
+  stageResults.push(issueResult);
+
+  buildGenerateContext({
+    book,
+    chapter,
+    ultPath: path.relative(cwd, outputs.ult),
+    ustPath: null,
+    issuesPath: path.relative(cwd, outputs.issues),
+    ultFullPath: path.relative(cwd, outputs.ult),
+    dirPath,
+  });
+
+  const ustPrompt = `${book} ${chapter} --context ${contextPath}`;
+  const ustResult = await executeNativeStage('UST-gen', ustPrompt, opts);
+  verifyOutputFile(outputs.ust, 'UST output');
+  stageResults.push(ustResult);
+
+  return summarizeStageResults('initial-pipeline', stageResults);
+}
+
+async function runAlignmentPipeline(prompt, opts = {}) {
+  const { book, chapter } = parseBookChapter(prompt);
+  const cwd = opts.cwd || '/srv/bot/workspace';
+  const outputs = buildCanonicalPaths(cwd, book, chapter);
+  const stageResults = [];
+  const verseCount = countVersesInUsfm(outputs.ult);
+  const versesArg = verseCount > 0 ? ` --verses 1-${verseCount}` : '';
+
+  const ultPrompt = `${book} ${chapter} --ult ${path.relative(cwd, outputs.ult)}${versesArg}`;
+  const ultResult = await executeNativeStage('ULT-alignment', ultPrompt, opts);
+  finalizeAlignmentOutputs({
+    cwd,
+    book,
+    chapter,
+    sourceRelPath: path.relative(cwd, outputs.ult),
+    outputRelPath: path.relative(cwd, outputs.ultAligned),
+    ust: false,
+  });
+  verifyOutputFile(outputs.ultAligned, 'Aligned ULT output');
+  stageResults.push(ultResult);
+
+  const ustPrompt = `${book} ${chapter} --ust ${path.relative(cwd, outputs.ust)}${versesArg}`;
+  const ustResult = await executeNativeStage('UST-alignment', ustPrompt, opts);
+  finalizeAlignmentOutputs({
+    cwd,
+    book,
+    chapter,
+    sourceRelPath: path.relative(cwd, outputs.ust),
+    outputRelPath: path.relative(cwd, outputs.ustAligned),
+    ust: true,
+  });
+  verifyOutputFile(outputs.ustAligned, 'Aligned UST output');
+  stageResults.push(ustResult);
+
+  return summarizeStageResults('align-all-parallel', stageResults);
+}
+
+async function runOpenAiNativeSkill(skillName, prompt, opts = {}) {
+  if ((opts.provider || 'openai') !== 'openai') {
+    throw new Error('OpenAI native stage runner only supports provider "openai"');
+  }
+
+  switch (skillName) {
+    case 'initial-pipeline':
+      return runInitialPipeline(prompt, opts);
+    case 'align-all-parallel':
+      return runAlignmentPipeline(prompt, opts);
+    case 'ULT-gen':
+    case 'deep-issue-id':
+    case 'UST-gen':
+    case 'ULT-alignment':
+    case 'UST-alignment':
+    case 'tn-writer':
+    case 'tn-quality-check':
+      return executeNativeStage(skillName, prompt, opts);
+    default:
+      return executeNativeStage(skillName, prompt, opts);
+  }
+}
+
+module.exports = {
+  OPENAI_TOOL_SCHEMAS,
+  STAGE_PRESETS,
+  buildCanonicalPaths,
+  parseBookChapter,
+  verifyOutputFile,
+  runOpenAiNativeSkill,
+  runInitialPipeline,
+  runAlignmentPipeline,
+};

--- a/src/api-runner/openai-native.js
+++ b/src/api-runner/openai-native.js
@@ -1,0 +1,181 @@
+const {
+  Agent,
+  MemorySession,
+  OpenAIProvider,
+  Runner,
+  tool,
+} = require('@openai/agents');
+
+const { executeTool, TOOL_SCHEMAS, strictifySchema } = require('./tools');
+const { getProviderConfig, resolveProviderModel } = require('./provider-config');
+const { resolveRuntime } = require('./runtime-config');
+
+const DEFAULT_MODEL = getProviderConfig('openai').defaultModel;
+
+const THINKING_MAP = {
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  max: 'xhigh',
+};
+
+async function runOpenAiNative({
+  provider: providerName,
+  model,
+  system,
+  userMessage,
+  maxTurns = 100,
+  timeoutMs = 30 * 60 * 1000,
+  cwd = '/srv/bot/workspace',
+  thinking = 'medium',
+  apiKey,
+  toolChoice,
+  depth = 0,
+  apiKeyResolver,
+  lockProvider = false,
+  runtime = 'openai-native',
+  session,
+}) {
+  if (providerName !== 'openai') {
+    throw new Error(`OpenAI native runtime only supports provider "openai" (received "${providerName}")`);
+  }
+
+  const modelId = resolveProviderModel('openai', model || DEFAULT_MODEL);
+  const provider = new OpenAIProvider({ apiKey, useResponses: true });
+  const runner = new Runner({
+    modelProvider: provider,
+    tracingDisabled: true,
+    traceIncludeSensitiveData: false,
+    workflowName: 'bp-assistant-openai-native',
+  });
+  const activeSession = session || new MemorySession();
+  const startTime = Date.now();
+  const depthPrefix = depth > 0 ? `[depth ${depth}] ` : '';
+
+  console.log(
+    `[openai-native] ${depthPrefix}Starting — model: ${modelId}, thinking: ${thinking || 'default'}${toolChoice ? `, toolChoice: ${toolChoice}` : ''}`
+  );
+  console.log(`[openai-native] ${depthPrefix}Max turns: ${maxTurns}, timeout: ${timeoutMs / 1000}s`);
+
+  const abortController = new AbortController();
+  const timer = setTimeout(() => {
+    console.warn(`[openai-native] ${depthPrefix}Timeout reached after ${(Date.now() - startTime) / 1000}s`);
+    abortController.abort();
+  }, timeoutMs);
+
+  try {
+    const agent = new Agent({
+      name: depth > 0 ? `WorkspaceAgentDepth${depth}` : 'WorkspaceAgent',
+      instructions: system,
+      model: modelId,
+      tools: buildOpenAiNativeTools({
+        cwd,
+        depth,
+        thinking,
+        apiKey,
+        apiKeyResolver,
+        lockProvider,
+        runtime,
+      }),
+      modelSettings: buildModelSettings({ model: modelId, thinking, toolChoice }),
+    });
+
+    const result = await runner.run(agent, userMessage, {
+      maxTurns,
+      signal: abortController.signal,
+      session: activeSession,
+    });
+
+    const usage = result.state?.usage || result.runContext?.usage;
+    const inputTokens = usage?.inputTokens || 0;
+    const outputTokens = usage?.outputTokens || 0;
+    const durationMs = Date.now() - startTime;
+    const providerCfg = getProviderConfig('openai');
+    const modelCfg = providerCfg.models[modelId] || providerCfg.models[providerCfg.defaultModel];
+    const cost = ((inputTokens / 1_000_000) * modelCfg.inputPer1M) + ((outputTokens / 1_000_000) * modelCfg.outputPer1M);
+    const finalText = typeof result.finalOutput === 'string'
+      ? result.finalOutput
+      : JSON.stringify(result.finalOutput ?? '');
+
+    console.log(
+      `[openai-native] ${depthPrefix}Finished — turns: ${usage?.requests || 0}, input: ${inputTokens}, output: ${outputTokens}, cost: $${cost.toFixed(4)}, duration: ${(durationMs / 1000).toFixed(1)}s`
+    );
+
+    return {
+      turns: usage?.requests || 0,
+      inputTokens,
+      outputTokens,
+      cost,
+      durationMs,
+      finalText,
+      _messages: [],
+      _session: activeSession,
+    };
+  } finally {
+    clearTimeout(timer);
+    await provider.close().catch(() => {});
+  }
+}
+
+function buildOpenAiNativeTools(parentOpts) {
+  return TOOL_SCHEMAS.map((schema) => tool({
+    name: schema.name,
+    description: schema.description,
+    parameters: strictifySchema(schema.parameters),
+    strict: true,
+    execute: async (args) => {
+      const result = await executeTool(
+        schema.name,
+        args || {},
+        parentOpts.cwd,
+        {
+          parentOpts,
+          runAgentLoopFn: runNestedAgent,
+        }
+      );
+      return typeof result === 'string' ? result : JSON.stringify(result);
+    },
+  }));
+}
+
+async function runNestedAgent(opts) {
+  const runtime = resolveRuntime(opts.provider, opts.runtime);
+  if (runtime === 'openai-native') {
+    return runOpenAiNative(opts);
+  }
+
+  const { runAgentLoop } = require('./agent-loop');
+  return runAgentLoop({
+    ...opts,
+    runtime,
+  });
+}
+
+function buildModelSettings({ model, thinking, toolChoice }) {
+  const settings = {
+    toolChoice: toolChoice || 'auto',
+    parallelToolCalls: false,
+    maxTokens: 65536,
+    store: true,
+    text: { verbosity: 'medium' },
+  };
+
+  if (supportsReasoning(model) && thinking && thinking !== 'none') {
+    settings.reasoning = {
+      effort: THINKING_MAP[thinking] || 'medium',
+      summary: 'concise',
+    };
+  }
+
+  return settings;
+}
+
+function supportsReasoning(model) {
+  return /^(gpt-5|o3|o4)/.test(String(model || ''));
+}
+
+module.exports = {
+  runOpenAiNative,
+  buildModelSettings,
+  supportsReasoning,
+};

--- a/src/api-runner/openai-native.js
+++ b/src/api-runner/openai-native.js
@@ -35,6 +35,7 @@ async function runOpenAiNative({
   lockProvider = false,
   runtime = 'openai-native',
   session,
+  toolSchemas = TOOL_SCHEMAS,
 }) {
   if (providerName !== 'openai') {
     throw new Error(`OpenAI native runtime only supports provider "openai" (received "${providerName}")`);
@@ -76,6 +77,7 @@ async function runOpenAiNative({
         apiKeyResolver,
         lockProvider,
         runtime,
+        toolSchemas,
       }),
       modelSettings: buildModelSettings({ model: modelId, thinking, toolChoice }),
     });
@@ -118,7 +120,8 @@ async function runOpenAiNative({
 }
 
 function buildOpenAiNativeTools(parentOpts) {
-  return TOOL_SCHEMAS.map((schema) => tool({
+  const toolSchemas = parentOpts.toolSchemas || TOOL_SCHEMAS;
+  return toolSchemas.map((schema) => tool({
     name: schema.name,
     description: schema.description,
     parameters: strictifySchema(schema.parameters),

--- a/src/api-runner/prompt-builder.js
+++ b/src/api-runner/prompt-builder.js
@@ -18,6 +18,7 @@ const DEFAULT_WORKSPACE = '/srv/bot/workspace';
 function buildSkillPrompt(skillName, opts = {}) {
   const cwd = opts.cwd || DEFAULT_WORKSPACE;
   const date = opts.date || new Date().toISOString().split('T')[0];
+  const toolSchemas = opts.toolSchemas || TOOL_SCHEMAS;
 
   const skillPath = path.join(cwd, '.claude', 'skills', skillName, 'SKILL.md');
   const skillExists = fs.existsSync(skillPath);
@@ -32,7 +33,7 @@ function buildSkillPrompt(skillName, opts = {}) {
     claudeMd = fs.readFileSync(claudeMdPath, 'utf8');
   }
 
-  return assemblePreamble(cwd, date) + '\n\n' + buildToolCatalog() + '\n\n' + claudeMd + '\n\n---\n\n' + skillContent;
+  return assemblePreamble(cwd, date) + '\n\n' + buildToolCatalog(toolSchemas) + '\n\n' + claudeMd + '\n\n---\n\n' + skillContent;
 }
 
 /**
@@ -45,8 +46,9 @@ function buildSkillPrompt(skillName, opts = {}) {
 function buildCustomPrompt(systemText, opts = {}) {
   const cwd = opts.cwd || DEFAULT_WORKSPACE;
   const date = opts.date || new Date().toISOString().split('T')[0];
+  const toolSchemas = opts.toolSchemas || TOOL_SCHEMAS;
 
-  return assemblePreamble(cwd, date) + '\n\n' + buildToolCatalog() + '\n\n' + systemText;
+  return assemblePreamble(cwd, date) + '\n\n' + buildToolCatalog(toolSchemas) + '\n\n' + systemText;
 }
 
 /**
@@ -63,7 +65,7 @@ function assemblePreamble(cwd, date) {
 /**
  * Build a dynamic tool catalog from TOOL_SCHEMAS, grouped by category.
  */
-function buildToolCatalog() {
+function buildToolCatalog(toolSchemas = TOOL_SCHEMAS) {
   const categories = {
     'File Tools': ['Read', 'Write', 'Edit', 'Glob', 'Grep'],
     'Bible Translation Data': ['get_verse_data', 'get_existing_notes', 'get_template'],
@@ -78,7 +80,7 @@ function buildToolCatalog() {
 
   // Collect workspace tools (everything not in a known category, excluding MCP-prefixed duplicates)
   const workspaceTools = [];
-  for (const schema of TOOL_SCHEMAS) {
+  for (const schema of toolSchemas) {
     if (!categorized.has(schema.name) && !schema.name.startsWith('mcp__')) {
       workspaceTools.push(schema);
     }
@@ -93,7 +95,7 @@ function buildToolCatalog() {
   for (const [category, toolNames] of Object.entries(categories)) {
     lines.push('', `## ${category}`);
     for (const toolName of toolNames) {
-      const schema = TOOL_SCHEMAS.find(s => s.name === toolName);
+      const schema = toolSchemas.find(s => s.name === toolName);
       if (schema) {
         lines.push(`- **${schema.name}** — ${schema.description}`);
       }
@@ -106,8 +108,13 @@ function buildToolCatalog() {
   lines.push('- Before using an issue type, validate it with get_template');
   lines.push('- When encountering unfamiliar Hebrew, look it up via build_strongs_index');
   lines.push('- Use Grep/Glob to explore workspace files before assuming structure');
-  lines.push('- For multi-step work, use Agent to delegate sub-tasks to specialists');
-  lines.push('- Each Agent can use a different provider/model — pick the best fit for the task');
+  const hasAgentTool = toolSchemas.some((schema) => schema.name === 'Agent');
+  if (hasAgentTool) {
+    lines.push('- For multi-step work, use Agent to delegate sub-tasks to specialists');
+    lines.push('- Each Agent can use a different provider/model — pick the best fit for the task');
+  } else {
+    lines.push('- Agent/team delegation tools are not available in this run; complete the task yourself using the available tools');
+  }
 
   return lines.join('\n');
 }

--- a/src/api-runner/provider-config.js
+++ b/src/api-runner/provider-config.js
@@ -61,16 +61,17 @@ const DEFAULT_PROVIDER_CONFIGS = {
     },
   },
   xai: {
-    defaultModel: 'grok-4-1-fast-reasoning',
+    defaultModel: 'grok-4.20-reasoning',
     secretName: 'xai_api_key',
     envName: 'XAI_API_KEY',
     baseUrl: 'https://api.x.ai/v1',
     modelAliases: {
-      opus: 'grok-4-1-fast-reasoning',
-      sonnet: 'grok-4-1-fast-reasoning',
+      opus: 'grok-4.20-reasoning',
+      sonnet: 'grok-4.20-reasoning',
       haiku: 'grok-4-1-fast-non-reasoning',
     },
     models: {
+      'grok-4.20-reasoning': { label: 'Grok 4.20 (reasoning)', inputPer1M: 3.0, outputPer1M: 15.0 },
       'grok-4-0709': { label: 'Grok 4', inputPer1M: 3.0, outputPer1M: 9.0 },
       'grok-4-1-fast-reasoning': { label: 'Grok 4.1 Fast (reasoning)', inputPer1M: 3.0, outputPer1M: 9.0 },
       'grok-4-1-fast-non-reasoning': { label: 'Grok 4.1 Fast (no CoT)', inputPer1M: 3.0, outputPer1M: 9.0 },
@@ -79,13 +80,14 @@ const DEFAULT_PROVIDER_CONFIGS = {
     },
     autoModelByThinking: {
       low: 'grok-4-1-fast-non-reasoning',
-      medium: 'grok-4-1-fast-reasoning',
-      high: 'grok-4-1-fast-reasoning',
-      max: 'grok-4-1-fast-reasoning',
+      medium: 'grok-4.20-reasoning',
+      high: 'grok-4.20-reasoning',
+      max: 'grok-4.20-reasoning',
       none: 'grok-4-1-fast-non-reasoning',
     },
     reasoningEffortModels: ['grok-3-mini'],
     fallbackModels: {
+      'grok-4.20-reasoning': ['grok-4-1-fast-reasoning', 'grok-4-0709', 'grok-4-1-fast-non-reasoning', 'grok-3-mini'],
       'grok-4-1-fast-reasoning': ['grok-4-0709', 'grok-4-1-fast-non-reasoning', 'grok-3-mini'],
       'grok-4-0709': ['grok-4-1-fast-non-reasoning', 'grok-3-mini'],
     },

--- a/src/api-runner/provider-config.js
+++ b/src/api-runner/provider-config.js
@@ -19,18 +19,21 @@ const DEFAULT_PROVIDER_CONFIGS = {
     },
   },
   openai: {
-    defaultModel: 'gpt-4.1',
+    defaultModel: 'gpt-5.4',
     secretName: 'openai_api_key',
     envName: 'OPENAI_API_KEY',
     modelAliases: {
       opus: 'gpt-5.4',
-      sonnet: 'gpt-5.3',
-      haiku: 'o4-mini',
+      sonnet: 'gpt-5.4-mini',
+      haiku: 'gpt-5.4-nano',
+      'gpt-5.1-mini': 'gpt-5.4-mini',
     },
     models: {
       'gpt-4.1': { label: 'GPT 4.1', inputPer1M: 2.0, outputPer1M: 8.0 },
       'gpt-5.3': { label: 'GPT 5.3', inputPer1M: 4.0, outputPer1M: 16.0 },
       'gpt-5.4': { label: 'GPT 5.4', inputPer1M: 5.0, outputPer1M: 20.0 },
+      'gpt-5.4-mini': { label: 'GPT 5.4 mini', inputPer1M: 0.8, outputPer1M: 3.2 },
+      'gpt-5.4-nano': { label: 'GPT 5.4 nano', inputPer1M: 0.2, outputPer1M: 0.8 },
       'o3': { label: 'o3', inputPer1M: 2.5, outputPer1M: 10.0 },
       'o4-mini': { label: 'o4 mini', inputPer1M: 0.5, outputPer1M: 2.0 },
     },
@@ -51,12 +54,17 @@ const DEFAULT_PROVIDER_CONFIGS = {
       'gemini-2.5-pro': { label: 'Gemini 2.5 Pro', inputPer1M: 1.25, outputPer1M: 10.0 },
       'gemini-2.5-flash': { label: 'Gemini 2.5 Flash', inputPer1M: 0.15, outputPer1M: 0.6 },
     },
+    fallbackModels: {
+      'gemini-3.1-pro-preview': ['gemini-3-pro-preview', 'gemini-2.5-pro'],
+      'gemini-3-pro-preview': ['gemini-2.5-pro'],
+      'gemini-3-flash-preview': ['gemini-2.5-flash'],
+    },
   },
   xai: {
     defaultModel: 'grok-4-0709',
     secretName: 'xai_api_key',
     envName: 'XAI_API_KEY',
-    baseUrl: 'https://api.x.ai',
+    baseUrl: 'https://api.x.ai/v1',
     modelAliases: {
       opus: 'grok-4-0709',
       sonnet: 'grok-4-1-fast-reasoning',
@@ -77,6 +85,10 @@ const DEFAULT_PROVIDER_CONFIGS = {
       none: 'grok-4-1-fast-non-reasoning',
     },
     reasoningEffortModels: ['grok-3-mini'],
+    fallbackModels: {
+      'grok-4-0709': ['grok-4-1-fast-reasoning'],
+      'grok-4-1-fast-reasoning': ['grok-4-1-fast-non-reasoning', 'grok-3-mini'],
+    },
   },
   groq: {
     defaultModel: 'meta-llama/llama-4-scout-17b-16e-instruct',
@@ -177,6 +189,12 @@ function mergeProvider(baseCfg, overrideCfg) {
       ...(overrideCfg?.modelAliases || {}),
     };
   }
+  if (baseCfg?.fallbackModels || overrideCfg?.fallbackModels) {
+    merged.fallbackModels = {
+      ...(baseCfg?.fallbackModels || {}),
+      ...(overrideCfg?.fallbackModels || {}),
+    };
+  }
   if (Array.isArray(overrideCfg?.reasoningEffortModels)) {
     merged.reasoningEffortModels = [...overrideCfg.reasoningEffortModels];
   } else if (Array.isArray(baseCfg?.reasoningEffortModels)) {
@@ -245,6 +263,39 @@ function resolveProviderModel(provider, model) {
   return cfg.modelAliases?.[candidate] || candidate;
 }
 
+function isConfiguredModel(provider, model) {
+  if (!model || typeof model !== 'string') return false;
+  const cfg = getProviderConfig(provider);
+  return !!cfg.models?.[model];
+}
+
+function assertProviderModel(provider, model) {
+  const cfg = getProviderConfig(provider);
+  const resolved = resolveProviderModel(provider, model);
+  if (typeof resolved !== 'string' || isConfiguredModel(provider, resolved)) {
+    return resolved;
+  }
+
+  const validAliases = Object.keys(cfg.modelAliases || {});
+  const validModels = Object.keys(cfg.models || {});
+  throw new Error(
+    `Unknown ${provider} model "${model}". Valid aliases: ${validAliases.join(', ') || '(none)'}; valid models: ${validModels.join(', ')}`
+  );
+}
+
+function getFallbackModel(provider, currentModel, attemptedModels = new Set()) {
+  const cfg = getProviderConfig(provider);
+  const resolvedCurrent = resolveProviderModel(provider, currentModel || cfg.defaultModel);
+  const candidates = cfg.fallbackModels?.[resolvedCurrent] || [];
+  for (const candidate of candidates) {
+    const resolved = resolveProviderModel(provider, candidate);
+    if (!attemptedModels.has(resolved) && isConfiguredModel(provider, resolved)) {
+      return resolved;
+    }
+  }
+  return null;
+}
+
 module.exports = {
   DEFAULT_PROVIDER_CONFIGS,
   getResolvedProviderConfigs,
@@ -252,4 +303,7 @@ module.exports = {
   getProviderNames,
   resolveProviderModel,
   resolveXaiModel,
+  isConfiguredModel,
+  assertProviderModel,
+  getFallbackModel,
 };

--- a/src/api-runner/provider-config.js
+++ b/src/api-runner/provider-config.js
@@ -61,12 +61,12 @@ const DEFAULT_PROVIDER_CONFIGS = {
     },
   },
   xai: {
-    defaultModel: 'grok-4-0709',
+    defaultModel: 'grok-4-1-fast-reasoning',
     secretName: 'xai_api_key',
     envName: 'XAI_API_KEY',
     baseUrl: 'https://api.x.ai/v1',
     modelAliases: {
-      opus: 'grok-4-0709',
+      opus: 'grok-4-1-fast-reasoning',
       sonnet: 'grok-4-1-fast-reasoning',
       haiku: 'grok-4-1-fast-non-reasoning',
     },
@@ -86,8 +86,8 @@ const DEFAULT_PROVIDER_CONFIGS = {
     },
     reasoningEffortModels: ['grok-3-mini'],
     fallbackModels: {
-      'grok-4-0709': ['grok-4-1-fast-reasoning'],
-      'grok-4-1-fast-reasoning': ['grok-4-1-fast-non-reasoning', 'grok-3-mini'],
+      'grok-4-1-fast-reasoning': ['grok-4-0709', 'grok-4-1-fast-non-reasoning', 'grok-3-mini'],
+      'grok-4-0709': ['grok-4-1-fast-non-reasoning', 'grok-3-mini'],
     },
   },
   groq: {

--- a/src/api-runner/provider-nudges.js
+++ b/src/api-runner/provider-nudges.js
@@ -21,25 +21,49 @@ ${extraLines}
 `.trim();
 }
 
+function buildAlignmentNudge(extraLines, book, chapter) {
+  const normalizedBook = String(book || 'BOOK').toUpperCase();
+  const tag = chapterTag(normalizedBook, chapter);
+  return `
+CRITICAL: Your alignment task is NOT complete until the aligned USFM files actually exist in the workspace:
+- output/AI-ULT/${normalizedBook}/${tag}-aligned.usfm
+- output/AI-UST/${normalizedBook}/${tag}-aligned.usfm
+Use those exact canonical filenames, including the zero-padded chapter tag "${tag}".
+Do NOT stop after a sub-agent returns JSON or says alignment is complete.
+You must keep calling tools until the mapping JSON is written, \`create_aligned_usfm\` succeeds, and both aligned USFM files are verified with a Glob or Read.
+If \`validate_alignment_json\` or \`create_aligned_usfm\` fails, repair the mapping and retry instead of narrating success.
+${extraLines}
+`.trim();
+}
+
 function getProviderSystemAppend(provider, skillName, context = {}) {
-  if (skillName !== 'initial-pipeline') return '';
   const { book, chapter } = context;
 
-  if (provider === 'openai') {
-    return buildInitialPipelineNudge(
-      'Verify they exist with a Glob or Read before declaring the task complete.',
-      book,
-      chapter
-    );
+  if (skillName === 'initial-pipeline') {
+    if (provider === 'openai') {
+      return buildInitialPipelineNudge(
+        'Verify they exist with a Glob or Read before declaring the task complete.',
+        book,
+        chapter
+      );
+    }
+
+    if (provider === 'xai') {
+      return buildInitialPipelineNudge(
+        [
+          'Do NOT collapse the issues TSV to a header-only file just because candidate notes resemble published TN notes.',
+          'Published notes are reference material; keep concrete issue rows for note-worthy translation problems in this chapter.',
+          'Verify the issues TSV has at least one data row before declaring the pipeline complete.',
+        ].join('\n'),
+        book,
+        chapter
+      );
+    }
   }
 
-  if (provider === 'xai') {
-    return buildInitialPipelineNudge(
-      [
-        'Do NOT collapse the issues TSV to a header-only file just because candidate notes resemble published TN notes.',
-        'Published notes are reference material; keep concrete issue rows for note-worthy translation problems in this chapter.',
-        'Verify the issues TSV has at least one data row before declaring the pipeline complete.',
-      ].join('\n'),
+  if (skillName === 'align-all-parallel' && provider === 'xai') {
+    return buildAlignmentNudge(
+      'Do not accept a representative sample, commented pseudo-JSON, or a summary in place of the final mapping and aligned USFM outputs.',
       book,
       chapter
     );

--- a/src/api-runner/provider-nudges.js
+++ b/src/api-runner/provider-nudges.js
@@ -1,0 +1,53 @@
+function chapterTag(book, chapter) {
+  const normalizedBook = String(book || 'BOOK').toUpperCase();
+  const width = normalizedBook === 'PSA' ? 3 : 2;
+  const numericChapter = Number.isFinite(Number(chapter)) ? Number(chapter) : chapter;
+  return `${normalizedBook}-${String(numericChapter ?? '00').padStart(width, '0')}`;
+}
+
+function buildInitialPipelineNudge(extraLines, book, chapter) {
+  const normalizedBook = String(book || 'BOOK').toUpperCase();
+  const tag = chapterTag(normalizedBook, chapter);
+  return `
+CRITICAL: You are a multi-step pipeline orchestrator. Do NOT stop after reading source data.
+Your task is NOT complete until ALL of the following files exist in the workspace:
+- output/AI-ULT/${normalizedBook}/${tag}.usfm  (ULT plain text)
+- output/AI-UST/${normalizedBook}/${tag}.usfm  (UST plain text)
+- output/issues/${normalizedBook}/${tag}.tsv   (issues TSV)
+Use those exact canonical filenames, including the zero-padded chapter tag "${tag}".
+Do NOT invent unpadded variants such as "${normalizedBook}-${Number(chapter)}.usfm".
+Keep calling tools — writing files, delegating to sub-agents — until all three files are written.
+${extraLines}
+`.trim();
+}
+
+function getProviderSystemAppend(provider, skillName, context = {}) {
+  if (skillName !== 'initial-pipeline') return '';
+  const { book, chapter } = context;
+
+  if (provider === 'openai') {
+    return buildInitialPipelineNudge(
+      'Verify they exist with a Glob or Read before declaring the task complete.',
+      book,
+      chapter
+    );
+  }
+
+  if (provider === 'xai') {
+    return buildInitialPipelineNudge(
+      [
+        'Do NOT collapse the issues TSV to a header-only file just because candidate notes resemble published TN notes.',
+        'Published notes are reference material; keep concrete issue rows for note-worthy translation problems in this chapter.',
+        'Verify the issues TSV has at least one data row before declaring the pipeline complete.',
+      ].join('\n'),
+      book,
+      chapter
+    );
+  }
+
+  return '';
+}
+
+module.exports = {
+  getProviderSystemAppend,
+};

--- a/src/api-runner/providers/gemini.js
+++ b/src/api-runner/providers/gemini.js
@@ -14,7 +14,8 @@ const THINKING_MAP_3X = {
 };
 
 const THINKING_MAP_25 = {
-  low: 0,
+  // Gemini 2.5 rejects a zero budget for models that require thinking mode.
+  low: 1024,
   medium: 4096,
   high: 8192,
   max: 32768,
@@ -188,6 +189,7 @@ module.exports = {
   formatToolResult,
   formatAssistantMessage,
   estimateCost,
+  getThinkingConfig,
   toGeminiContents,
   DEFAULT_MODEL,
   MODELS,

--- a/src/api-runner/providers/gemini.js
+++ b/src/api-runner/providers/gemini.js
@@ -1,7 +1,7 @@
 // providers/gemini.js — Google Gemini SDK provider
 
 const { GoogleGenAI } = require('@google/genai');
-const { getProviderConfig, resolveProviderModel } = require('../provider-config');
+const { assertProviderModel, getProviderConfig, resolveProviderModel } = require('../provider-config');
 
 const DEFAULT_MODEL = getProviderConfig('gemini').defaultModel;
 const MODELS = getProviderConfig('gemini').models;
@@ -57,6 +57,7 @@ function toGeminiContents(messages) {
         role: 'user',
         parts: msg.results.map(r => ({
           functionResponse: {
+            ...(r.toolCallId ? { id: r.toolCallId } : {}),
             name: r.name,
             response: { content: r.content },
           },
@@ -73,7 +74,7 @@ function toGeminiContents(messages) {
 async function sendRequest({ model, system, messages, tools, thinking, apiKey, providerName = 'gemini', toolChoice }) {
   const ai = new GoogleGenAI({ apiKey });
   const providerCfg = getProviderConfig(providerName);
-  const modelId = resolveProviderModel(providerName, model || providerCfg.defaultModel);
+  const modelId = assertProviderModel(providerName, model || providerCfg.defaultModel);
 
   const config = { maxOutputTokens: 65536 };
   const thinkingCfg = getThinkingConfig(modelId, thinking);
@@ -105,7 +106,7 @@ async function sendRequest({ model, system, messages, tools, thinking, apiKey, p
     });
   } catch (error) {
     const status = error?.status || error?.response?.status;
-    const message = error?.message || 'Unknown Gemini SDK error';
+    const message = extractGeminiErrorMessage(error);
     throw new Error(`Gemini API error${status ? ` ${status}` : ''}: ${message}`);
   }
 
@@ -127,7 +128,7 @@ function parseResponse(data) {
       content += part.text;
     } else if (part.functionCall) {
       toolCalls.push({
-        id: `gemini-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        id: part.functionCall.id || `gemini-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         name: part.functionCall.name,
         arguments: part.functionCall.args || {},
       });
@@ -149,7 +150,12 @@ function parseResponse(data) {
 function formatToolResult(toolCallId, name, result, isError) {
   return {
     role: 'tool',
-    results: [{ name, content: typeof result === 'string' ? result : JSON.stringify(result) }],
+    results: [{
+      toolCallId,
+      name,
+      content: typeof result === 'string' ? result : JSON.stringify(result),
+      isError: !!isError,
+    }],
   };
 }
 
@@ -166,11 +172,23 @@ function estimateCost(model, usage, providerName = 'gemini') {
   return inputCost + outputCost;
 }
 
+function extractGeminiErrorMessage(error) {
+  if (!error) return 'Unknown Gemini SDK error';
+  const raw = error?.message || 'Unknown Gemini SDK error';
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed?.error?.message || raw;
+  } catch {
+    return raw;
+  }
+}
+
 module.exports = {
   sendRequest,
   formatToolResult,
   formatAssistantMessage,
   estimateCost,
+  toGeminiContents,
   DEFAULT_MODEL,
   MODELS,
 };

--- a/src/api-runner/providers/openai.js
+++ b/src/api-runner/providers/openai.js
@@ -1,7 +1,7 @@
 // providers/openai.js — OpenAI SDK provider
 
 const OpenAI = require('openai');
-const { getProviderConfig, resolveProviderModel } = require('../provider-config');
+const { assertProviderModel, getProviderConfig, resolveProviderModel } = require('../provider-config');
 
 const DEFAULT_MODEL = getProviderConfig('openai').defaultModel;
 const MODELS = getProviderConfig('openai').models;
@@ -57,7 +57,7 @@ function toOpenAIMessages(system, messages) {
 async function sendRequest({ model, system, messages, tools, thinking, apiKey, baseUrl, providerName = 'openai', toolChoice }) {
   const client = new OpenAI({ apiKey, baseURL: baseUrl });
   const providerCfg = getProviderConfig(providerName);
-  const modelId = resolveProviderModel(providerName, model || providerCfg.defaultModel);
+  const modelId = assertProviderModel(providerName, model || providerCfg.defaultModel);
 
   const body = {
     model: modelId,
@@ -84,7 +84,7 @@ async function sendRequest({ model, system, messages, tools, thinking, apiKey, b
     data = await client.chat.completions.create(body);
   } catch (error) {
     const status = error?.status || error?.response?.status;
-    const message = error?.message || 'Unknown OpenAI SDK error';
+    const message = normalizeOpenAiErrorMessage(error);
     throw new Error(`OpenAI API error${status ? ` ${status}` : ''}: ${message}`);
   }
   return parseResponse(data);
@@ -144,6 +144,12 @@ function estimateCost(model, usage, providerName = 'openai') {
   const inputCost = (usage.inputTokens / 1_000_000) * m.inputPer1M;
   const outputCost = (usage.outputTokens / 1_000_000) * m.outputPer1M;
   return inputCost + outputCost;
+}
+
+function normalizeOpenAiErrorMessage(error) {
+  const raw = error?.message || 'Unknown OpenAI SDK error';
+  const providerMessage = error?.error?.message || error?.response?.data?.error?.message;
+  return providerMessage || raw;
 }
 
 module.exports = {

--- a/src/api-runner/runner.js
+++ b/src/api-runner/runner.js
@@ -4,6 +4,7 @@
 const { buildSkillPrompt, buildCustomPrompt } = require('./prompt-builder');
 const { runAgentLoop } = require('./agent-loop');
 const { runOpenAiNative } = require('./openai-native');
+const { runOpenAiNativeSkill } = require('./openai-native-stage-runner');
 const { DEFAULT_RUNTIME, resolveRuntime } = require('./runtime-config');
 const { readSecret } = require('../secrets');
 const { getProviderConfig } = require('./provider-config');
@@ -29,13 +30,26 @@ const { getProviderConfig } = require('./provider-config');
  */
 async function runSkill(name, prompt, opts = {}) {
   const cwd = opts.cwd || '/srv/bot/workspace';
+  const provider = opts.provider || 'gemini';
+  const runtime = resolveRuntime(provider, opts.runtime);
+
+  if (provider === 'openai' && runtime === 'openai-native') {
+    return runOpenAiNativeSkill(name, prompt, {
+      ...opts,
+      provider,
+      runtime,
+      cwd,
+      apiKey: resolveApiKey(provider, opts.apiKeys || {}),
+      apiKeyResolver: (p) => resolveApiKey(p, opts.apiKeys || {}),
+    });
+  }
+
   const system = buildSkillPrompt(name, { cwd }) + (opts.systemAppend ? '\n\n' + opts.systemAppend : '');
 
   if (opts.dryRun) {
     return dryRun(system, prompt, opts);
   }
 
-  const provider = opts.provider || 'gemini';
   return runWithSystem(system, prompt, {
     ...opts,
     provider,
@@ -67,6 +81,7 @@ async function runCustom(systemText, prompt, opts = {}) {
 
 async function runWithSystem(system, prompt, opts = {}) {
   const provider = opts.provider || 'gemini';
+  const cwd = opts.cwd || '/srv/bot/workspace';
   const runtime = resolveRuntime(provider, opts.runtime);
   const runner = runtime === 'openai-native' ? runOpenAiNative : runAgentLoop;
 

--- a/src/api-runner/runner.js
+++ b/src/api-runner/runner.js
@@ -3,6 +3,8 @@
 
 const { buildSkillPrompt, buildCustomPrompt } = require('./prompt-builder');
 const { runAgentLoop } = require('./agent-loop');
+const { runOpenAiNative } = require('./openai-native');
+const { DEFAULT_RUNTIME, resolveRuntime } = require('./runtime-config');
 const { readSecret } = require('../secrets');
 const { getProviderConfig } = require('./provider-config');
 
@@ -34,20 +36,9 @@ async function runSkill(name, prompt, opts = {}) {
   }
 
   const provider = opts.provider || 'gemini';
-  return runAgentLoop({
+  return runWithSystem(system, prompt, {
+    ...opts,
     provider,
-    model: opts.model,
-    system,
-    userMessage: prompt,
-    maxTurns: opts.maxTurns || 100,
-    timeoutMs: (opts.timeout || 30) * 60 * 1000,
-    cwd,
-    verbose: opts.verbose || false,
-    thinking: opts.thinking || 'medium',
-    apiKey: resolveApiKey(provider, opts.apiKeys || {}),
-    toolChoice: opts.toolChoice,
-    apiKeyResolver: (p) => resolveApiKey(p, opts.apiKeys || {}),
-    lockProvider: !!opts.lockProvider,
   });
 }
 
@@ -68,8 +59,20 @@ async function runCustom(systemText, prompt, opts = {}) {
   }
 
   const provider = opts.provider || 'gemini';
-  return runAgentLoop({
+  return runWithSystem(system, prompt, {
+    ...opts,
     provider,
+  });
+}
+
+async function runWithSystem(system, prompt, opts = {}) {
+  const provider = opts.provider || 'gemini';
+  const runtime = resolveRuntime(provider, opts.runtime);
+  const runner = runtime === 'openai-native' ? runOpenAiNative : runAgentLoop;
+
+  return runner({
+    provider,
+    runtime,
     model: opts.model,
     system,
     userMessage: prompt,
@@ -82,6 +85,7 @@ async function runCustom(systemText, prompt, opts = {}) {
     toolChoice: opts.toolChoice,
     apiKeyResolver: (p) => resolveApiKey(p, opts.apiKeys || {}),
     lockProvider: !!opts.lockProvider,
+    session: opts.session,
   });
 }
 
@@ -107,7 +111,7 @@ function listProviders() {
   return getProviderNames();
 }
 
-module.exports = { runSkill, runCustom, resolveApiKey, listProviders };
+module.exports = { runSkill, runCustom, resolveApiKey, listProviders, runWithSystem };
 
 function dryRun(system, prompt, opts) {
   console.log('=== DRY RUN ===\n');
@@ -117,6 +121,7 @@ function dryRun(system, prompt, opts) {
   console.log(prompt);
   console.log('\n--- Options ---');
   console.log(`Provider: ${opts.provider || 'gemini'}`);
+  console.log(`Runtime: ${opts.runtime || DEFAULT_RUNTIME}`);
   console.log(`Model: ${opts.model || '(default)'}`);
   console.log(`Thinking: ${opts.thinking || 'medium'}`);
   console.log(`Tool Choice: ${opts.toolChoice || '(default)'}`);

--- a/src/api-runner/runner.js
+++ b/src/api-runner/runner.js
@@ -47,6 +47,7 @@ async function runSkill(name, prompt, opts = {}) {
     apiKey: resolveApiKey(provider, opts.apiKeys || {}),
     toolChoice: opts.toolChoice,
     apiKeyResolver: (p) => resolveApiKey(p, opts.apiKeys || {}),
+    lockProvider: !!opts.lockProvider,
   });
 }
 
@@ -80,6 +81,7 @@ async function runCustom(systemText, prompt, opts = {}) {
     apiKey: resolveApiKey(provider, opts.apiKeys || {}),
     toolChoice: opts.toolChoice,
     apiKeyResolver: (p) => resolveApiKey(p, opts.apiKeys || {}),
+    lockProvider: !!opts.lockProvider,
   });
 }
 

--- a/src/api-runner/runtime-config.js
+++ b/src/api-runner/runtime-config.js
@@ -1,0 +1,33 @@
+const DEFAULT_RUNTIME = 'generic-api';
+
+const VALID_RUNTIMES = new Set([
+  DEFAULT_RUNTIME,
+  'openai-native',
+]);
+
+function normalizeRuntime(runtime) {
+  if (!runtime) return DEFAULT_RUNTIME;
+  return String(runtime).trim().toLowerCase();
+}
+
+function resolveRuntime(provider, runtime) {
+  const resolvedProvider = String(provider || 'gemini').trim().toLowerCase();
+  const resolvedRuntime = normalizeRuntime(runtime);
+
+  if (!VALID_RUNTIMES.has(resolvedRuntime)) {
+    throw new Error(`Unknown runtime "${runtime}". Valid: ${Array.from(VALID_RUNTIMES).join(', ')}`);
+  }
+
+  if (resolvedRuntime === 'openai-native' && resolvedProvider !== 'openai') {
+    throw new Error(`Runtime "${resolvedRuntime}" is only supported with provider "openai"`);
+  }
+
+  return resolvedRuntime;
+}
+
+module.exports = {
+  DEFAULT_RUNTIME,
+  VALID_RUNTIMES,
+  normalizeRuntime,
+  resolveRuntime,
+};

--- a/src/api-runner/team-manager.js
+++ b/src/api-runner/team-manager.js
@@ -2,6 +2,7 @@
 // Manages named teams of agents, each with their own provider/model/conversation state.
 
 const MAX_DEPTH = 3;
+const { isConfiguredModel, resolveProviderModel } = require('./provider-config');
 
 // Global state
 const teams = new Map();   // teamName → Team
@@ -76,8 +77,9 @@ async function spawnAgent(opts, parentOpts, runAgentLoopFn) {
     return `Error: Maximum agent nesting depth (${MAX_DEPTH}) reached. Cannot spawn "${opts.name}".`;
   }
 
-  const provider = opts.provider || parentOpts.provider || 'gemini';
-  const model = opts.model || (provider === parentOpts.provider ? parentOpts.model : undefined);
+  const provider = resolveAgentProvider(opts, parentOpts);
+  const requestedModel = opts.model || (provider === parentOpts.provider ? parentOpts.model : undefined);
+  const model = normalizeAgentModel(provider, requestedModel);
   const thinking = opts.thinking || parentOpts.thinking || 'medium';
   const cwd = parentOpts.cwd || '/srv/bot/workspace';
   const apiKey = parentOpts.apiKeyResolver ? parentOpts.apiKeyResolver(provider) : parentOpts.apiKey;
@@ -178,7 +180,7 @@ async function sendMessageToAgent(opts, parentOpts, runAgentLoopFn) {
   try {
     const result = await runAgentLoopFn({
       provider: agent.provider,
-      model: agent.model,
+      model: normalizeAgentModel(agent.provider, agent.model),
       system: agent.systemPrompt,
       userMessage: opts.message,
       existingMessages: agent.messages,
@@ -244,6 +246,22 @@ function getTask(id) {
   return { id, status: entry.status, result: entry.result };
 }
 
+function normalizeAgentModel(provider, requestedModel) {
+  if (!requestedModel) return undefined;
+  const resolved = resolveProviderModel(provider, requestedModel);
+  if (isConfiguredModel(provider, resolved)) {
+    return resolved;
+  }
+  return undefined;
+}
+
+function resolveAgentProvider(opts, parentOpts) {
+  if (parentOpts?.lockProvider && parentOpts?.provider) {
+    return parentOpts.provider;
+  }
+  return opts.provider || parentOpts.provider || 'gemini';
+}
+
 module.exports = {
   createTeam,
   deleteTeam,
@@ -253,4 +271,6 @@ module.exports = {
   createTask,
   getTask,
   MAX_DEPTH,
+  normalizeAgentModel,
+  resolveAgentProvider,
 };

--- a/src/api-runner/team-manager.js
+++ b/src/api-runner/team-manager.js
@@ -78,6 +78,7 @@ async function spawnAgent(opts, parentOpts, runAgentLoopFn) {
   }
 
   const provider = resolveAgentProvider(opts, parentOpts);
+  const runtime = resolveAgentRuntime(opts, parentOpts);
   const requestedModel = opts.model || (provider === parentOpts.provider ? parentOpts.model : undefined);
   const model = normalizeAgentModel(provider, requestedModel);
   const thinking = opts.thinking || parentOpts.thinking || 'medium';
@@ -87,7 +88,7 @@ async function spawnAgent(opts, parentOpts, runAgentLoopFn) {
   // Build system prompt for the sub-agent
   const system = opts.system || `You are "${opts.name}", a specialist sub-agent. Complete your assigned task thoroughly and return your final answer as text.`;
 
-  console.log(`[team-manager] Spawning agent "${opts.name}" (provider: ${provider}, model: ${model || 'default'}, depth: ${depth})`);
+  console.log(`[team-manager] Spawning agent "${opts.name}" (provider: ${provider}, runtime: ${runtime}, model: ${model || 'default'}, depth: ${depth})`);
 
   // Register in team if specified
   let agentState;
@@ -102,9 +103,11 @@ async function spawnAgent(opts, parentOpts, runAgentLoopFn) {
       name: opts.name,
       systemPrompt: system,
       provider,
+      runtime,
       model,
       thinking,
       messages: [],
+      session: null,
       status: 'running',
       lastResult: '',
     };
@@ -114,6 +117,7 @@ async function spawnAgent(opts, parentOpts, runAgentLoopFn) {
   try {
     const result = await runAgentLoopFn({
       provider,
+      runtime,
       model,
       system,
       userMessage: opts.prompt,
@@ -134,6 +138,7 @@ async function spawnAgent(opts, parentOpts, runAgentLoopFn) {
       agentState.status = 'completed';
       agentState.lastResult = finalText;
       agentState.messages = result._messages || [];
+      agentState.session = result._session || null;
     }
 
     console.log(`[team-manager] Agent "${opts.name}" completed — ${result.turns} turns, $${result.cost.toFixed(4)}`);
@@ -181,10 +186,12 @@ async function sendMessageToAgent(opts, parentOpts, runAgentLoopFn) {
   try {
     const result = await runAgentLoopFn({
       provider: agent.provider,
+      runtime: agent.runtime,
       model: normalizeAgentModel(agent.provider, agent.model),
       system: agent.systemPrompt,
       userMessage: opts.message,
       existingMessages: agent.messages,
+      session: agent.session || undefined,
       maxTurns: 50,
       timeoutMs: 15 * 60 * 1000,
       cwd: parentOpts.cwd || '/srv/bot/workspace',
@@ -198,6 +205,7 @@ async function sendMessageToAgent(opts, parentOpts, runAgentLoopFn) {
     agent.status = 'completed';
     agent.lastResult = result.finalText || '(no output)';
     agent.messages = result._messages || [];
+    agent.session = result._session || null;
 
     console.log(`[team-manager] Agent "${opts.to}" responded — ${result.turns} turns, $${result.cost.toFixed(4)}`);
     return agent.lastResult;
@@ -264,6 +272,13 @@ function resolveAgentProvider(opts, parentOpts) {
   return opts.provider || parentOpts.provider || 'gemini';
 }
 
+function resolveAgentRuntime(opts, parentOpts) {
+  if (parentOpts?.lockProvider && parentOpts?.runtime) {
+    return parentOpts.runtime;
+  }
+  return opts.runtime || parentOpts.runtime || 'generic-api';
+}
+
 module.exports = {
   createTeam,
   deleteTeam,
@@ -275,4 +290,5 @@ module.exports = {
   MAX_DEPTH,
   normalizeAgentModel,
   resolveAgentProvider,
+  resolveAgentRuntime,
 };

--- a/src/api-runner/team-manager.js
+++ b/src/api-runner/team-manager.js
@@ -124,6 +124,7 @@ async function spawnAgent(opts, parentOpts, runAgentLoopFn) {
       thinking,
       apiKey,
       depth: depth + 1,
+      lockProvider: !!parentOpts.lockProvider,
     });
 
     const finalText = result.finalText || '(no output)';
@@ -191,6 +192,7 @@ async function sendMessageToAgent(opts, parentOpts, runAgentLoopFn) {
       thinking: agent.thinking,
       apiKey,
       depth: (parentOpts.depth || 0) + 1,
+      lockProvider: !!parentOpts.lockProvider,
     });
 
     agent.status = 'completed';

--- a/src/api-runner/tools.js
+++ b/src/api-runner/tools.js
@@ -381,4 +381,5 @@ module.exports = {
   executeTool,
   listToolNames,
   getToolDescriptions,
+  strictifySchema,
 };

--- a/src/api-runner/tools.js
+++ b/src/api-runner/tools.js
@@ -90,6 +90,26 @@ const TOOL_SCHEMAS = [
   ...WORKSPACE_TOOL_REGISTRY.schemas,
 ];
 
+function getToolSchemas(opts = {}) {
+  const {
+    excludeAgentTools = false,
+    includeNames = null,
+  } = opts;
+
+  let schemas = TOOL_SCHEMAS;
+
+  if (excludeAgentTools) {
+    schemas = schemas.filter((schema) => !isAgentTool(schema.name));
+  }
+
+  if (Array.isArray(includeNames) && includeNames.length > 0) {
+    const allowed = new Set(includeNames);
+    schemas = schemas.filter((schema) => allowed.has(schema.name));
+  }
+
+  return schemas;
+}
+
 function buildWorkspaceToolRegistry() {
   const workspaceToolsServer = createWorkspaceTools(
     (config) => config,
@@ -375,6 +395,7 @@ async function executeWorkspaceTool(name, params) {
 
 module.exports = {
   TOOL_SCHEMAS,
+  getToolSchemas,
   toGeminiTools,
   toOpenAITools,
   toClaudeTools,

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -1625,7 +1625,7 @@ async function notesPipeline(route, message) {
       expectedOutput: `output/quality/${book}/${qualityTag}-quality.md`,
       appendSystemPrompt: TN_QUALITY_CHECK_HINT,
       mcpTools: 'quality',
-      maxTurns: 30,
+      maxTurns: 100,
       ops: 1,
       model: 'sonnet',
     });

--- a/src/pipeline-context.js
+++ b/src/pipeline-context.js
@@ -321,7 +321,18 @@ async function buildNotesContext({ book, chapter, verseStart, verseEnd, issuesPa
  * @param {number} [opts.verseEnd]
  * @returns {{dirPath: string, contextPath: string}}
  */
-function buildGenerateContext({ book, chapter, ultPath, ustPath, verseStart, verseEnd, dirPath: existingDirPath = null }) {
+function buildGenerateContext({
+  book,
+  chapter,
+  ultPath,
+  ustPath,
+  issuesPath = null,
+  ultFullPath = null,
+  ustFullPath = null,
+  verseStart,
+  verseEnd,
+  dirPath: existingDirPath = null,
+}) {
   const dirPath = existingDirPath || createPipelineDir({ book, chapter, verseStart, verseEnd, reset: true });
   const bookUpper = book.toUpperCase();
   const num = BOOK_NUMBERS[bookUpper];
@@ -338,7 +349,10 @@ function buildGenerateContext({ book, chapter, ultPath, ustPath, verseStart, ver
     sources: {
       ult: ultPath,
       ust: ustPath || null,
+      ultFull: ultFullPath || ultPath,
+      ustFull: ustFullPath || ustPath || null,
       hebrew: hebrewPath,
+      issues: issuesPath,
     },
     sourceOrigin: {
       ult: { from: 'pipeline', skill: 'initial-pipeline' },

--- a/src/workspace-tools/tn-tools.js
+++ b/src/workspace-tools/tn-tools.js
@@ -1827,7 +1827,8 @@ function prepareATContext({ preparedJson, generatedJson, output }) {
  */
 function readPreparedNotes({ preparedJson, start = 0, end, summaryOnly = false }) {
   const fullPath = path.resolve(CSKILLBP_DIR, preparedJson);
-  const items = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+  const parsed = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+  const items = Array.isArray(parsed) ? parsed : (Array.isArray(parsed?.items) ? parsed.items : []);
   const total = items.length;
 
   if (summaryOnly) {

--- a/test/api-runner-provider-regressions.test.js
+++ b/test/api-runner-provider-regressions.test.js
@@ -8,12 +8,20 @@ const {
   getProviderConfig,
   resolveProviderModel,
 } = require('../src/api-runner/provider-config');
+const { parseArgs } = require('../src/api-runner/cli');
+const {
+  DEFAULT_RUNTIME,
+  resolveRuntime,
+} = require('../src/api-runner/runtime-config');
 const geminiProvider = require('../src/api-runner/providers/gemini');
 const {
   getHarnessModels,
   validateRequiredArtifacts,
 } = require('../scripts/test-providers-zec3');
-const { resolveAgentProvider } = require('../src/api-runner/team-manager');
+const {
+  resolveAgentProvider,
+  resolveAgentRuntime,
+} = require('../src/api-runner/team-manager');
 const { getProviderSystemAppend } = require('../src/api-runner/provider-nudges');
 const { readPreparedNotes } = require('../src/workspace-tools/tn-tools');
 
@@ -23,6 +31,35 @@ test('openai aliases resolve to current runner defaults', () => {
   assert.equal(resolveProviderModel('openai', 'haiku'), 'gpt-5.4-nano');
   assert.equal(resolveProviderModel('xai', 'opus'), 'grok-4.20-reasoning');
   assert.equal(resolveProviderModel('xai', 'sonnet'), 'grok-4.20-reasoning');
+});
+
+test('runtime config defaults to generic api and restricts openai-native to openai', () => {
+  assert.equal(resolveRuntime('openai'), DEFAULT_RUNTIME);
+  assert.equal(resolveRuntime('openai', 'openai-native'), 'openai-native');
+  assert.throws(
+    () => resolveRuntime('gemini', 'openai-native'),
+    /only supported with provider "openai"/
+  );
+  assert.throws(
+    () => resolveRuntime('openai', 'made-up-runtime'),
+    /Unknown runtime/
+  );
+});
+
+test('cli parses runtime flag for api runner selection', () => {
+  const args = parseArgs([
+    'node',
+    'src/api-runner/cli.js',
+    '--provider', 'openai',
+    '--runtime', 'openai-native',
+    '--skill', 'ULT-gen',
+    '--prompt', 'PSA 133',
+  ]);
+
+  assert.equal(args.provider, 'openai');
+  assert.equal(args.runtime, 'openai-native');
+  assert.equal(args.skill, 'ULT-gen');
+  assert.equal(args.prompt, 'PSA 133');
 });
 
 test('gemini provider config exposes fallback models for transient overloads', () => {
@@ -101,6 +138,17 @@ test('locked provider runs keep sub-agents on the parent provider', () => {
   assert.equal(
     resolveAgentProvider({}, { provider: 'gemini', lockProvider: true }),
     'gemini'
+  );
+});
+
+test('locked runtime runs keep sub-agents on the parent runtime', () => {
+  assert.equal(
+    resolveAgentRuntime({ runtime: 'generic-api' }, { runtime: 'openai-native', lockProvider: true }),
+    'openai-native'
+  );
+  assert.equal(
+    resolveAgentRuntime({}, { runtime: 'generic-api', lockProvider: false }),
+    'generic-api'
   );
 });
 

--- a/test/api-runner-provider-regressions.test.js
+++ b/test/api-runner-provider-regressions.test.js
@@ -16,14 +16,195 @@ const {
 const geminiProvider = require('../src/api-runner/providers/gemini');
 const {
   getHarnessModels,
+  getCleanupTargets,
   validateRequiredArtifacts,
+  destDirName,
 } = require('../scripts/test-providers-zec3');
 const {
   resolveAgentProvider,
   resolveAgentRuntime,
 } = require('../src/api-runner/team-manager');
 const { getProviderSystemAppend } = require('../src/api-runner/provider-nudges');
+const {
+  OPENAI_TOOL_SCHEMAS,
+  buildCanonicalPaths,
+  verifyOutputFile,
+} = require('../src/api-runner/openai-native-stage-runner');
 const { readPreparedNotes } = require('../src/workspace-tools/tn-tools');
+
+test('openai native tool catalog excludes recursive agent tools', () => {
+  const names = OPENAI_TOOL_SCHEMAS.map((schema) => schema.name);
+  assert.equal(names.includes('Agent'), false);
+  assert.equal(names.includes('TeamCreate'), false);
+  assert.equal(names.includes('SendMessage'), false);
+  assert.equal(names.includes('TaskCreate'), false);
+  assert.equal(names.includes('TaskGet'), false);
+  assert.equal(names.includes('Read'), true);
+  assert.equal(names.includes('mcp__workspace-tools__read_prepared_notes'), true);
+});
+
+test('openai native output verification rejects missing and empty files', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openai-native-verify-'));
+  const missingPath = path.join(tempDir, 'missing.tsv');
+  assert.throws(() => verifyOutputFile(missingPath, 'notes'), /missing/);
+
+  const emptyPath = path.join(tempDir, 'empty.tsv');
+  fs.writeFileSync(emptyPath, '');
+  assert.throws(() => verifyOutputFile(emptyPath, 'notes'), /empty/);
+
+  const okPath = path.join(tempDir, 'ok.tsv');
+  fs.writeFileSync(okPath, 'Reference\tID\nZEC 3:1\ta1b2\n');
+  assert.doesNotThrow(() => verifyOutputFile(okPath, 'notes'));
+});
+
+test('runSkill delegates openai native skills to the native stage runner', async () => {
+  const runnerPath = require.resolve('../src/api-runner/runner');
+  const stageRunnerPath = require.resolve('../src/api-runner/openai-native-stage-runner');
+  const stageRunnerModule = require(stageRunnerPath);
+  const originalRunOpenAiNativeSkill = stageRunnerModule.runOpenAiNativeSkill;
+
+  let received = null;
+  stageRunnerModule.runOpenAiNativeSkill = async (skillName, prompt, opts) => {
+    received = { skillName, prompt, opts };
+    return {
+      turns: 1,
+      inputTokens: 10,
+      outputTokens: 5,
+      cost: 0.01,
+      durationMs: 5,
+      finalText: 'ok',
+    };
+  };
+
+  delete require.cache[runnerPath];
+
+  try {
+    const runner = require(runnerPath);
+    const result = await runner.runSkill('tn-writer', 'ZEC 3 --context tmp/pipeline/ZEC-03/context.json', {
+      provider: 'openai',
+      runtime: 'openai-native',
+      cwd: '/srv/bot/workspace',
+      apiKeys: { openai: 'test-key' },
+    });
+
+    assert.equal(received.skillName, 'tn-writer');
+    assert.equal(received.prompt, 'ZEC 3 --context tmp/pipeline/ZEC-03/context.json');
+    assert.equal(received.opts.runtime, 'openai-native');
+    assert.equal(result.finalText, 'ok');
+  } finally {
+    stageRunnerModule.runOpenAiNativeSkill = originalRunOpenAiNativeSkill;
+    delete require.cache[runnerPath];
+  }
+});
+
+test('openai native initial-pipeline expands into ULT, issues, and UST stages', async () => {
+  const agentLoopPath = require.resolve('../src/api-runner/agent-loop');
+  const stageRunnerPath = require.resolve('../src/api-runner/openai-native-stage-runner');
+  const agentLoopModule = require(agentLoopPath);
+  const originalRunAgentLoop = agentLoopModule.runAgentLoop;
+  const tempTag = `JON-${String(9).padStart(2, '0')}`;
+  const cwd = '/srv/bot/workspace';
+  const outputs = buildCanonicalPaths(cwd, 'JON', 9);
+  const pipelineDir = path.join(cwd, 'tmp/pipeline', tempTag);
+
+  for (const target of [
+    outputs.ult,
+    outputs.ust,
+    outputs.issues,
+    pipelineDir,
+  ]) {
+    if (fs.existsSync(target)) {
+      fs.rmSync(target, { recursive: true, force: true });
+    }
+  }
+
+  agentLoopModule.runAgentLoop = async (opts) => {
+    const system = String(opts.system || '');
+    if (system.includes('name: ULT-gen')) {
+      fs.mkdirSync(path.dirname(outputs.ult), { recursive: true });
+      fs.writeFileSync(outputs.ult, '\\id JON\n\\c 9\n\\v 1 test\n');
+    } else if (system.includes('name: deep-issue-id')) {
+      fs.mkdirSync(path.dirname(outputs.issues), { recursive: true });
+      fs.writeFileSync(outputs.issues, 'Reference\tID\tTags\tSupportReference\tQuote\tOccurrence\tNote\nJON 9:1\ta1b2\tfigs-metaphor\t\tfish\t1\tTest\n');
+    } else if (system.includes('name: UST-gen')) {
+      fs.mkdirSync(path.dirname(outputs.ust), { recursive: true });
+      fs.writeFileSync(outputs.ust, '\\id JON\n\\c 9\n\\v 1 test\n');
+    }
+
+    return {
+      turns: 1,
+      inputTokens: 10,
+      outputTokens: 5,
+      cost: 0.01,
+      durationMs: 5,
+      finalText: 'ok',
+    };
+  };
+
+  delete require.cache[stageRunnerPath];
+
+  try {
+    const { runOpenAiNativeSkill } = require(stageRunnerPath);
+    const result = await runOpenAiNativeSkill('initial-pipeline', 'jon 9', {
+      provider: 'openai',
+      runtime: 'openai-native',
+      cwd,
+      apiKey: 'test-key',
+      apiKeyResolver: () => 'test-key',
+    });
+
+    assert.deepEqual(result.steps.map((step) => step.skill), ['ULT-gen', 'deep-issue-id', 'UST-gen']);
+    assert.equal(fs.existsSync(outputs.ult), true);
+    assert.equal(fs.existsSync(outputs.issues), true);
+    assert.equal(fs.existsSync(outputs.ust), true);
+  } finally {
+    agentLoopModule.runAgentLoop = originalRunAgentLoop;
+    if (fs.existsSync(outputs.ult)) fs.rmSync(outputs.ult, { force: true });
+    if (fs.existsSync(outputs.ust)) fs.rmSync(outputs.ust, { force: true });
+    if (fs.existsSync(outputs.issues)) fs.rmSync(outputs.issues, { force: true });
+    if (fs.existsSync(pipelineDir)) fs.rmSync(pipelineDir, { recursive: true, force: true });
+  }
+});
+
+test('runWithSystem forwards cwd into the openai native runtime', async () => {
+  const runnerPath = require.resolve('../src/api-runner/runner');
+  const nativePath = require.resolve('../src/api-runner/openai-native');
+  const originalNativeModule = require.cache[nativePath];
+  const nativeModule = require(nativePath);
+  const originalRunOpenAiNative = nativeModule.runOpenAiNative;
+
+  let receivedOpts = null;
+  nativeModule.runOpenAiNative = async (opts) => {
+    receivedOpts = opts;
+    return {
+      turns: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+      durationMs: 0,
+      finalText: 'ok',
+    };
+  };
+
+  delete require.cache[runnerPath];
+
+  try {
+    const runner = require(runnerPath);
+    await runner.runWithSystem('system', 'prompt', {
+      provider: 'openai',
+      runtime: 'openai-native',
+      cwd: '/tmp/native-cwd',
+      apiKeys: { openai: 'test-key' },
+    });
+
+    assert.equal(receivedOpts.cwd, '/tmp/native-cwd');
+    assert.equal(receivedOpts.runtime, 'openai-native');
+  } finally {
+    nativeModule.runOpenAiNative = originalRunOpenAiNative;
+    delete require.cache[runnerPath];
+    if (originalNativeModule) require.cache[nativePath] = originalNativeModule;
+  }
+});
 
 test('openai aliases resolve to current runner defaults', () => {
   assert.equal(resolveProviderModel('openai', 'opus'), 'gpt-5.4');
@@ -79,6 +260,51 @@ test('gemini ZEC harness defaults follow provider-config aliases', () => {
   assert.equal(models.sonnet, resolveProviderModel('gemini', 'sonnet'));
   assert.equal(models.opus, 'gemini-3.1-pro-preview');
   assert.equal(models.sonnet, 'gemini-2.5-pro');
+});
+
+test('zec harness parses runtime flag for openai native runs', () => {
+  const args = require('../scripts/test-providers-zec3').parseArgs([
+    'node',
+    'scripts/test-providers-zec3.js',
+    '--provider', 'openai',
+    '--runtime', 'openai-native',
+  ]);
+
+  assert.equal(args.provider, 'openai');
+  assert.equal(args.runtime, 'openai-native');
+});
+
+test('zec harness keeps generic api as the default runtime', () => {
+  const args = require('../scripts/test-providers-zec3').parseArgs([
+    'node',
+    'scripts/test-providers-zec3.js',
+    '--provider', 'openai',
+  ]);
+
+  assert.equal(args.runtime, DEFAULT_RUNTIME);
+});
+
+test('zec harness files openai native snapshots in a sibling folder', () => {
+  assert.equal(destDirName('openai', DEFAULT_RUNTIME), 'openai-api');
+  assert.equal(destDirName('openai', 'openai-native'), 'openai-native');
+  assert.equal(destDirName('gemini', DEFAULT_RUNTIME), 'gemini-api');
+});
+
+test('zec harness cleanup includes live zec 3 output and temp artifacts', () => {
+  const targets = getCleanupTargets('ZEC', 3, 'openai', 'openai-native');
+
+  assert.ok(targets.some((target) => target.endsWith('/workspace/output/AI-ULT/ZEC/ZEC-03.usfm')));
+  assert.ok(targets.some((target) => target.endsWith('/workspace/output/AI-UST/ZEC/ZEC-03-aligned.usfm')));
+  assert.ok(targets.some((target) => target.endsWith('/workspace/output/issues/ZEC/ZEC-03.tsv')));
+  assert.ok(targets.some((target) => target.endsWith('/workspace/output/notes/ZEC/ZEC-03.tsv')));
+  assert.ok(targets.some((target) => target.endsWith('/workspace/output/quality/ZEC/ZEC-03-quality.md')));
+  assert.ok(targets.some((target) => target.endsWith('/workspace/output/AI-UST/hints/ZEC/ZEC-03.json')));
+  assert.ok(targets.some((target) => target.endsWith('/workspace/tmp/alignments/ZEC/ZEC-03-mapping.json')));
+  assert.ok(targets.some((target) => target.endsWith('/workspace/tmp/ZEC-03-alignment-mapping.json')));
+  assert.ok(targets.some((target) => target.endsWith('/workspace/tmp/pipeline/ZEC-03')));
+  assert.ok(targets.some((target) => target.endsWith('/workspace/tmp/pipeline-ZEC-03')));
+  assert.ok(targets.some((target) => target.endsWith('/workspace/test/zec-03/openai-native')));
+  assert.equal(targets.some((target) => target.endsWith('/workspace/test/zec-03/openai-api')), false);
 });
 
 test('gemini tool results preserve upstream tool call ids', () => {

--- a/test/api-runner-provider-regressions.test.js
+++ b/test/api-runner-provider-regressions.test.js
@@ -9,6 +9,10 @@ const {
   resolveProviderModel,
 } = require('../src/api-runner/provider-config');
 const geminiProvider = require('../src/api-runner/providers/gemini');
+const {
+  getHarnessModels,
+  validateRequiredArtifacts,
+} = require('../scripts/test-providers-zec3');
 const { resolveAgentProvider } = require('../src/api-runner/team-manager');
 const { getProviderSystemAppend } = require('../src/api-runner/provider-nudges');
 const { readPreparedNotes } = require('../src/workspace-tools/tn-tools');
@@ -32,6 +36,14 @@ test('gemini provider config exposes fallback models for transient overloads', (
   ]);
 });
 
+test('gemini ZEC harness defaults follow provider-config aliases', () => {
+  const models = getHarnessModels('gemini');
+  assert.equal(models.opus, resolveProviderModel('gemini', 'opus'));
+  assert.equal(models.sonnet, resolveProviderModel('gemini', 'sonnet'));
+  assert.equal(models.opus, 'gemini-3.1-pro-preview');
+  assert.equal(models.sonnet, 'gemini-2.5-pro');
+});
+
 test('gemini tool results preserve upstream tool call ids', () => {
   const result = geminiProvider.formatToolResult('call-123', 'ping', { ok: true }, false);
   assert.deepEqual(result, {
@@ -42,6 +54,16 @@ test('gemini tool results preserve upstream tool call ids', () => {
       content: JSON.stringify({ ok: true }),
       isError: false,
     }],
+  });
+});
+
+test('gemini 2.5 low thinking keeps a positive budget', () => {
+  assert.equal(typeof geminiProvider.getThinkingConfig, 'function');
+  assert.deepEqual(geminiProvider.getThinkingConfig('gemini-2.5-pro', 'low'), {
+    thinkingConfig: { thinkingBudget: 1024 },
+  });
+  assert.deepEqual(geminiProvider.getThinkingConfig('gemini-3.1-pro-preview', 'low'), {
+    thinkingConfig: { thinkingLevel: 'low' },
   });
 });
 
@@ -101,6 +123,29 @@ test('provider-specific runner nudges stay attached to openai and xai', () => {
   assert.equal(getProviderSystemAppend('gemini', 'initial-pipeline'), '');
   assert.equal(getProviderSystemAppend('openai', 'align-all-parallel', { book: 'ZEC', chapter: 3 }), '');
   assert.equal(getProviderSystemAppend('xai', 'tn-writer'), '');
+});
+
+test('zec harness artifact gate rejects missing or empty required outputs', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zec3-artifacts-'));
+  const paths = {
+    ult: path.join(tempDir, 'ZEC-03.usfm'),
+    ultAligned: path.join(tempDir, 'ZEC-03-aligned.usfm'),
+    ust: path.join(tempDir, 'ZEC-03-UST.usfm'),
+    ustAligned: path.join(tempDir, 'ZEC-03-UST-aligned.usfm'),
+    issues: path.join(tempDir, 'ZEC-03-issues.tsv'),
+    notes: path.join(tempDir, 'ZEC-03-notes.tsv'),
+  };
+
+  fs.writeFileSync(paths.ult, '\\id ZEC');
+  fs.writeFileSync(paths.ultAligned, '\\id ZEC');
+  fs.writeFileSync(paths.ust, '');
+  fs.writeFileSync(paths.ustAligned, '\\id ZEC');
+  fs.writeFileSync(paths.issues, 'Reference\tID\n3:1\ta1b2\n');
+
+  const result = validateRequiredArtifacts(paths);
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing.map((entry) => entry.key), ['notes']);
+  assert.deepEqual(result.empty.map((entry) => entry.key), ['ust']);
 });
 
 test('readPreparedNotes accepts object-backed prepared_notes packets', () => {

--- a/test/api-runner-provider-regressions.test.js
+++ b/test/api-runner-provider-regressions.test.js
@@ -10,12 +10,14 @@ const {
 } = require('../src/api-runner/provider-config');
 const geminiProvider = require('../src/api-runner/providers/gemini');
 const { resolveAgentProvider } = require('../src/api-runner/team-manager');
+const { getProviderSystemAppend } = require('../src/api-runner/provider-nudges');
 const { readPreparedNotes } = require('../src/workspace-tools/tn-tools');
 
 test('openai aliases resolve to current runner defaults', () => {
   assert.equal(resolveProviderModel('openai', 'opus'), 'gpt-5.4');
   assert.equal(resolveProviderModel('openai', 'sonnet'), 'gpt-5.4-mini');
   assert.equal(resolveProviderModel('openai', 'haiku'), 'gpt-5.4-nano');
+  assert.equal(resolveProviderModel('xai', 'opus'), 'grok-4-1-fast-reasoning');
 });
 
 test('gemini provider config exposes fallback models for transient overloads', () => {
@@ -77,6 +79,21 @@ test('locked provider runs keep sub-agents on the parent provider', () => {
     resolveAgentProvider({}, { provider: 'gemini', lockProvider: true }),
     'gemini'
   );
+});
+
+test('provider-specific initial-pipeline nudges stay attached to openai and xai', () => {
+  const openaiNudge = getProviderSystemAppend('openai', 'initial-pipeline', { book: 'ZEC', chapter: 3 });
+  assert.match(openaiNudge, /output\/AI-ULT\/ZEC\/ZEC-03\.usfm/);
+  assert.match(openaiNudge, /Verify they exist with a Glob or Read/);
+  assert.match(openaiNudge, /zero-padded chapter tag "ZEC-03"/);
+
+  const xaiNudge = getProviderSystemAppend('xai', 'initial-pipeline', { book: 'ZEC', chapter: 3 });
+  assert.match(xaiNudge, /header-only file/);
+  assert.match(xaiNudge, /at least one data row/);
+  assert.match(xaiNudge, /Do NOT invent unpadded variants such as "ZEC-3\.usfm"/);
+
+  assert.equal(getProviderSystemAppend('gemini', 'initial-pipeline'), '');
+  assert.equal(getProviderSystemAppend('xai', 'tn-writer'), '');
 });
 
 test('readPreparedNotes accepts object-backed prepared_notes packets', () => {

--- a/test/api-runner-provider-regressions.test.js
+++ b/test/api-runner-provider-regressions.test.js
@@ -1,0 +1,102 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  getProviderConfig,
+  resolveProviderModel,
+} = require('../src/api-runner/provider-config');
+const geminiProvider = require('../src/api-runner/providers/gemini');
+const { resolveAgentProvider } = require('../src/api-runner/team-manager');
+const { readPreparedNotes } = require('../src/workspace-tools/tn-tools');
+
+test('openai aliases resolve to current runner defaults', () => {
+  assert.equal(resolveProviderModel('openai', 'opus'), 'gpt-5.4');
+  assert.equal(resolveProviderModel('openai', 'sonnet'), 'gpt-5.4-mini');
+  assert.equal(resolveProviderModel('openai', 'haiku'), 'gpt-5.4-nano');
+});
+
+test('gemini provider config exposes fallback models for transient overloads', () => {
+  const cfg = getProviderConfig('gemini');
+  assert.deepEqual(cfg.fallbackModels['gemini-3.1-pro-preview'], [
+    'gemini-3-pro-preview',
+    'gemini-2.5-pro',
+  ]);
+  assert.deepEqual(cfg.fallbackModels['gemini-3-flash-preview'], [
+    'gemini-2.5-flash',
+  ]);
+});
+
+test('gemini tool results preserve upstream tool call ids', () => {
+  const result = geminiProvider.formatToolResult('call-123', 'ping', { ok: true }, false);
+  assert.deepEqual(result, {
+    role: 'tool',
+    results: [{
+      toolCallId: 'call-123',
+      name: 'ping',
+      content: JSON.stringify({ ok: true }),
+      isError: false,
+    }],
+  });
+});
+
+test('gemini tool response contents include matching function response ids', () => {
+  assert.equal(typeof geminiProvider.toGeminiContents, 'function');
+
+  const contents = geminiProvider.toGeminiContents([
+    geminiProvider.formatAssistantMessage('', [{
+      id: 'call-123',
+      name: 'ping',
+      arguments: { text: 'hello' },
+    }], [
+      { functionCall: { id: 'call-123', name: 'ping', args: { text: 'hello' } } },
+    ]),
+    geminiProvider.formatToolResult('call-123', 'ping', 'OK', false),
+  ]);
+
+  assert.deepEqual(contents[1], {
+    role: 'user',
+    parts: [{
+      functionResponse: {
+        id: 'call-123',
+        name: 'ping',
+        response: { content: 'OK' },
+      },
+    }],
+  });
+});
+
+test('locked provider runs keep sub-agents on the parent provider', () => {
+  assert.equal(
+    resolveAgentProvider({ provider: 'claude' }, { provider: 'openai', lockProvider: true }),
+    'openai'
+  );
+  assert.equal(
+    resolveAgentProvider({}, { provider: 'gemini', lockProvider: true }),
+    'gemini'
+  );
+});
+
+test('readPreparedNotes accepts object-backed prepared_notes packets', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prepared-notes-'));
+  const relRoot = path.join('tmp', path.basename(tempDir));
+  const absRoot = path.join('/srv/bot/workspace', relRoot);
+  fs.mkdirSync(absRoot, { recursive: true });
+
+  const preparedRel = path.join(relRoot, 'prepared_notes.json');
+  fs.writeFileSync(path.join('/srv/bot/workspace', preparedRel), JSON.stringify({
+    book: 'ZEC',
+    chapter: '03',
+    item_count: 2,
+    items: [
+      { id: 'a1b2', reference: '3:1' },
+      { id: 'c3d4', reference: '3:2' },
+    ],
+  }, null, 2));
+
+  const summary = JSON.parse(readPreparedNotes({ preparedJson: preparedRel, summaryOnly: true }));
+  assert.equal(summary.total, 2);
+  assert.deepEqual(summary.ids, ['a1b2', 'c3d4']);
+});

--- a/test/api-runner-provider-regressions.test.js
+++ b/test/api-runner-provider-regressions.test.js
@@ -17,7 +17,8 @@ test('openai aliases resolve to current runner defaults', () => {
   assert.equal(resolveProviderModel('openai', 'opus'), 'gpt-5.4');
   assert.equal(resolveProviderModel('openai', 'sonnet'), 'gpt-5.4-mini');
   assert.equal(resolveProviderModel('openai', 'haiku'), 'gpt-5.4-nano');
-  assert.equal(resolveProviderModel('xai', 'opus'), 'grok-4-1-fast-reasoning');
+  assert.equal(resolveProviderModel('xai', 'opus'), 'grok-4.20-reasoning');
+  assert.equal(resolveProviderModel('xai', 'sonnet'), 'grok-4.20-reasoning');
 });
 
 test('gemini provider config exposes fallback models for transient overloads', () => {
@@ -81,7 +82,7 @@ test('locked provider runs keep sub-agents on the parent provider', () => {
   );
 });
 
-test('provider-specific initial-pipeline nudges stay attached to openai and xai', () => {
+test('provider-specific runner nudges stay attached to openai and xai', () => {
   const openaiNudge = getProviderSystemAppend('openai', 'initial-pipeline', { book: 'ZEC', chapter: 3 });
   assert.match(openaiNudge, /output\/AI-ULT\/ZEC\/ZEC-03\.usfm/);
   assert.match(openaiNudge, /Verify they exist with a Glob or Read/);
@@ -92,7 +93,13 @@ test('provider-specific initial-pipeline nudges stay attached to openai and xai'
   assert.match(xaiNudge, /at least one data row/);
   assert.match(xaiNudge, /Do NOT invent unpadded variants such as "ZEC-3\.usfm"/);
 
+  const xaiAlignNudge = getProviderSystemAppend('xai', 'align-all-parallel', { book: 'ZEC', chapter: 3 });
+  assert.match(xaiAlignNudge, /output\/AI-ULT\/ZEC\/ZEC-03-aligned\.usfm/);
+  assert.match(xaiAlignNudge, /create_aligned_usfm/);
+  assert.match(xaiAlignNudge, /Do not accept a representative sample/);
+
   assert.equal(getProviderSystemAppend('gemini', 'initial-pipeline'), '');
+  assert.equal(getProviderSystemAppend('openai', 'align-all-parallel', { book: 'ZEC', chapter: 3 }), '');
   assert.equal(getProviderSystemAppend('xai', 'tn-writer'), '');
 });
 


### PR DESCRIPTION
## Summary
- rebuild `openai-native` as an explicit stage-orchestrated pipeline instead of recursive team orchestration
- route OpenAI native generate, alignment, notes, and QC through the same bounded runtime with filtered tools and output verification
- include the pending provider-runtime hardening work already on this branch for xAI, Gemini, and the ZEC3 harness

## Testing
- `npm test`
- `BOT_SECRETS_DIR=/srv/bot/config/secrets node scripts/test-providers-zec3.js --provider openai --runtime openai-native`

## Notes
- the OpenAI-native ZEC 3 acceptance snapshot completed successfully in `workspace/test/zec-03/openai-native/`
- unrelated local edits in `src/index.js` and `.claude/` are not part of this PR