### PR TITLE
Fix MCP cache CSV path resolution

### DIFF
--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -4,6 +4,7 @@
 const http = require('http');
 const https = require('https');
 const fs = require('fs');
+const path = require('path');
 const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
 const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
 const { z } = require('zod');
@@ -193,11 +194,29 @@ function stripMarkup(verseUsfm) {
 function loadCache() {
   if (cache.validIssues && cache.templates) return;
 
-  const issuesPath = '/workspace/data/translation-issues.csv';
-  const templatesPath = '/workspace/data/templates.csv';
+  const workspaceDir = process.env.CSKILLBP_DIR || '';
+  const dataDirCandidates = [
+    workspaceDir ? path.join(workspaceDir, 'data') : null,
+    '/data/workspace/data',
+    '/srv/bot/workspace/data',
+    '/workspace/data',
+    '/srv/bot/app/data',
+  ].filter(Boolean);
 
-  if (!fs.existsSync(issuesPath) || !fs.existsSync(templatesPath)) {
-    console.warn(`[mcp] Cache preload skipped: ${!fs.existsSync(issuesPath) ? issuesPath : templatesPath} not found.`);
+  let issuesPath = null;
+  let templatesPath = null;
+  for (const dataDir of dataDirCandidates) {
+    const issuesCandidate = path.join(dataDir, 'translation-issues.csv');
+    const templatesCandidate = path.join(dataDir, 'templates.csv');
+    if (fs.existsSync(issuesCandidate) && fs.existsSync(templatesCandidate)) {
+      issuesPath = issuesCandidate;
+      templatesPath = templatesCandidate;
+      break;
+    }
+  }
+
+  if (!issuesPath || !templatesPath) {
+    console.warn(`[mcp] Cache preload skipped: translation CSVs not found in any candidate data dir: ${dataDirCandidates.join(', ')}`);
     return;
   }
 
@@ -278,6 +297,9 @@ async function getExistingNotes({ book, chapter }) {
 
 function getTemplate({ issue_type }) {
   loadCache();
+  if (!cache.validIssues || !cache.templates) {
+    throw new Error('Template cache unavailable: translation CSV files were not found in known data directories.');
+  }
 
   const issueKey = issue_type.trim().toLowerCase();
 
@@ -413,7 +435,11 @@ function startMcpServer() {
 
   try {
     loadCache();
-    console.log(`[mcp] Loaded ${cache.validIssues.size} issue types, ${cache.templates.size} template entries`);
+    if (cache.validIssues && cache.templates) {
+      console.log(`[mcp] Loaded ${cache.validIssues.size} issue types, ${cache.templates.size} template entries`);
+    } else {
+      console.warn('[mcp] Cache not loaded at startup; will retry on first template request.');
+    }
   } catch (err) {
     console.warn(`[mcp] Cache preload failed (will retry on first request): ${err.message}`);
     cache.validIssues = null;


### PR DESCRIPTION
Resolve translation cache files from environment-aware data directories (CSKILLBP_DIR, Fly, srv paths) instead of a single hardcoded /workspace path. Add cache null guards so startup no longer logs .size on null when preload is skipped.

#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
