### PR TITLE
fix: raise classifier timeout and normalize abort error

### DIFF
--- a/src/issue-report-pipeline.js
+++ b/src/issue-report-pipeline.js
@@ -146,7 +146,7 @@ async function runAgentSdkClassifierQuery({ classifierInput, getClaudeQuery = ge
   await ensureFreshToken();
   const queryFn = await getClaudeQuery();
   const abortController = new AbortController();
-  const timer = setTimeout(() => abortController.abort(), 30000);
+  const timer = setTimeout(() => abortController.abort(), 300000);
   const options = {
     cwd: process.cwd(),
     abortController,
@@ -178,6 +178,11 @@ async function runAgentSdkClassifierQuery({ classifierInput, getClaudeQuery = ge
         if (!raw && typeof event.result === 'string') raw = event.result;
       }
     }
+  } catch (err) {
+    if (abortController.signal.aborted) {
+      throw new Error('Classifier timed out');
+    }
+    throw err;
   } finally {
     clearTimeout(timer);
     try { conversation.close(); } catch (_) {}


### PR DESCRIPTION
## Summary

- Raises the feedback issue classifier timeout from 30s to 5 minutes — Sonnet needs time to decompose complaints, assign repos, and write full issue bodies over the OAuth subprocess path.
- Wraps the `for await` catch in `runAgentSdkClassifierQuery` so that an abort mid-stream throws `Classifier timed out` instead of leaking the SDK's raw `Claude Code process aborted by user` message to Zulip.

## Root cause

PR #25 moved the classifier from direct Anthropic API to Claude Agent SDK OAuth. The subprocess cold-start + auth handshake + Sonnet generation of a multi-section issue body easily exceeds 30s on a real feedback report. When the abort fired mid-stream, the SDK threw its own error before our post-loop timed-out check could normalize it.

## Test plan

- [x] `npm test` — 142 tests pass
- [ ] Live: send `feedback: <multi-paragraph tweak list>` to bot and confirm `eyes` → `check` with a GitHub issue URL reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)