### PR TITLE
Separate admin HTTP from MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,11 @@ DCS_TOKEN=your-door43-api-token
 # Anthropic API key (used by Haiku NLU intent classifier)
 ANTHROPIC_API_KEY=your-anthropic-api-key
 
-# HTTP port for MCP server (optional, default: 3001)
-PORT=3001
+# HTTP port for the public admin status board (optional, default: 8080)
+PORT=8080
+
+# Local-only MCP server port (optional, default: 3001)
+MCP_PORT=3001
 
 # Password for the read-only admin status board
 ADMIN_PAGE_PASSWORD=choose-a-strong-password

--- a/fly.toml
+++ b/fly.toml
@@ -12,11 +12,18 @@ kill_timeout = 30
 
 [env]
   NODE_ENV = "production"
+  PORT = "8080"
   CSKILLBP_DIR = "/data/workspace"
   DOOR43_REPOS_PATH = "/data/workspace/door43-repos"
   HEBREW_DIR = "/data/workspace/data/hebrew_bible"
   CLAUDE_CONFIG_DIR = "/data/claude-config"
   MODEL_PROVIDER_CONFIG_FILE = "/config/model-provider-config.json"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_start_machines = true
+  auto_stop_machines = "off"
 
 [[vm]]
   memory = "2gb"

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const config = require('./config');
-const { startMcpServer } = require('./mcp-server');
+const { startAdminServer, startMcpServer } = require('./mcp-server');
 const { getClient, sendMessage } = require('./zulip-client');
 const { routeMessage, hasPendingAction, hasActiveSession } = require('./router');
 const { ensureFreshToken } = require('./auth-refresh');
@@ -170,6 +170,7 @@ async function main() {
   }
 }
 
+startAdminServer();
 startMcpServer();
 startWeeklyRefresh();
 

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -12,7 +12,9 @@ const { z } = require('zod');
 const { readSecret } = require('./secrets');
 const { readAdminStatus } = require('./admin-status');
 
-const MCP_PORT = 3001;
+const ADMIN_PORT = Number(process.env.PORT || 8080);
+const MCP_PORT = Number(process.env.MCP_PORT || 3001);
+const MCP_BIND_HOST = process.env.MCP_BIND_HOST || '127.0.0.1';
 const DOOR43_BASE = 'https://git.door43.org/unfoldingWord';
 
 // ---------------------------------------------------------------------------
@@ -611,7 +613,6 @@ function requireAdminAuth(req, res, password) {
 }
 
 function createHttpServer() {
-  const token = readSecret('bt_mcp_api_token', 'BT_MCP_API_TOKEN');
   const adminPassword = readSecret('admin_page_password', 'ADMIN_PAGE_PASSWORD');
   return http.createServer(async (req, res) => {
     res.setHeader('Access-Control-Allow-Origin', '*');
@@ -653,12 +654,34 @@ function createHttpServer() {
       return;
     }
 
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not found' }));
+  });
+}
+
+function createMcpHttpServer(token) {
+  return http.createServer(async (req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, DELETE');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, Mcp-Session-Id');
+    res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    const reqUrl = new URL(req.url, 'http://localhost');
+    const urlPath = reqUrl.pathname;
+
+    if (req.method === 'GET' && urlPath === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, service: 'bt-pipeline-mcp' }));
+      return;
+    }
+
     if (urlPath === '/mcp') {
-      if (!token) {
-        res.writeHead(503, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'mcp_disabled' }));
-        return;
-      }
       const auth = req.headers.authorization || '';
       const urlToken = reqUrl.searchParams.get('token') || '';
       const authed = auth === `Bearer ${token}` || urlToken === token;
@@ -688,6 +711,13 @@ function createHttpServer() {
   });
 }
 
+function startAdminServer() {
+  const httpServer = createHttpServer();
+  httpServer.listen(ADMIN_PORT, '0.0.0.0', () => {
+    console.log(`[admin] Admin server listening on port ${ADMIN_PORT}`);
+  });
+}
+
 function startMcpServer() {
   const token = readSecret('bt_mcp_api_token', 'BT_MCP_API_TOKEN');
   if (!token) {
@@ -708,11 +738,11 @@ function startMcpServer() {
     cache.templates = null;
   }
 
-  const httpServer = createHttpServer();
+  const httpServer = createMcpHttpServer(token);
 
-  httpServer.listen(MCP_PORT, '0.0.0.0', () => {
-    console.log(`[mcp] MCP server listening on port ${MCP_PORT}`);
+  httpServer.listen(MCP_PORT, MCP_BIND_HOST, () => {
+    console.log(`[mcp] MCP server listening on ${MCP_BIND_HOST}:${MCP_PORT}`);
   });
 }
 
-module.exports = { startMcpServer, createHttpServer };
+module.exports = { startAdminServer, startMcpServer, createHttpServer, createMcpHttpServer };


### PR DESCRIPTION
Serve the admin status board on the public Fly HTTP port, keep the MCP endpoint bound to localhost only, and update Fly config and env defaults to match the split.

#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
