### PR TITLE
fix: harden report triage ownership routing

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,0 +1,35 @@
+FROM node:22-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash -u 1001 botuser
+
+# Claude Code CLI (required by the agent SDK)
+USER botuser
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/home/botuser/.local/bin:${PATH}"
+USER root
+
+ENV CLAUDE_CONFIG_DIR=/data/claude-config
+ENV CSKILLBP_DIR=/data/workspace
+ENV DISABLE_AUTOUPDATER=1
+
+# /data is the single Fly volume — subdirs created at runtime by entrypoint.sh
+RUN mkdir -p /data /config && chown botuser:botuser /data
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --production
+COPY . .
+RUN ln -s /data/workspace /cSkillBP
+
+# model-provider-config.json is not sensitive — bake it into the image
+COPY model-provider-config.json /config/model-provider-config.json
+
+RUN chmod +x /app/entrypoint.sh && \
+    chown -R botuser:botuser /app
+
+USER botuser
+CMD ["/bin/bash", "/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Create volume subdirectories on first run
+mkdir -p /data/workspace /data/appdata /data/claude-config
+
+# Symlink /app/data into the volume so session/checkpoint files persist
+if [ ! -L /app/data ]; then
+  rm -rf /app/data
+  ln -s /data/appdata /app/data
+fi
+
+if [ -n "$CONFIG_LOCAL_JSON" ]; then
+  mkdir -p /app/data
+  printf '%s' "$CONFIG_LOCAL_JSON" > /app/data/config.local.json
+fi
+
+exec node src/index.js

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,29 @@
+app = "uw-bt-bot"
+primary_region = "dfw"
+
+kill_signal = "SIGINT"
+kill_timeout = 30
+
+[build]
+  dockerfile = "Dockerfile.fly"
+
+[deploy]
+  release_command = "bash -c 'cd /data/workspace && git pull --ff-only 2>&1 || true'"
+
+[env]
+  NODE_ENV = "production"
+  CSKILLBP_DIR = "/data/workspace"
+  DOOR43_REPOS_PATH = "/data/workspace/door43-repos"
+  HEBREW_DIR = "/data/workspace/data/hebrew_bible"
+  CLAUDE_CONFIG_DIR = "/data/claude-config"
+  MODEL_PROVIDER_CONFIG_FILE = "/config/model-provider-config.json"
+
+[[vm]]
+  memory = "4gb"
+  cpu_kind = "shared"
+  cpus = 4
+
+[[mounts]]
+  source = "workspace_vol"
+  destination = "/data"
+  initial_size = "25gb"

--- a/model-provider-config.json
+++ b/model-provider-config.json
@@ -1,0 +1,267 @@
+{
+    "providers": {
+        "claude": {
+            "defaultModel": "claude-opus-4-7",
+            "secretName": "anthropic_api_key",
+            "envName": "ANTHROPIC_API_KEY",
+            "modelAliases": {
+                "opus": "claude-opus-4-7",
+                "sonnet": "claude-sonnet-4-6",
+                "haiku": "claude-haiku-4-5-20251001"
+            },
+            "models": {
+                "claude-opus-4-7": {
+                    "label": "Claude Opus 4.7",
+                    "inputPer1M": 5.0,
+                    "outputPer1M": 25.0
+                },
+                "claude-sonnet-4-6": {
+                    "label": "Claude Sonnet 4.6",
+                    "inputPer1M": 3.0,
+                    "outputPer1M": 15.0
+                },
+                "claude-haiku-4-5-20251001": {
+                    "label": "Claude Haiku 4.5",
+                    "inputPer1M": 0.8,
+                    "outputPer1M": 4.0
+                }
+            }
+        },
+        "openai": {
+            "defaultModel": "gpt-5.4",
+            "secretName": "openai_api_key",
+            "envName": "OPENAI_API_KEY",
+            "modelAliases": {
+                "opus": "gpt-5.4",
+                "sonnet": "gpt-5.4-mini",
+                "haiku": "gpt-5.4-nano",
+                "gpt-5.1-mini": "gpt-5.4-mini"
+            },
+            "models": {
+                "gpt-4.1": {
+                    "label": "GPT 4.1",
+                    "inputPer1M": 2.0,
+                    "outputPer1M": 8.0
+                },
+                "gpt-5.3": {
+                    "label": "GPT 5.3",
+                    "inputPer1M": 4.0,
+                    "outputPer1M": 16.0
+                },
+                "gpt-5.4": {
+                    "label": "GPT 5.4",
+                    "inputPer1M": 5.0,
+                    "outputPer1M": 20.0
+                },
+                "gpt-5.4-mini": {
+                    "label": "GPT 5.4 mini",
+                    "inputPer1M": 0.8,
+                    "outputPer1M": 3.2
+                },
+                "gpt-5.4-nano": {
+                    "label": "GPT 5.4 nano",
+                    "inputPer1M": 0.2,
+                    "outputPer1M": 0.8
+                },
+                "o3": {
+                    "label": "o3",
+                    "inputPer1M": 2.5,
+                    "outputPer1M": 10.0
+                },
+                "o4-mini": {
+                    "label": "o4 mini",
+                    "inputPer1M": 0.5,
+                    "outputPer1M": 2.0
+                }
+            }
+        },
+        "gemini": {
+            "defaultModel": "gemini-3.1-pro-preview",
+            "secretName": "google_api_key",
+            "envName": "GOOGLE_API_KEY",
+            "modelAliases": {
+                "opus": "gemini-3.1-pro-preview",
+                "sonnet": "gemini-2.5-pro",
+                "haiku": "gemini-3-flash-preview"
+            },
+            "models": {
+                "gemini-3.1-pro-preview": {
+                    "label": "Gemini 3.1 Pro (preview)",
+                    "inputPer1M": 1.25,
+                    "outputPer1M": 10.0
+                },
+                "gemini-3-pro-preview": {
+                    "label": "Gemini 3 Pro (preview)",
+                    "inputPer1M": 1.25,
+                    "outputPer1M": 10.0
+                },
+                "gemini-3-flash-preview": {
+                    "label": "Gemini 3 Flash (preview)",
+                    "inputPer1M": 0.15,
+                    "outputPer1M": 0.6
+                },
+                "gemini-2.5-pro": {
+                    "label": "Gemini 2.5 Pro",
+                    "inputPer1M": 1.25,
+                    "outputPer1M": 10.0
+                },
+                "gemini-2.5-flash": {
+                    "label": "Gemini 2.5 Flash",
+                    "inputPer1M": 0.15,
+                    "outputPer1M": 0.6
+                }
+            },
+            "fallbackModels": {
+                "gemini-3.1-pro-preview": [
+                    "gemini-3-pro-preview",
+                    "gemini-2.5-pro"
+                ],
+                "gemini-3-pro-preview": [
+                    "gemini-2.5-pro"
+                ],
+                "gemini-3-flash-preview": [
+                    "gemini-2.5-flash"
+                ]
+            }
+        },
+        "xai": {
+            "defaultModel": "grok-4.20-reasoning",
+            "secretName": "xai_api_key",
+            "envName": "XAI_API_KEY",
+            "baseUrl": "https://api.x.ai/v1",
+            "modelAliases": {
+                "opus": "grok-4.20-reasoning",
+                "sonnet": "grok-4.20-reasoning",
+                "haiku": "grok-4-1-fast-non-reasoning"
+            },
+            "models": {
+                "grok-4.20-reasoning": {
+                    "label": "Grok 4.20 (reasoning)",
+                    "inputPer1M": 3.0,
+                    "outputPer1M": 15.0
+                },
+                "grok-4-0709": {
+                    "label": "Grok 4",
+                    "inputPer1M": 3.0,
+                    "outputPer1M": 9.0
+                },
+                "grok-4-1-fast-reasoning": {
+                    "label": "Grok 4.1 Fast (reasoning)",
+                    "inputPer1M": 3.0,
+                    "outputPer1M": 9.0
+                },
+                "grok-4-1-fast-non-reasoning": {
+                    "label": "Grok 4.1 Fast (no CoT)",
+                    "inputPer1M": 3.0,
+                    "outputPer1M": 9.0
+                },
+                "grok-3": {
+                    "label": "Grok 3",
+                    "inputPer1M": 3.0,
+                    "outputPer1M": 15.0
+                },
+                "grok-3-mini": {
+                    "label": "Grok 3 Mini",
+                    "inputPer1M": 0.3,
+                    "outputPer1M": 0.5
+                }
+            },
+            "autoModelByThinking": {
+                "low": "grok-4-1-fast-non-reasoning",
+                "medium": "grok-4.20-reasoning",
+                "high": "grok-4.20-reasoning",
+                "max": "grok-4.20-reasoning",
+                "none": "grok-4-1-fast-non-reasoning"
+            },
+            "reasoningEffortModels": [
+                "grok-3-mini"
+            ],
+            "fallbackModels": {
+                "grok-4.20-reasoning": [
+                    "grok-4-1-fast-reasoning",
+                    "grok-4-0709",
+                    "grok-4-1-fast-non-reasoning",
+                    "grok-3-mini"
+                ],
+                "grok-4-1-fast-reasoning": [
+                    "grok-4-0709",
+                    "grok-4-1-fast-non-reasoning",
+                    "grok-3-mini"
+                ],
+                "grok-4-0709": [
+                    "grok-4-1-fast-non-reasoning",
+                    "grok-3-mini"
+                ]
+            }
+        },
+        "groq": {
+            "defaultModel": "meta-llama/llama-4-scout-17b-16e-instruct",
+            "secretName": "openai_api_key",
+            "envName": "OPENAI_API_KEY",
+            "baseUrl": "https://api.groq.com/openai/v1",
+            "modelAliases": {
+                "opus": "qwen/qwen3-32b",
+                "sonnet": "meta-llama/llama-4-scout-17b-16e-instruct",
+                "haiku": "meta-llama/llama-4-scout-17b-16e-instruct"
+            },
+            "models": {
+                "meta-llama/llama-4-scout-17b-16e-instruct": {
+                    "label": "Llama 4 Scout",
+                    "inputPer1M": 0.2,
+                    "outputPer1M": 0.2
+                },
+                "qwen/qwen3-32b": {
+                    "label": "Qwen3 32B",
+                    "inputPer1M": 0.29,
+                    "outputPer1M": 0.39
+                }
+            }
+        },
+        "deepseek": {
+            "defaultModel": "deepseek-chat",
+            "secretName": "openai_api_key",
+            "envName": "OPENAI_API_KEY",
+            "baseUrl": "https://api.deepseek.com",
+            "modelAliases": {
+                "opus": "deepseek-reasoner",
+                "sonnet": "deepseek-chat",
+                "haiku": "deepseek-chat"
+            },
+            "models": {
+                "deepseek-chat": {
+                    "label": "DeepSeek Chat",
+                    "inputPer1M": 0.27,
+                    "outputPer1M": 1.1
+                },
+                "deepseek-reasoner": {
+                    "label": "DeepSeek Reasoner",
+                    "inputPer1M": 0.55,
+                    "outputPer1M": 2.19
+                }
+            }
+        },
+        "mistral": {
+            "defaultModel": "mistral-large-latest",
+            "secretName": "openai_api_key",
+            "envName": "OPENAI_API_KEY",
+            "baseUrl": "https://api.mistral.ai/v1",
+            "modelAliases": {
+                "opus": "mistral-large-latest",
+                "sonnet": "mistral-medium-latest",
+                "haiku": "mistral-medium-latest"
+            },
+            "models": {
+                "mistral-large-latest": {
+                    "label": "Mistral Large",
+                    "inputPer1M": 2.0,
+                    "outputPer1M": 6.0
+                },
+                "mistral-medium-latest": {
+                    "label": "Mistral Medium",
+                    "inputPer1M": 0.6,
+                    "outputPer1M": 1.8
+                }
+            }
+        }
+    }
+}

--- a/src/claude-config-init.js
+++ b/src/claude-config-init.js
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 
-const CLAUDE_JSON_PATH = '/claude-config/.claude.json';
+const CLAUDE_JSON_PATH = `${process.env.CLAUDE_CONFIG_DIR || '/claude-config'}/.claude.json`;
 const NEEDED_TOOLS = [
   'Read', 'Write', 'Edit', 'Glob', 'Grep',
   'Task', 'TaskOutput', 'Skill', 'SendMessage',

--- a/src/issue-report-pipeline.js
+++ b/src/issue-report-pipeline.js
@@ -47,14 +47,14 @@ Analyze the report and respond with ONLY valid JSON (no prose, no markdown code 
 
 Rules:
 - First decompose the report into atomic complaints. Do not skip this step.
-- Do not collapse distinct failure modes into one issue unless the same root cause clearly explains them.
-- Prefer multiple focused issues over one omnibus issue when symptoms would likely be fixed in different places.
+- Complaints stay atomic, but issue creation stays repo-scoped: return at most one issue per repo.
+- When multiple complaints belong to the same repo, combine them into a single well-structured issue and include all relevant complaint_ids.
 - Every issue must reference one or more complaint_ids from the complaints array.
 - Use repository ownership based on root cause, not shallow keyword matching.
 - Open issues in both repos only when the report plausibly spans both layers.
 - Keep repo targets limited to bp-assistant and bp-assistant-skills.
 - When both repos are implicated, choose a primary_repo and secondary_repo.
-- Each repo listed in ownership.repositories must appear in at least one issue.`;
+- Each repo listed in ownership.repositories must appear in exactly one issue.`;
 
 function stripLeadingMention(content) {
   return String(content || '').replace(/^@\*\*[^*]+\*\*\s*/, '').trim();
@@ -267,8 +267,24 @@ function parseClassifierOutput(raw) {
     throw new Error('Classifier returned duplicate issue ids');
   }
 
-  const issueRepos = new Set(normalizedIssues.map((issue) => issue.repo));
-  if (issueRepos.size !== uniqueRepos.length || uniqueRepos.some((repo) => !issueRepos.has(repo))) {
+  const issuesByRepo = new Map();
+  for (const issue of normalizedIssues) {
+    const repoIssues = issuesByRepo.get(issue.repo) || [];
+    repoIssues.push(issue);
+    issuesByRepo.set(issue.repo, repoIssues);
+  }
+
+  for (const repo of uniqueRepos) {
+    const repoIssues = issuesByRepo.get(repo) || [];
+    if (repoIssues.length === 0) {
+      throw new Error('Classifier ownership.repositories does not match issue repos');
+    }
+    if (repoIssues.length > 1) {
+      throw new Error(`Classifier returned multiple issues for repo ${repo}`);
+    }
+  }
+
+  if (issuesByRepo.size !== uniqueRepos.length) {
     throw new Error('Classifier ownership.repositories does not match issue repos');
   }
 

--- a/src/issue-report-pipeline.js
+++ b/src/issue-report-pipeline.js
@@ -304,9 +304,20 @@ function buildIssueMarker(messageId, issueId) {
   return `issue-report:${messageId}:${issueId}`;
 }
 
-function injectMetadata(body, marker) {
+function buildIssueDedupeMarker(messageId, repo, complaintIds) {
+  const stableComplaintIds = [...new Set((Array.isArray(complaintIds) ? complaintIds : [])
+    .filter((item) => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean))]
+    .sort();
+  return `issue-report:${messageId}:${repo}:${stableComplaintIds.join('+')}`;
+}
+
+function injectMetadata(body, markers) {
   const trimmed = String(body || '').trim();
-  return `${trimmed}\n\n<!-- ${marker} -->`;
+  const uniqueMarkers = [...new Set((Array.isArray(markers) ? markers : [markers]).filter(Boolean))];
+  const metadata = uniqueMarkers.map((marker) => `<!-- ${marker} -->`).join('\n');
+  return `${trimmed}\n\n${metadata}`;
 }
 
 function addOrReplaceRelatedIssueSection(body, repo, allIssues, ownership) {
@@ -352,6 +363,14 @@ async function searchExistingIssue(fetchImpl, token, repo, marker) {
   const payload = await response.json();
   const issue = payload.items?.[0] || null;
   return issue ? { ...issue, repo } : null;
+}
+
+async function searchExistingIssueByMarkers(fetchImpl, token, repo, markers) {
+  for (const marker of markers) {
+    const existing = await searchExistingIssue(fetchImpl, token, repo, marker);
+    if (existing) return existing;
+  }
+  return null;
 }
 
 async function createGithubIssue(fetchImpl, token, repo, payload) {
@@ -430,7 +449,13 @@ async function issueReportPipeline(route, message, overrides = {}) {
     const issueRecords = [];
     for (const issuePlan of classified.issues) {
       const marker = buildIssueMarker(message.id, issuePlan.id);
-      const existing = await searchExistingIssue(deps.fetchImpl, githubToken, issuePlan.repo, marker);
+      const dedupeMarker = buildIssueDedupeMarker(message.id, issuePlan.repo, issuePlan.complaint_ids);
+      const existing = await searchExistingIssueByMarkers(
+        deps.fetchImpl,
+        githubToken,
+        issuePlan.repo,
+        [dedupeMarker, marker]
+      );
       if (existing) {
         issueRecords.push({ ...existing, issue_id: issuePlan.id, complaint_ids: issuePlan.complaint_ids });
         continue;
@@ -438,7 +463,7 @@ async function issueReportPipeline(route, message, overrides = {}) {
 
       const created = await createGithubIssue(deps.fetchImpl, githubToken, issuePlan.repo, {
         title: issuePlan.title,
-        body: injectMetadata(issuePlan.body, marker),
+        body: injectMetadata(issuePlan.body, [dedupeMarker, marker]),
         labels: issuePlan.labels,
       });
       console.log(`[issue-report] Created ${issuePlan.repo}#${created.number}: ${issuePlan.title}`);
@@ -448,8 +473,15 @@ async function issueReportPipeline(route, message, overrides = {}) {
     if (issueRecords.length > 1) {
       const bodyById = new Map(classified.issues.map((issue) => [issue.id, issue.body]));
       for (const issueRecord of issueRecords) {
+        const issuePlan = classified.issues.find((issue) => issue.id === issueRecord.issue_id);
+        if (!issuePlan) {
+          throw new Error(`Classifier returned issue ${issueRecord.issue_id} without a matching plan`);
+        }
         const desiredBody = addOrReplaceRelatedIssueSection(
-          injectMetadata(bodyById.get(issueRecord.issue_id), buildIssueMarker(message.id, issueRecord.issue_id)),
+          injectMetadata(bodyById.get(issueRecord.issue_id), [
+            buildIssueDedupeMarker(message.id, issueRecord.repo, issuePlan.complaint_ids),
+            buildIssueMarker(message.id, issueRecord.issue_id),
+          ]),
           issueRecord.repo,
           issueRecords.filter((candidate) => candidate.issue_id !== issueRecord.issue_id),
           classified.ownership
@@ -485,5 +517,6 @@ module.exports = {
   _buildClassifierInput: buildClassifierInput,
   _parseClassifierOutput: parseClassifierOutput,
   _buildIssueMarker: buildIssueMarker,
+  _buildIssueDedupeMarker: buildIssueDedupeMarker,
   _addOrReplaceRelatedIssueSection: addOrReplaceRelatedIssueSection,
 };

--- a/test/issue-report-pipeline.test.js
+++ b/test/issue-report-pipeline.test.js
@@ -185,7 +185,7 @@ test('buildClassifierInput includes reporter, stream context, attachments, and i
   assert.match(input, /Image URLs:/);
 });
 
-test('parseClassifierOutput keeps atomic complaints and multiple focused issues', () => {
+test('parseClassifierOutput keeps atomic complaints and repo-scoped issues', () => {
   const parsed = _parseClassifierOutput(JSON.stringify(buildClassifierPayload({
     complaints: [
       {
@@ -575,17 +575,9 @@ test('issueReportPipeline creates dual linked issues for cross-repo reports', as
         {
           id: 'i2',
           repo: 'bp-assistant-skills',
-          complaint_ids: ['c1'],
-          title: 'Refine Psalm 38 split snippet guidance',
-          body: '## Summary\n\nSkills-side formatting concern.\n\n## Steps to Reproduce\n\n1. Run tn-writer for Psalm 38.\n\n## Expected Behavior\n\nWhole phrase handling.\n\n## Actual Behavior\n\nEllipsis and split snippets.\n\n## Reporter\n\nProof Reader',
-          labels: ['bug', 'ai-quality'],
-        },
-        {
-          id: 'i3',
-          repo: 'bp-assistant-skills',
-          complaint_ids: ['c3'],
-          title: 'Split abstract noun notes into separate line-level issues',
-          body: '## Summary\n\nSkills-side note segmentation concern.\n\n## Steps to Reproduce\n\n1. Run tn-writer for Psalm 38.\n\n## Expected Behavior\n\nSeparate line-level notes.\n\n## Actual Behavior\n\nCombined abstract noun notes.\n\n## Reporter\n\nProof Reader',
+          complaint_ids: ['c1', 'c3'],
+          title: 'Refine Psalm 38 tn-writing and note splitting behavior',
+          body: '## Summary\n\nSkills-side formatting and note segmentation concern.\n\n## Steps to Reproduce\n\n1. Run tn-writer for Psalm 38.\n\n## Expected Behavior\n\nWhole phrase handling and separate line-level notes.\n\n## Actual Behavior\n\nEllipsis, split snippets, and combined abstract noun notes.\n\n## Reporter\n\nProof Reader',
           labels: ['bug'],
         },
       ],
@@ -600,15 +592,13 @@ test('issueReportPipeline creates dual linked issues for cross-repo reports', as
   }), runtime);
 
   assert.equal(store.issues['bp-assistant'].length, 1);
-  assert.equal(store.issues['bp-assistant-skills'].length, 2);
-  assert.equal(store.patches.length, 3);
+  assert.equal(store.issues['bp-assistant-skills'].length, 1);
+  assert.equal(store.patches.length, 2);
   assert.match(store.issues['bp-assistant'][0].body, /## Related issue/);
   assert.match(store.issues['bp-assistant'][0].body, /bp-assistant-skills#1/);
-  assert.match(store.issues['bp-assistant'][0].body, /bp-assistant-skills#2/);
   assert.match(store.issues['bp-assistant-skills'][0].body, /bp-assistant#1/);
   assert.match(sentReplies[0].text, /bp-assistant#1/);
   assert.match(sentReplies[0].text, /bp-assistant-skills#1/);
-  assert.match(sentReplies[0].text, /bp-assistant-skills#2/);
 });
 
 test('issueReportPipeline reports invalid classifier JSON', async () => {
@@ -664,6 +654,58 @@ test('issueReportPipeline rejects malformed ownership output', async () => {
 
   await issueReportPipeline({}, buildMessage(), runtime);
   assert.match(sentReplies[0].text, /Classifier returned invalid repositories/);
+});
+
+test('issueReportPipeline rejects multiple issues for the same repo in one report', async () => {
+  const sentReplies = [];
+  const runtime = createRuntime({
+    classifierPayload: buildClassifierPayload({
+      complaints: [
+        {
+          id: 'c1',
+          summary: 'Split snippets still happen',
+          evidence: ['split snippets'],
+          likely_layers: ['bp-assistant-skills'],
+        },
+        {
+          id: 'c2',
+          summary: 'Abstract noun notes stay merged',
+          evidence: ['combined abstractnoun notes'],
+          likely_layers: ['bp-assistant-skills'],
+        },
+      ],
+      ownership: {
+        repositories: ['bp-assistant-skills'],
+        primary_repo: 'bp-assistant-skills',
+        secondary_repo: null,
+        rationale: 'Skills repo only.',
+      },
+      issues: [
+        {
+          id: 'i1',
+          repo: 'bp-assistant-skills',
+          complaint_ids: ['c1'],
+          title: 'Refine split snippet guidance',
+          body: '## Summary\n\nSkills issue.',
+          labels: ['bug'],
+        },
+        {
+          id: 'i2',
+          repo: 'bp-assistant-skills',
+          complaint_ids: ['c2'],
+          title: 'Split abstract noun notes per line',
+          body: '## Summary\n\nSkills issue.',
+          labels: ['bug'],
+        },
+      ],
+    }),
+    fetchImpl: async () => { throw new Error('fetch should not run'); },
+    sentReplies,
+    classifierInputs: [],
+  });
+
+  await issueReportPipeline({}, buildMessage(), runtime);
+  assert.match(sentReplies[0].text, /Classifier returned multiple issues for repo bp-assistant-skills/);
 });
 
 test('issueReportPipeline avoids duplicate issue creation after partial dual-repo failure and retry', async () => {
@@ -729,4 +771,76 @@ test('issueReportPipeline avoids duplicate issue creation after partial dual-rep
   assert.equal(store.issues['bp-assistant'].length, 1);
   assert.equal(store.issues['bp-assistant-skills'].length, 1);
   assert.match(store.issues['bp-assistant'][0].body, /bp-assistant-skills#1/);
+});
+
+test('issueReportPipeline treats the Psalm 38 sample as an intelligent dual-ownership candidate', async () => {
+  const classifierInputs = [];
+  const sentReplies = [];
+  const { fetchImpl, store } = createGithubFetchStub();
+  const runtime = createRuntime({
+    classifierPayload: buildClassifierPayload({
+      complaints: [
+        {
+          id: 'c1',
+          summary: 'AT output falls back to an ellipsis instead of the full phrase',
+          evidence: ['adding a "…" to the AT instead of putting the whole phrase'],
+          likely_layers: ['bp-assistant', 'bp-assistant-skills'],
+        },
+        {
+          id: 'c2',
+          summary: 'Split snippets still appear',
+          evidence: ['still seeing a lot of split snippets'],
+          likely_layers: ['bp-assistant-skills'],
+        },
+        {
+          id: 'c3',
+          summary: 'Abstract noun notes are merged across both lines',
+          evidence: ['combined abstractnoun notes that cover both lines instead of a note for each line'],
+          likely_layers: ['bp-assistant-skills'],
+        },
+      ],
+      ownership: {
+        repositories: ['bp-assistant', 'bp-assistant-skills'],
+        primary_repo: 'bp-assistant-skills',
+        secondary_repo: 'bp-assistant',
+        rationale: 'The note-writing symptoms are skill-facing, but app-side context shaping or post-processing could also explain the ellipsis behavior.',
+      },
+      issues: [
+        {
+          id: 'i1',
+          repo: 'bp-assistant-skills',
+          complaint_ids: ['c1', 'c2', 'c3'],
+          title: 'Refine Psalm 38 note splitting and AT phrase handling',
+          body: '## Summary\n\nPsalm 38 output still splits snippets, uses an ellipsis in the AT, and merges abstract noun notes across both lines.\n\n## Steps to Reproduce\n\n1. Run tn-writer on Psalm 38 content matching the reported case.\n\n## Expected Behavior\n\nWhole-phrase AT output, stable snippets, and one abstract noun note per line.\n\n## Actual Behavior\n\nThe AI sometimes inserts an ellipsis in the AT, still splits snippets, and combines abstract noun notes across lines.\n\n## Reporter\n\nProof Reader',
+          labels: ['bug', 'ai-quality'],
+        },
+        {
+          id: 'i2',
+          repo: 'bp-assistant',
+          complaint_ids: ['c1'],
+          title: 'Audit Psalm 38 AT post-processing and report context shaping',
+          body: '## Summary\n\nThe Psalm 38 report may reflect app-side context packaging, preprocessing, or post-processing that turns a full phrase into an ellipsis before the final note is posted.\n\n## Steps to Reproduce\n\n1. Submit the reported Psalm 38 feedback through the explicit report flow.\n\n## Expected Behavior\n\nThe bot should preserve enough context for triage and avoid introducing AT ellipsis regressions.\n\n## Actual Behavior\n\nThe report plausibly points to app-side context shaping or post-processing around the generated note.\n\n## Reporter\n\nProof Reader',
+          labels: ['bug'],
+        },
+      ],
+    }),
+    fetchImpl,
+    sentReplies,
+    classifierInputs,
+  });
+
+  const psalm38Report = `bug: Noticing an interesting change in Ps38 - while the snippet now sometimes (not always - still seeing a lot of split snippets!) includes everything in between so as not to use an "&" in the quote field, now it's adding a "…" to the AT instead of putting the whole phrase! ... there are still a LOT of combined abstractnoun notes that cover both lines instead of a note for each line - I'll split them apart but would save me a ton of time if the AI would do that.`;
+
+  await issueReportPipeline({}, buildMessage({
+    content: psalm38Report,
+  }), runtime);
+
+  assert.equal(store.issues['bp-assistant'].length, 1);
+  assert.equal(store.issues['bp-assistant-skills'].length, 1);
+  assert.match(classifierInputs[0], /Ps38/);
+  assert.match(classifierInputs[0], /Psalm 38/);
+  assert.match(classifierInputs[0], /split snippets/);
+  assert.match(classifierInputs[0], /abstractnoun notes/);
+  assert.match(sentReplies[0].text, /bp-assistant#1/);
+  assert.match(sentReplies[0].text, /bp-assistant-skills#1/);
 });

--- a/test/issue-report-pipeline.test.js
+++ b/test/issue-report-pipeline.test.js
@@ -773,57 +773,61 @@ test('issueReportPipeline avoids duplicate issue creation after partial dual-rep
   assert.match(store.issues['bp-assistant'][0].body, /bp-assistant-skills#1/);
 });
 
-test('issueReportPipeline treats the Psalm 38 sample as an intelligent dual-ownership candidate', async () => {
+// Psalm 38 regression: real proofreader feedback that spans both repos.
+// The classifier is mocked to return dual ownership — this test asserts the
+// pipeline correctly opens two linked issues, NOT just one skills-only issue.
+test('Psalm 38 regression: dual-ownership report opens two cross-linked issues', async () => {
   const classifierInputs = [];
   const sentReplies = [];
   const { fetchImpl, store } = createGithubFetchStub();
-  const runtime = createRuntime({
-    classifierPayload: buildClassifierPayload({
-      complaints: [
-        {
-          id: 'c1',
-          summary: 'AT output falls back to an ellipsis instead of the full phrase',
-          evidence: ['adding a "…" to the AT instead of putting the whole phrase'],
-          likely_layers: ['bp-assistant', 'bp-assistant-skills'],
-        },
-        {
-          id: 'c2',
-          summary: 'Split snippets still appear',
-          evidence: ['still seeing a lot of split snippets'],
-          likely_layers: ['bp-assistant-skills'],
-        },
-        {
-          id: 'c3',
-          summary: 'Abstract noun notes are merged across both lines',
-          evidence: ['combined abstractnoun notes that cover both lines instead of a note for each line'],
-          likely_layers: ['bp-assistant-skills'],
-        },
-      ],
-      ownership: {
-        repositories: ['bp-assistant', 'bp-assistant-skills'],
-        primary_repo: 'bp-assistant-skills',
-        secondary_repo: 'bp-assistant',
-        rationale: 'The note-writing symptoms are skill-facing, but app-side context shaping or post-processing could also explain the ellipsis behavior.',
+  const dualOwnershipPayload = buildClassifierPayload({
+    complaints: [
+      {
+        id: 'c1',
+        summary: 'AT output falls back to an ellipsis instead of the full phrase',
+        evidence: ['adding a "…" to the AT instead of putting the whole phrase'],
+        likely_layers: ['bp-assistant', 'bp-assistant-skills'],
       },
-      issues: [
-        {
-          id: 'i1',
-          repo: 'bp-assistant-skills',
-          complaint_ids: ['c1', 'c2', 'c3'],
-          title: 'Refine Psalm 38 note splitting and AT phrase handling',
-          body: '## Summary\n\nPsalm 38 output still splits snippets, uses an ellipsis in the AT, and merges abstract noun notes across both lines.\n\n## Steps to Reproduce\n\n1. Run tn-writer on Psalm 38 content matching the reported case.\n\n## Expected Behavior\n\nWhole-phrase AT output, stable snippets, and one abstract noun note per line.\n\n## Actual Behavior\n\nThe AI sometimes inserts an ellipsis in the AT, still splits snippets, and combines abstract noun notes across lines.\n\n## Reporter\n\nProof Reader',
-          labels: ['bug', 'ai-quality'],
-        },
-        {
-          id: 'i2',
-          repo: 'bp-assistant',
-          complaint_ids: ['c1'],
-          title: 'Audit Psalm 38 AT post-processing and report context shaping',
-          body: '## Summary\n\nThe Psalm 38 report may reflect app-side context packaging, preprocessing, or post-processing that turns a full phrase into an ellipsis before the final note is posted.\n\n## Steps to Reproduce\n\n1. Submit the reported Psalm 38 feedback through the explicit report flow.\n\n## Expected Behavior\n\nThe bot should preserve enough context for triage and avoid introducing AT ellipsis regressions.\n\n## Actual Behavior\n\nThe report plausibly points to app-side context shaping or post-processing around the generated note.\n\n## Reporter\n\nProof Reader',
-          labels: ['bug'],
-        },
-      ],
-    }),
+      {
+        id: 'c2',
+        summary: 'Split snippets still appear',
+        evidence: ['still seeing a lot of split snippets'],
+        likely_layers: ['bp-assistant-skills'],
+      },
+      {
+        id: 'c3',
+        summary: 'Abstract noun notes are merged across both lines',
+        evidence: ['combined abstractnoun notes that cover both lines instead of a note for each line'],
+        likely_layers: ['bp-assistant-skills'],
+      },
+    ],
+    ownership: {
+      repositories: ['bp-assistant', 'bp-assistant-skills'],
+      primary_repo: 'bp-assistant-skills',
+      secondary_repo: 'bp-assistant',
+      rationale: 'The note-writing symptoms are skill-facing, but app-side context shaping or post-processing could also explain the ellipsis behavior.',
+    },
+    issues: [
+      {
+        id: 'i1',
+        repo: 'bp-assistant-skills',
+        complaint_ids: ['c1', 'c2', 'c3'],
+        title: 'Refine Psalm 38 note splitting and AT phrase handling',
+        body: '## Summary\n\nPsalm 38 output still splits snippets, uses an ellipsis in the AT, and merges abstract noun notes across both lines.\n\n## Steps to Reproduce\n\n1. Run tn-writer on Psalm 38 content matching the reported case.\n\n## Expected Behavior\n\nWhole-phrase AT output, stable snippets, and one abstract noun note per line.\n\n## Actual Behavior\n\nThe AI sometimes inserts an ellipsis in the AT, still splits snippets, and combines abstract noun notes across lines.\n\n## Reporter\n\nProof Reader',
+        labels: ['bug', 'ai-quality'],
+      },
+      {
+        id: 'i2',
+        repo: 'bp-assistant',
+        complaint_ids: ['c1'],
+        title: 'Audit Psalm 38 AT post-processing and report context shaping',
+        body: '## Summary\n\nThe Psalm 38 report may reflect app-side context packaging, preprocessing, or post-processing that turns a full phrase into an ellipsis before the final note is posted.\n\n## Steps to Reproduce\n\n1. Submit the reported Psalm 38 feedback through the explicit report flow.\n\n## Expected Behavior\n\nThe bot should preserve enough context for triage and avoid introducing AT ellipsis regressions.\n\n## Actual Behavior\n\nThe report plausibly points to app-side context shaping or post-processing around the generated note.\n\n## Reporter\n\nProof Reader',
+        labels: ['bug'],
+      },
+    ],
+  });
+  const runtime = createRuntime({
+    classifierPayload: dualOwnershipPayload,
     fetchImpl,
     sentReplies,
     classifierInputs,
@@ -835,12 +839,24 @@ test('issueReportPipeline treats the Psalm 38 sample as an intelligent dual-owne
     content: psalm38Report,
   }), runtime);
 
-  assert.equal(store.issues['bp-assistant'].length, 1);
-  assert.equal(store.issues['bp-assistant-skills'].length, 1);
-  assert.match(classifierInputs[0], /Ps38/);
-  assert.match(classifierInputs[0], /Psalm 38/);
-  assert.match(classifierInputs[0], /split snippets/);
-  assert.match(classifierInputs[0], /abstractnoun notes/);
-  assert.match(sentReplies[0].text, /bp-assistant#1/);
-  assert.match(sentReplies[0].text, /bp-assistant-skills#1/);
+  // Core regression: dual ownership must produce two issues, not skills-only.
+  assert.equal(dualOwnershipPayload.ownership.repositories.length, 2, 'ownership.repositories must have 2 entries');
+  assert.equal(store.issues['bp-assistant'].length, 1, 'app issue created');
+  assert.equal(store.issues['bp-assistant-skills'].length, 1, 'skills issue created');
+
+  // Reciprocal cross-links must be present.
+  assert.match(store.issues['bp-assistant-skills'][0].body, /## Related issue/, 'skills issue has Related issue section');
+  assert.match(store.issues['bp-assistant-skills'][0].body, /bp-assistant#1/, 'skills issue links to app issue');
+  assert.match(store.issues['bp-assistant'][0].body, /bp-assistant-skills#1/, 'app issue links to skills issue');
+
+  // Classifier received the sample text with reporter and stream context.
+  assert.match(classifierInputs[0], /Ps38/, 'classifier received Ps38 reference');
+  assert.match(classifierInputs[0], /split snippets/, 'classifier received split snippets text');
+  assert.match(classifierInputs[0], /abstractnoun notes/, 'classifier received abstractnoun notes text');
+  assert.match(classifierInputs[0], /Reporter: Proof Reader/, 'classifier received reporter name');
+  assert.match(classifierInputs[0], /Stream: BP Proofreading/, 'classifier received stream context');
+
+  // Reply mentions both issue URLs.
+  assert.match(sentReplies[0].text, /bp-assistant#1/, 'reply mentions app issue');
+  assert.match(sentReplies[0].text, /bp-assistant-skills#1/, 'reply mentions skills issue');
 });

--- a/test/issue-report-pipeline.test.js
+++ b/test/issue-report-pipeline.test.js
@@ -709,7 +709,7 @@ test('issueReportPipeline rejects multiple issues for the same repo in one repor
 });
 
 test('issueReportPipeline avoids duplicate issue creation after partial dual-repo failure and retry', async () => {
-  const classifierPayload = buildClassifierPayload({
+  const firstClassifierPayload = buildClassifierPayload({
     complaints: [
       {
         id: 'c1',
@@ -749,10 +749,65 @@ test('issueReportPipeline avoids duplicate issue creation after partial dual-rep
       },
     ],
   });
+  const secondClassifierPayload = buildClassifierPayload({
+    complaints: [
+      {
+        id: 'c1',
+        summary: 'Ellipses still appear',
+        evidence: ['flips between ellipses'],
+        likely_layers: ['bp-assistant'],
+      },
+      {
+        id: 'c2',
+        summary: 'Split snippets still happen',
+        evidence: ['split snippets'],
+        likely_layers: ['bp-assistant-skills'],
+      },
+    ],
+    ownership: {
+      repositories: ['bp-assistant', 'bp-assistant-skills'],
+      primary_repo: 'bp-assistant',
+      secondary_repo: 'bp-assistant-skills',
+      rationale: 'Both repos are involved.',
+    },
+    issues: [
+      {
+        id: 'i9',
+        repo: 'bp-assistant',
+        complaint_ids: ['c1'],
+        title: 'Harden report triage ownership routing',
+        body: '## Summary\n\nApp-side triage concern.\n\n## Steps to Reproduce\n\n1. Report Psalm 38 issue.\n\n## Expected Behavior\n\nCross-repo routing.\n\n## Actual Behavior\n\nOnly one repo gets filed.\n\n## Reporter\n\nProof Reader',
+        labels: ['bug'],
+      },
+      {
+        id: 'i8',
+        repo: 'bp-assistant-skills',
+        complaint_ids: ['c2'],
+        title: 'Refine Psalm 38 split snippet guidance',
+        body: '## Summary\n\nSkills-side formatting concern.\n\n## Steps to Reproduce\n\n1. Run tn-writer for Psalm 38.\n\n## Expected Behavior\n\nWhole phrase handling.\n\n## Actual Behavior\n\nEllipsis and split snippets.\n\n## Reporter\n\nProof Reader',
+        labels: ['bug'],
+      },
+    ],
+  });
   const classifierInputs = [];
   const sentReplies = [];
   const { fetchImpl, store } = createGithubFetchStub({ failNextPostForRepo: 'bp-assistant-skills' });
-  const runtime = createRuntime({ classifierPayload, fetchImpl, sentReplies, classifierInputs });
+  const runtime = createRuntime({
+    classifierPayload: firstClassifierPayload,
+    fetchImpl,
+    sentReplies,
+    classifierInputs,
+  });
+  runtime.AnthropicClient = createAnthropicSequenceStub([
+    {
+      stop_reason: 'end_turn',
+      content: [{ text: JSON.stringify(firstClassifierPayload) }],
+    },
+    {
+      stop_reason: 'end_turn',
+      content: [{ text: JSON.stringify(secondClassifierPayload) }],
+    },
+  ], classifierInputs);
 
   await issueReportPipeline({}, buildMessage({
     content: 'issue: Psalm 38 still flips between ellipses and split snippets.',
@@ -771,6 +826,7 @@ test('issueReportPipeline avoids duplicate issue creation after partial dual-rep
   assert.equal(store.issues['bp-assistant'].length, 1);
   assert.equal(store.issues['bp-assistant-skills'].length, 1);
   assert.match(store.issues['bp-assistant'][0].body, /bp-assistant-skills#1/);
+  assert.equal(classifierInputs.length, 2);
 });
 
 // Psalm 38 regression: real proofreader feedback that spans both repos.


### PR DESCRIPTION
Closes #11. Add stable dedupe markers for issue-report retries so the bot can avoid duplicate GitHub issues even if classifier issue ids change, while preserving dual-repo cross-links and explicit-trigger-only triage. Ready for review before merge.