### PR TITLE
Prioritize AT issue resolution in validator

### DIFF
--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -560,9 +560,7 @@ async function runATGeneration({ notesPath, pipeDir, status }) {
   ].join('\n');
 
   // Haiku validator system prompt
-  const validatorSystemPrompt =
-    'Answer YES or NO only, then one sentence explaining why. Do not use any tools.\n\n' +
-    'Does the modified verse read as natural English AND address the issue described in the note?';
+  const validatorSystemPrompt = buildAtValidatorSystemPrompt();
 
   // Helper to extract text from SDK result
   function extractResultText(result) {
@@ -1144,6 +1142,24 @@ const TN_WRITER_MAX_TOOL_CALLS = Number((config.notesGuardrails || {}).tnWriterM
 const RESCUE_MAX_PASSES = Number((config.notesGuardrails || {}).rescueMaxPasses || 1);
 const USE_PER_NOTE_GENERATION = Boolean((config.notesGuardrails || {}).usePerNoteGeneration);
 const TN_WRITER_RESTRICTED_TOOLS = DEFAULT_RESTRICTED_TOOLS.filter((tool) => !TN_WRITER_TOOL_BLOCKLIST.includes(tool));
+
+function buildAtValidatorSystemPrompt() {
+  return [
+    'Answer YES or NO only, then one sentence explaining why. Do not use any tools.',
+    '',
+    'Judge the candidate alternate translation by these priorities:',
+    '1. First, confirm that it actually SOLVES the translation problem named in the note.',
+    '2. Second, confirm that the modified verse reads as natural English.',
+    '',
+    'A candidate fails if it leaves the original problem in place, even if the English sounds natural.',
+    'Examples:',
+    '- If the note says passive voice is the issue, reject any candidate that still uses passive voice.',
+    '- If the note says a metaphor should be changed, reject any candidate that still uses the metaphor instead of a simile or plain meaning.',
+    '- If the note says a figure should be made explicit, reject any candidate that still leaves the meaning implicit.',
+    '',
+    'Does the modified verse read as natural English AND clearly resolve the issue described in the note?',
+  ].join('\n');
+}
 
 function countIssueRows(tsvRelPath) {
   try {
@@ -2798,6 +2814,7 @@ module.exports = {
   _hasPauseBeforeATsFlag: hasPauseBeforeATsFlag,
   _buildAtGenerationCheckpoint: buildAtGenerationCheckpoint,
   _classifyRunClaudeEmpty: classifyRunClaudeEmpty,
+  _buildAtValidatorSystemPrompt: buildAtValidatorSystemPrompt,
   _AT_TIMEOUTS: {
     generationMs: AT_GENERATION_TIMEOUT_MS,
     validationMs: AT_VALIDATION_TIMEOUT_MS,

--- a/test/at-classification.test.js
+++ b/test/at-classification.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 
 const {
   _classifyRunClaudeEmpty: classify,
+  _buildAtValidatorSystemPrompt: buildValidatorPrompt,
   _AT_TIMEOUTS: atTimeouts,
   _DEFAULT_AT_CONCURRENCY: defaultAtConcurrency,
 } = require('../src/notes-pipeline');
@@ -60,4 +61,11 @@ test('AT stage timeouts are extended to five minutes for generate, validate, and
 
 test('AT generation defaults to lower concurrency to reduce rate-limit pressure', () => {
   assert.equal(defaultAtConcurrency, 2);
+});
+
+test('AT validator prompt prioritizes solving the note issue over mere naturalness', () => {
+  const prompt = buildValidatorPrompt();
+  assert.match(prompt, /First, confirm that it actually SOLVES the translation problem named in the note\./);
+  assert.match(prompt, /passive voice is the issue, reject any candidate that still uses passive voice\./);
+  assert.match(prompt, /metaphor should be changed, reject any candidate that still uses the metaphor instead of a simile or plain meaning\./);
 });


### PR DESCRIPTION
Update the Haiku AT validator prompt so solving the note's translation issue is the primary acceptance criterion, with explicit passive-voice and metaphor examples. Add a regression test that locks in the new validator guidance.

#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
