### PR TITLE
Add resumable pause before AT generation

### DIFF
--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -111,6 +111,14 @@ function hasFreshFlag(content) {
   return /--fresh\b/i.test(String(content || '')) || /--new\b/i.test(String(content || ''));
 }
 
+function hasPauseBeforeATsFlag(content) {
+  const text = String(content || '');
+  return /--pause-before-ats\b/i.test(text)
+    || /--pause-ats\b/i.test(text)
+    || /\bpause[\s-]+before[\s-]+ats\b/i.test(text)
+    || /\bpause[\s-]+before[\s-]+alternate[\s-]+translations\b/i.test(text);
+}
+
 /**
  * Run all mechanical prep steps in Node.js before invoking tn-writer.
  * This replaces ~100 Claude MCP tool calls with direct function calls:
@@ -998,6 +1006,7 @@ function buildUsageLimitResetTag(errorText) {
 function parseWriteNotesCommand(content) {
   // Range: write notes PSA 66-72 or write notes for PSA 66-72
   const withIntro = !hasNoIntroFlag(content) || hasWithIntroFlag(content);
+  const pauseBeforeATs = hasPauseBeforeATsFlag(content);
 
   const rangeMatch = content.match(/write notes(?:\s+for)?\s+(\w+)\s+(\d+)\s*[-\u2013\u2014to]+\s*(\d+)/i);
   if (rangeMatch) {
@@ -1007,6 +1016,7 @@ function parseWriteNotesCommand(content) {
       endChapter: parseInt(rangeMatch[3], 10),
       withIntro,
       fresh: hasFreshFlag(content),
+      pauseBeforeATs,
     };
   }
 
@@ -1022,6 +1032,7 @@ function parseWriteNotesCommand(content) {
       verseEnd: parseInt(verseMatch[4], 10),
       withIntro,
       fresh: hasFreshFlag(content),
+      pauseBeforeATs,
     };
   }
 
@@ -1035,6 +1046,7 @@ function parseWriteNotesCommand(content) {
       endChapter: ch,
       withIntro,
       fresh: hasFreshFlag(content),
+      pauseBeforeATs,
     };
   }
 
@@ -1051,9 +1063,31 @@ function buildParsedNotesRequest(route, content) {
       verseEnd: route._verseEnd ?? null,
       withIntro: !hasNoIntroFlag(content) || hasWithIntroFlag(content),
       fresh: hasFreshFlag(content),
+      pauseBeforeATs: hasPauseBeforeATsFlag(content),
     };
   }
   return parseWriteNotesCommand(content);
+}
+
+function buildAtGenerationCheckpoint({
+  totalSuccess,
+  totalFail,
+  skillOutputs,
+  chapter,
+}) {
+  return {
+    state: 'failed',
+    totalSuccess,
+    totalFail,
+    skillOutputs,
+    current: {
+      chapter,
+      skill: 'tn-quality-check',
+      status: 'paused_before_at_generation',
+      errorKind: 'awaiting_at_generation',
+    },
+    resume: { chapter, skill: 'tn-quality-check' },
+  };
 }
 
 // Default verse chunk size for parallel tn-writer batching
@@ -1456,7 +1490,7 @@ async function notesPipeline(route, message) {
     return;
   }
 
-  const { book, startChapter, endChapter, verseStart, verseEnd, withIntro, fresh } = parsed;
+  const { book, startChapter, endChapter, verseStart, verseEnd, withIntro, fresh, pauseBeforeATs } = parsed;
   const sessionKey = stream ? `stream-${stream}-${topic}` : `dm-${message.sender_id}`;
   const debugRunId = `notes-${message.id || Date.now()}`;
   const checkpointRef = {
@@ -1830,6 +1864,17 @@ async function notesPipeline(route, message) {
 
       // --- AT generation: run between tn-writer and tn-quality-check ---
       if (skill.name === 'tn-quality-check' && !atGenerationDone && pipeDir) {
+        if (pauseBeforeATs && chapterCount === 1 && ch === resumeChapter && resumeSkill !== 'tn-quality-check') {
+          setCheckpoint(checkpointRef, buildAtGenerationCheckpoint({
+            totalSuccess,
+            totalFail,
+            skillOutputs,
+            chapter: ch,
+          }));
+          await status(`**${ref}**: Notes are written. Pausing before alternate translations so you can resume AT generation from Zulip.`);
+          await reply(`Notes for **${ref}** are written and saved. Say **resume** in this topic when you want me to generate the alternate translations.`);
+          return;
+        }
         try {
           const writerNotesPath = skills.find(s => s.name === 'tn-writer')?.resolvedOutput
             || skills.find(s => s.name === 'tn-writer')?.expectedOutput;
@@ -2654,4 +2699,6 @@ module.exports = {
   _isMalformedIssuesShape: isMalformedIssuesShape,
   _postProcessNotesTsv: postProcessNotesTsv,
   _runMechanicalQualityPrep: runMechanicalQualityPrep,
+  _hasPauseBeforeATsFlag: hasPauseBeforeATsFlag,
+  _buildAtGenerationCheckpoint: buildAtGenerationCheckpoint,
 };

--- a/src/router.js
+++ b/src/router.js
@@ -989,6 +989,9 @@ async function routeMessage(message) {
       let confirmText = activeRoute._contentTypes
         ? activeRoute.confirmMessage
         : buildConfirmMessage(activeRoute.confirmMessage, captures);
+      if (activeRoute.name === 'write-notes' && /--pause-before-ats\b/i.test(message.content)) {
+        confirmText += `\n\nPause mode enabled: I will stop after writing notes and wait for \`resume\` before alternate translations.`;
+      }
       if (activeRoute.name === 'generate-content') {
         confirmText = buildGenerateConfirmText(confirmText, message.content);
       }
@@ -1096,6 +1099,9 @@ async function routeMessage(message) {
               ? [intent.book, String(intent.startChapter)]
               : [intent.book, String(intent.startChapter), String(intent.endChapter)]);
           let confirmText = buildConfirmMessage(syntheticRoute.confirmMessage, captures);
+          if (syntheticRoute.name === 'write-notes' && /--pause-before-ats\b/i.test(message.content)) {
+            confirmText += `\n\nPause mode enabled: I will stop after writing notes and wait for \`resume\` before alternate translations.`;
+          }
           if (syntheticRoute.name === 'generate-content') {
             confirmText = buildGenerateConfirmText(confirmText, message.content);
           }

--- a/test/pipeline-regressions.test.js
+++ b/test/pipeline-regressions.test.js
@@ -20,6 +20,7 @@ const {
   _runMechanicalQualityPrep,
   _analyzeIssuesTsvShape,
   _isMalformedIssuesShape,
+  _buildAtGenerationCheckpoint,
 } = require('../src/notes-pipeline');
 const { buildParallelismIntroHintArgs } = require('../src/issue-normalizer');
 
@@ -119,6 +120,23 @@ test('write notes defaults to running chapter intro unless explicitly disabled',
 
   const disabledParsed = parseWriteNotesCommand('write notes for isa 51 --no-intro');
   assert.equal(disabledParsed.withIntro, false);
+});
+
+test('write notes pause-before-ats flag is parsed and checkpoints resume at AT generation', () => {
+  const parsed = parseWriteNotesCommand('write notes for isa 41 --pause-before-ats');
+  assert.equal(parsed.pauseBeforeATs, true);
+
+  const checkpoint = _buildAtGenerationCheckpoint({
+    totalSuccess: 1,
+    totalFail: 0,
+    skillOutputs: { 41: { 'tn-writer': 'output/notes/ISA/ISA-041.tsv' } },
+    chapter: 41,
+  });
+
+  assert.equal(checkpoint.state, 'failed');
+  assert.equal(checkpoint.current.status, 'paused_before_at_generation');
+  assert.equal(checkpoint.current.skill, 'tn-quality-check');
+  assert.equal(checkpoint.resume.skill, 'tn-quality-check');
 });
 
 test('chapter intro is auto-skipped for Psalms', () => {


### PR DESCRIPTION
Introduce a notes pipeline pause mode that checkpoints after tn-writer and resumes at tn-quality-check so alternate translations can be retriggered from Zulip without redoing note writing. Add router confirmation messaging and regression coverage for the new flag and checkpoint shape.

#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
