### PR TITLE
Fix feedback issue filing auth

### DIFF
--- a/src/issue-report-pipeline.js
+++ b/src/issue-report-pipeline.js
@@ -1,9 +1,17 @@
 'use strict';
 
-const Anthropic = require('@anthropic-ai/sdk');
 const { sendMessage, sendDM, addReaction, removeReaction } = require('./zulip-client');
 const { readSecret } = require('./secrets');
-const { resolveProviderModel } = require('./api-runner/provider-config');
+const { ensureFreshToken } = require('./auth-refresh');
+
+let _query = null;
+async function getQuery() {
+  if (!_query) {
+    const sdk = await import('@anthropic-ai/claude-agent-sdk');
+    _query = sdk.query;
+  }
+  return _query;
+}
 
 const GITHUB_ORG = 'unfoldingWord';
 const VALID_REPOS = new Set(['bp-assistant', 'bp-assistant-skills']);
@@ -134,24 +142,68 @@ function shouldRetryClassifierJson(raw, stopReason) {
   return text.startsWith('{') && !text.endsWith('}');
 }
 
-async function classifyIssueReport(client, deps, classifierInput) {
+async function runAgentSdkClassifierQuery({ classifierInput, getClaudeQuery = getQuery }) {
+  await ensureFreshToken();
+  const queryFn = await getClaudeQuery();
+  const abortController = new AbortController();
+  const timer = setTimeout(() => abortController.abort(), 30000);
+  const options = {
+    cwd: process.cwd(),
+    abortController,
+    maxTurns: 1,
+    allowedTools: [],
+    permissionMode: 'bypassPermissions',
+    allowDangerouslySkipPermissions: true,
+    persistSession: false,
+    model: 'sonnet',
+    systemPrompt: SYSTEM_PROMPT,
+  };
+
+  const conversation = queryFn({
+    prompt: `Classify this issue report and respond with JSON only:\n\n${classifierInput}`,
+    options,
+  });
+  let raw = '';
+  let stopReason = 'unknown';
+
+  try {
+    for await (const event of conversation) {
+      if (abortController.signal.aborted) break;
+      if (event.type === 'assistant' && event.message?.content) {
+        for (const block of event.message.content) {
+          if (block && typeof block.text === 'string') raw += block.text;
+        }
+      } else if (event.type === 'result') {
+        stopReason = event.stop_reason || event.subtype || stopReason;
+        if (!raw && typeof event.result === 'string') raw = event.result;
+      }
+    }
+  } finally {
+    clearTimeout(timer);
+    try { conversation.close(); } catch (_) {}
+  }
+
+  if (abortController.signal.aborted) {
+    throw new Error('Classifier timed out');
+  }
+
+  return { raw: raw.trim(), stopReason };
+}
+
+async function classifyIssueReport(deps, classifierInput) {
   let lastRaw = '';
   let lastStopReason = 'unknown';
 
   for (let index = 0; index < CLASSIFIER_MAX_TOKENS.length; index++) {
     const maxTokens = CLASSIFIER_MAX_TOKENS[index];
-    const response = await client.messages.create({
-      model: deps.resolveProviderModel('claude', 'sonnet'),
-      max_tokens: maxTokens,
-      system: SYSTEM_PROMPT,
-      messages: [{
-        role: 'user',
-        content: classifierInput,
-      }],
+    const response = await deps.runClassifierQuery({
+      classifierInput,
+      maxTokens,
+      attempt: index + 1,
     });
 
-    const raw = response.content?.[0]?.text?.trim() || '';
-    const stopReason = response.stop_reason || 'unknown';
+    const raw = response?.raw?.trim() || '';
+    const stopReason = response?.stopReason || 'unknown';
     lastRaw = raw;
     lastStopReason = stopReason;
 
@@ -409,13 +461,15 @@ function summarizeIssues(issues) {
 
 function getRuntimeDeps(overrides = {}) {
   return {
-    AnthropicClient: overrides.AnthropicClient || Anthropic,
+    runClassifierQuery: overrides.runClassifierQuery || ((args) => runAgentSdkClassifierQuery({
+      ...args,
+      getClaudeQuery: overrides.getClaudeQuery || getQuery,
+    })),
     sendMessage: overrides.sendMessage || sendMessage,
     sendDM: overrides.sendDM || sendDM,
     addReaction: overrides.addReaction || addReaction,
     removeReaction: overrides.removeReaction || removeReaction,
     readSecret: overrides.readSecret || readSecret,
-    resolveProviderModel: overrides.resolveProviderModel || resolveProviderModel,
     fetchImpl: overrides.fetchImpl || fetch,
   };
 }
@@ -438,11 +492,7 @@ async function issueReportPipeline(route, message, overrides = {}) {
   try { await deps.addReaction(message.id, 'eyes'); } catch (_) {}
 
   try {
-    const apiKey = process.env.ANTHROPIC_API_KEY || deps.readSecret('anthropic_api_key', 'ANTHROPIC_API_KEY');
-    if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured');
-
-    const client = new deps.AnthropicClient({ apiKey });
-    const classified = await classifyIssueReport(client, deps, buildClassifierInput(message, feedbackText));
+    const classified = await classifyIssueReport(deps, buildClassifierInput(message, feedbackText));
     const githubToken = deps.readSecret('github_token', 'GITHUB_TOKEN');
     if (!githubToken) throw new Error('github_token secret not configured');
 

--- a/test/issue-report-pipeline.test.js
+++ b/test/issue-report-pipeline.test.js
@@ -22,37 +22,22 @@ function buildMessage(overrides = {}) {
   };
 }
 
-function buildClassifierResponse(payload) {
-  return {
-    content: [{ text: JSON.stringify(payload) }],
-  };
-}
-
 function wrapInJsonFence(text) {
   return `\`\`\`json\n${text}\n\`\`\``;
 }
 
-function createAnthropicStub(payload) {
-  return class AnthropicStub {
-    constructor() {
-      this.messages = {
-        create: async () => buildClassifierResponse(payload),
-      };
-    }
+function buildClassifierResult(payload) {
+  return {
+    raw: JSON.stringify(payload),
+    stopReason: 'end_turn',
   };
 }
 
 function createRuntime({ classifierPayload, fetchImpl, sentReplies, classifierInputs }) {
   return {
-    AnthropicClient: class AnthropicStub {
-      constructor() {
-        this.messages = {
-          create: async (request) => {
-            classifierInputs.push(request.messages[0].content);
-            return buildClassifierResponse(classifierPayload);
-          },
-        };
-      }
+    runClassifierQuery: async ({ classifierInput }) => {
+      classifierInputs.push(classifierInput);
+      return buildClassifierResult(classifierPayload);
     },
     sendMessage: async (stream, topic, text) => {
       sentReplies.push({ stream, topic, text });
@@ -63,28 +48,21 @@ function createRuntime({ classifierPayload, fetchImpl, sentReplies, classifierIn
     addReaction: async () => {},
     removeReaction: async () => {},
     readSecret: (name) => {
-      if (name === 'anthropic_api_key') return 'anthropic-test-key';
+      if (name === 'anthropic_api_key') throw new Error('anthropic_api_key should not be read');
       if (name === 'github_token') return 'github-test-token';
       return null;
     },
-    resolveProviderModel: () => 'claude-sonnet-test',
     fetchImpl,
   };
 }
 
-function createAnthropicSequenceStub(responses, classifierInputs) {
+function createClassifierSequenceStub(responses, classifierInputs) {
   let index = 0;
-  return class AnthropicStub {
-    constructor() {
-      this.messages = {
-        create: async (request) => {
-          classifierInputs.push(request.messages[0].content);
-          const next = responses[Math.min(index, responses.length - 1)];
-          index += 1;
-          return next;
-        },
-      };
-    }
+  return async ({ classifierInput }) => {
+    classifierInputs.push(classifierInput);
+    const next = responses[Math.min(index, responses.length - 1)];
+    index += 1;
+    return next;
   };
 }
 
@@ -289,14 +267,14 @@ test('issueReportPipeline retries classifier when JSON is truncated at max_token
   });
   const runtime = {
     ...createRuntime({ classifierPayload: payload, fetchImpl, sentReplies, classifierInputs }),
-    AnthropicClient: createAnthropicSequenceStub([
+    runClassifierQuery: createClassifierSequenceStub([
       {
-        stop_reason: 'max_tokens',
-        content: [{ text: '{\n  "complaints": [\n    { "id": "c1", "summary": "Split snippets still happen"' }],
+        stopReason: 'max_tokens',
+        raw: '{\n  "complaints": [\n    { "id": "c1", "summary": "Split snippets still happen"',
       },
       {
-        stop_reason: 'end_turn',
-        content: [{ text: JSON.stringify(payload) }],
+        stopReason: 'end_turn',
+        raw: JSON.stringify(payload),
       },
     ], classifierInputs),
   };
@@ -338,14 +316,14 @@ test('issueReportPipeline retries classifier when fenced JSON is truncated at ma
   });
   const runtime = {
     ...createRuntime({ classifierPayload: payload, fetchImpl, sentReplies, classifierInputs }),
-    AnthropicClient: createAnthropicSequenceStub([
+    runClassifierQuery: createClassifierSequenceStub([
       {
-        stop_reason: 'max_tokens',
-        content: [{ text: '```json\n{\n  "complaints": [\n    { "id": "c1", "summary": "Template choice is wrong",\n      "evidence"' }],
+        stopReason: 'max_tokens',
+        raw: '```json\n{\n  "complaints": [\n    { "id": "c1", "summary": "Template choice is wrong",\n      "evidence"',
       },
       {
-        stop_reason: 'end_turn',
-        content: [{ text: wrapInJsonFence(JSON.stringify(payload)) }],
+        stopReason: 'end_turn',
+        raw: wrapInJsonFence(JSON.stringify(payload)),
       },
     ], classifierInputs),
   };
@@ -387,14 +365,14 @@ test('issueReportPipeline retries classifier when fenced JSON is truncated witho
   });
   const runtime = {
     ...createRuntime({ classifierPayload: payload, fetchImpl, sentReplies, classifierInputs }),
-    AnthropicClient: createAnthropicSequenceStub([
+    runClassifierQuery: createClassifierSequenceStub([
       {
-        stop_reason: 'end_turn',
-        content: [{ text: '```json\n{\n  "complaints": [\n    { "id": "c1", "summary": "Template choice is wrong",\n      "evidence"' }],
+        stopReason: 'end_turn',
+        raw: '```json\n{\n  "complaints": [\n    { "id": "c1", "summary": "Template choice is wrong",\n      "evidence"',
       },
       {
-        stop_reason: 'end_turn',
-        content: [{ text: wrapInJsonFence(JSON.stringify(payload)) }],
+        stopReason: 'end_turn',
+        raw: wrapInJsonFence(JSON.stringify(payload)),
       },
     ], classifierInputs),
   };
@@ -610,13 +588,7 @@ test('issueReportPipeline reports invalid classifier JSON', async () => {
       sentReplies,
       classifierInputs: [],
     }),
-    AnthropicClient: class AnthropicStub {
-      constructor() {
-        this.messages = {
-          create: async () => ({ content: [{ text: '{not-json' }] }),
-        };
-      }
-    },
+    runClassifierQuery: async () => ({ raw: '{not-json', stopReason: 'end_turn' }),
   };
 
   await issueReportPipeline({}, buildMessage(), runtime);
@@ -798,14 +770,14 @@ test('issueReportPipeline avoids duplicate issue creation after partial dual-rep
     sentReplies,
     classifierInputs,
   });
-  runtime.AnthropicClient = createAnthropicSequenceStub([
+  runtime.runClassifierQuery = createClassifierSequenceStub([
     {
-      stop_reason: 'end_turn',
-      content: [{ text: JSON.stringify(firstClassifierPayload) }],
+      stopReason: 'end_turn',
+      raw: JSON.stringify(firstClassifierPayload),
     },
     {
-      stop_reason: 'end_turn',
-      content: [{ text: JSON.stringify(secondClassifierPayload) }],
+      stopReason: 'end_turn',
+      raw: JSON.stringify(secondClassifierPayload),
     },
   ], classifierInputs);
 


### PR DESCRIPTION
## Summary

Fixes the Zulip feedback/report issue filing path so it uses the Claude Agent SDK OAuth runtime instead of requiring `ANTHROPIC_API_KEY`.

## Root Cause

`src/issue-report-pipeline.js` was the outlier among the editor/Zulip Claude paths: it instantiated `@anthropic-ai/sdk` directly and read `anthropic_api_key` / `ANTHROPIC_API_KEY` before classifying feedback. Fly production uses the Claude Code OAuth setup token path, so feedback filing failed before GitHub issue creation.

## Changes

- Route feedback issue classification through `@anthropic-ai/claude-agent-sdk` `query()` after `ensureFreshToken()`.
- Preserve the existing classifier prompt, JSON parsing, truncated JSON retry, GitHub issue creation, dedupe, and cross-repo linking behavior.
- Update tests to stub `runClassifierQuery` and fail if the issue-report runtime reads `anthropic_api_key`.

## Validation

- `npm test` passed: 142/142

Closes #24
