### PR TITLE
fix: prevent duplicate alternate translations on resume re-runs

### DIFF
--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -14,7 +14,7 @@ const { sendMessage, sendDM, addReaction, removeReaction } = require('./zulip-cl
 const { runClaude, DEFAULT_RESTRICTED_TOOLS, isTransientOutageError } = require('./claude-runner');
 const { getDoor43Username, emailToFallbackUsername, buildBranchName, resolveOutputFile, discoverFreshOutput, checkPrerequisites, calcSkillTimeout, normalizeBookName, resolveConflictMention, parsePartialTsv, truncatePartialTsv, parseChunkRange, CSKILLBP_DIR } = require('./pipeline-utils');
 const { splitTsv, fixTrailingNewlines } = require('./workspace-tools/tsv-tools');
-const { fillTsvIds, generateIds, prepareNotes, fillOrigQuotes, resolveGlQuotes, flagNarrowQuotes, extractAlignmentData, prepareATContext, substituteAT, fixUnicodeQuotes, verifyBoldMatches, syncCanonicalHebrewQuotes } = require('./workspace-tools/tn-tools');
+const { fillTsvIds, generateIds, prepareNotes, fillOrigQuotes, resolveGlQuotes, flagNarrowQuotes, extractAlignmentData, prepareATContext, substituteAT, fixUnicodeQuotes, verifyBoldMatches, syncCanonicalHebrewQuotes, _stripAlternateTranslation: stripAlternateTranslation } = require('./workspace-tools/tn-tools');
 const { checkTnQuality } = require('./workspace-tools/quality-tools');
 const { normalizeIssuesFile, buildParallelismIntroHintArgs } = require('./issue-normalizer');
 const { curlyQuotes } = require('./workspace-tools/usfm-tools');
@@ -715,8 +715,9 @@ async function runATGeneration({ notesPath, pipeDir, status }) {
       results.success++;
       if (r.validated) results.validated++;
       if (r.retryReason) bumpReason(r.retryReason);
-      // Append AT to the note text
-      const existingNote = generatedNotes[r.id] || '';
+      // Append AT to the note text. Strip any existing trailing AT first so this
+      // operation is idempotent across resume re-runs.
+      const existingNote = stripAlternateTranslation(generatedNotes[r.id] || '');
       generatedNotes[r.id] = `${existingNote} Alternate translation: [${r.at}]`;
       if (r.tag) tagsToApply.set(r.id, r.tag);
     } else {

--- a/src/workspace-tools/tn-tools.js
+++ b/src/workspace-tools/tn-tools.js
@@ -2557,6 +2557,9 @@ function prepareATContext({ preparedJson, generatedJson, output }) {
     if (item.programmatic_note) continue; // "see how" notes already have ATs
 
     const noteText = generatedNotes[item.id] || '';
+    // Idempotency: if this item's stored note already has an AT clause, skip it.
+    // Lets resume-to-fill-missing-ATs runs avoid double-appending (ZEC 3 incident).
+    if (/Alternate translation:/i.test(noteText)) continue;
     const verseCtx = getVerseContext(item.reference);
     const scopedQuote = item.issue_span_gl_quote || item.gl_quote || '';
 

--- a/test/tn-tools.test.js
+++ b/test/tn-tools.test.js
@@ -233,6 +233,30 @@ test('prepareATContext keys off canonical at_required', () => {
   assert.equal(atCtx.packets[0].exact_ult_span, 'new text');
 });
 
+test('prepareATContext skips items whose generated note already contains an AT (idempotent re-runs)', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tn-tools-atctx-idem-'));
+  const preparedRel = path.join('tmp', path.basename(tempDir), 'prepared_notes.json');
+  const generatedRel = path.join('tmp', path.basename(tempDir), 'generated_notes.json');
+  fs.mkdirSync(path.join('/srv/bot/workspace', 'tmp', path.basename(tempDir)), { recursive: true });
+
+  fs.writeFileSync(path.join('/srv/bot/workspace', preparedRel), JSON.stringify({
+    book: 'PSA',
+    chapter: '1',
+    items: [
+      { id: 'has_at', reference: '1:1', sref: 'figs-metaphor', at_required: true, gl_quote: 'foo', issue_span_gl_quote: 'foo', ult_verse: 'foo bar', ust_verse: 'ust one', scope_mode: 'focused_span' },
+      { id: 'no_at', reference: '1:2', sref: 'figs-metaphor', at_required: true, gl_quote: 'baz', issue_span_gl_quote: 'baz', ult_verse: 'baz qux', ust_verse: 'ust two', scope_mode: 'focused_span' },
+    ],
+  }, null, 2));
+  fs.writeFileSync(path.join('/srv/bot/workspace', generatedRel), JSON.stringify({
+    has_at: 'Existing note text. Alternate translation: [already filled]',
+    no_at: 'Existing note text without an AT.',
+  }, null, 2));
+
+  const atCtx = JSON.parse(prepareATContext({ preparedJson: preparedRel, generatedJson: generatedRel }));
+  assert.equal(atCtx.item_count, 1);
+  assert.equal(atCtx.packets[0].id, 'no_at');
+});
+
 test('resolveGlQuotes preserves contiguous aligned spans instead of unioning repeated Hebrew tokens', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tn-tools-resolvegl-'));
   const relRoot = path.join('tmp', path.basename(tempDir));


### PR DESCRIPTION
## Summary

- `prepareATContext` now skips items whose stored note already contains an `Alternate translation:` clause — resume-to-fill-missing-ATs runs only generate ATs for notes still missing one
- `runATGeneration`'s apply loop strips any pre-existing trailing AT via `stripAlternateTranslation` before appending, making the operation unconditionally idempotent
- New test: `prepareATContext skips items whose generated note already contains an AT`

## Root cause (ZEC 3 incident)

A third resume run hit the `tn-quality-check` checkpoint and re-entered `runATGeneration` against a `generated_notes.json` already populated with ATs from a prior pass. Both `prepareATContext` and the apply loop had no idempotency checks, so 40 notes in the live `en_tn` output ended up with two `Alternate translation` clauses — sometimes identical, sometimes different (second was a fresh LLM call).

## Test plan

- [x] New unit test passes: `prepareATContext` skips already-ATed items
- [x] Full test suite: 142/143 pass (pre-existing unrelated failure on main)
- [ ] Post-merge: one-shot cleanup pass to strip the duplicate ATs from `tn_ZEC.tsv` on en_tn (tracked separately)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)