### PR TITLE
Add degraded alignment guard with one retry

### DIFF
--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -21,6 +21,7 @@ const { setPendingMerge } = require('./pending-merges');
 const { getCheckpoint, setCheckpoint, clearCheckpoint } = require('./pipeline-checkpoints');
 const { buildGenerateContext, buildUstContext } = require('./pipeline-context');
 const { publishAdminStatus } = require('./admin-status');
+const { validateAlignedUsfmCompleteness } = require('./workspace-tools/usfm-tools');
 
 const LOG_DIR = path.resolve(__dirname, '../logs');
 const REQUIRED_INITIAL_PIPELINE_FILES = [
@@ -282,6 +283,14 @@ function isFreshOutput(relPath, minMs) {
   } catch {
     return false;
   }
+}
+
+function summarizeAlignmentValidation({ book, chapter, ultCheck, ustCheck }) {
+  const parts = [];
+  const ref = `${book} ${chapter}`;
+  if (ultCheck) parts.push(`ULT: ${ultCheck.summary}`);
+  if (ustCheck) parts.push(`UST: ${ustCheck.summary}`);
+  return `${ref} — ${parts.join(' || ')}`;
 }
 
 async function generatePipeline(route, message) {
@@ -867,7 +876,7 @@ async function generatePipeline(route, message) {
       }
     }
 
-    await status(`Running **align-all-parallel** for ${book} ${ch}...`);
+      await status(`Running **align-all-parallel** for ${book} ${ch} at ${new Date().toISOString()}...`);
     setCheckpoint(checkpointRef, {
       state: 'running',
       success,
@@ -945,41 +954,116 @@ async function generatePipeline(route, message) {
         success: alignResult?.subtype === 'success', userId: message.sender_id,
       });
 
-      // Discover aligned output files by recency — handles any naming variant
-      const alignPat = new RegExp(`^${book}-0*${ch}(-.*)?-aligned\\.usfm$`);
       const needUlt = contentTypes.includes('ult');
       const needUst = contentTypes.includes('ust');
-      const alignedUltRel = needUlt ? discoverFreshOutput('output/AI-ULT', book, alignPat, chapterStart) : null;
-      const alignedUstRel = needUst ? discoverFreshOutput('output/AI-UST', book, alignPat, chapterStart) : null;
+      let alignedUltRel = null;
+      let alignedUstRel = null;
+      let alignmentValidated = false;
+      let alignmentTerminalFailure = false;
+      let finalValidationSummary = '';
 
-      if ((needUlt && !alignedUltRel) || (needUst && !alignedUstRel)) {
-        const missing = [needUlt && !alignedUltRel && 'ULT', needUst && !alignedUstRel && 'UST'].filter(Boolean).join(', ');
-        await status(`**align-all-parallel** failed for ${book} ${ch} \u2014 aligned ${missing} file(s) not found (${alignDuration}s)`);
+      for (let alignAttempt = 1; alignAttempt <= 2; alignAttempt++) {
+        // Discover aligned output files by recency — handles any naming variant
+        const alignPat = new RegExp(`^${book}-0*${ch}(-.*)?-aligned\\.usfm$`);
+        alignedUltRel = needUlt ? discoverFreshOutput('output/AI-ULT', book, alignPat, chapterStart) : null;
+        alignedUstRel = needUst ? discoverFreshOutput('output/AI-UST', book, alignPat, chapterStart) : null;
+
+        if ((needUlt && !alignedUltRel) || (needUst && !alignedUstRel)) {
+          const missing = [needUlt && !alignedUltRel && 'ULT', needUst && !alignedUstRel && 'UST'].filter(Boolean).join(', ');
+          await status(`**align-all-parallel** failed for ${book} ${ch} at ${new Date().toISOString()} — aligned ${missing} file(s) not found (${alignDuration}s)`);
+          fail++;
+          setCheckpoint(checkpointRef, {
+            state: 'failed',
+            success,
+            fail,
+            completedChapters,
+            current: { chapter: ch, skill: 'align-all-parallel', status: 'failed', errorKind: 'missing_output', outputStatus: 'missing' },
+            resume: { chapter: ch, skill: 'align-all-parallel' },
+          });
+          alignmentTerminalFailure = true;
+          break;
+        }
+        if ((needUlt && !isFreshOutput(alignedUltRel, chapterStart)) || (needUst && !isFreshOutput(alignedUstRel, chapterStart))) {
+          await status(`**align-all-parallel** failed for ${book} ${ch} at ${new Date().toISOString()} — aligned output appears stale from an earlier run`);
+          fail++;
+          setCheckpoint(checkpointRef, {
+            state: 'failed',
+            success,
+            fail,
+            completedChapters,
+            current: { chapter: ch, skill: 'align-all-parallel', status: 'failed', errorKind: 'stale_output', outputStatus: 'stale' },
+            resume: { chapter: ch, skill: 'align-all-parallel' },
+          });
+          alignmentTerminalFailure = true;
+          break;
+        }
+
+        const ultCheck = needUlt ? validateAlignedUsfmCompleteness({ alignedUsfm: alignedUltRel }) : null;
+        const ustCheck = needUst ? validateAlignedUsfmCompleteness({ alignedUsfm: alignedUstRel }) : null;
+        finalValidationSummary = summarizeAlignmentValidation({ book, chapter: ch, ultCheck, ustCheck });
+        const validationOk = (!ultCheck || ultCheck.ok) && (!ustCheck || ustCheck.ok);
+        if (validationOk) {
+          alignmentValidated = true;
+          break;
+        }
+
+        await status(`Alignment validation failed for ${book} ${ch} (attempt ${alignAttempt}/2): ${finalValidationSummary}`);
+        if (alignAttempt === 2) break;
+
+        // Retry once: remove detected outputs and rerun alignment
+        for (const rel of [alignedUltRel, alignedUstRel].filter(Boolean)) {
+          try { fs.unlinkSync(path.resolve(CSKILLBP_DIR, rel)); } catch (_) { /* ignore */ }
+        }
+        await status(`Retrying **align-all-parallel** for ${book} ${ch} after degraded alignment check...`);
+        const retryResult = await runClaude({
+          prompt: `${alignRef} ${alignTypeFlags}${genCtxFlag}`,
+          cwd: CSKILLBP_DIR,
+          model: model || 'sonnet',
+          betas,
+          skill: 'align-all-parallel',
+          tools: DEFAULT_RESTRICTED_TOOLS,
+          disallowedTools: ['Bash'],
+          disableLocalSettings: true,
+          forceNoAutoBashSandbox: true,
+          timeoutMs: alignTimeout,
+          onProgress: ({ turnCount, lastTool, elapsedMs, timedOut }) => {
+            const elapsed = Math.round(elapsedMs / 60000);
+            const suffix = timedOut ? ' — **timed out**, aborting' : '';
+            return status(`Still aligning **${book} ${ch}** retry — ${elapsed}min, ${turnCount} tool calls${lastTool ? `, last: \`${lastTool}\`` : ''}${suffix}`);
+          },
+        });
+        if (!retryResult || retryResult.subtype !== 'success') {
+          finalValidationSummary = !retryResult
+            ? 'retry timed out or was aborted (no result returned)'
+            : (retryResult.error || retryResult.result || `retry non-success subtype: "${retryResult.subtype}"`);
+          break;
+        }
+      }
+
+      if (alignmentTerminalFailure) continue;
+
+      if (!alignmentValidated) {
+        await status(`**align-all-parallel** failed for ${book} ${ch} at ${new Date().toISOString()} — degraded alignment (${finalValidationSummary})`);
         fail++;
         setCheckpoint(checkpointRef, {
           state: 'failed',
           success,
           fail,
           completedChapters,
-          current: { chapter: ch, skill: 'align-all-parallel', status: 'failed', errorKind: 'missing_output', outputStatus: 'missing' },
+          current: {
+            chapter: ch,
+            skill: 'align-all-parallel',
+            status: 'failed',
+            errorKind: 'degraded_alignment',
+            outputStatus: 'degraded',
+            validationSummary: finalValidationSummary,
+          },
           resume: { chapter: ch, skill: 'align-all-parallel' },
         });
         continue;
       }
-      if ((needUlt && !isFreshOutput(alignedUltRel, chapterStart)) || (needUst && !isFreshOutput(alignedUstRel, chapterStart))) {
-        await status(`**align-all-parallel** failed for ${book} ${ch} \u2014 aligned output appears stale from an earlier run`);
-        fail++;
-        setCheckpoint(checkpointRef, {
-          state: 'failed',
-          success,
-          fail,
-          completedChapters,
-          current: { chapter: ch, skill: 'align-all-parallel', status: 'failed', errorKind: 'stale_output', outputStatus: 'stale' },
-          resume: { chapter: ch, skill: 'align-all-parallel' },
-        });
-        continue;
-      }
-      await status(`**align-all-parallel** done for ${book} ${ch} (${alignDuration}s)`);
+
+      await status(`**align-all-parallel** done for ${book} ${ch} (${alignDuration}s) — ${finalValidationSummary}`);
 
       // Collect for Phase 2 insertion (must be inside try block — alignedUltRel/alignedUstRel are block-scoped)
       if (!completedChapters.some((c) => c.ch === ch)) {

--- a/src/workspace-tools/usfm-tools.js
+++ b/src/workspace-tools/usfm-tools.js
@@ -615,6 +615,71 @@ function summarizeAlignedUsfmMarkupFindings(findings, maxExamples = 5) {
     .join('; ');
 }
 
+function validateAlignedUsfmCompleteness({
+  alignedUsfm,
+  minVerseCoverage = 0.6,
+  minWordMarkers = 1,
+  maxExamples = 5,
+}) {
+  const filePath = path.resolve(CSKILLBP_DIR, alignedUsfm);
+  if (!fs.existsSync(filePath)) {
+    return {
+      ok: false,
+      summary: `Aligned USFM missing: ${alignedUsfm}`,
+      reasons: ['missing_file'],
+      malformed: null,
+      metrics: { verseCount: 0, alignedVerseCount: 0, verseCoverage: 0, wordMarkerCount: 0, zalnStartCount: 0 },
+      examples: [],
+    };
+  }
+
+  const malformed = validateAlignedUsfmMarkup({ alignedUsfm, maxExamples });
+  const content = fs.readFileSync(filePath, 'utf8');
+  const verses = [];
+  const lines = content.split('\n');
+  let chapter = null;
+
+  for (const line of lines) {
+    const chMatch = line.match(/^\\c\s+(\d+)/);
+    if (chMatch) chapter = chMatch[1];
+    const verseMatch = line.match(/\\v\s+(\d+)/);
+    if (!verseMatch) continue;
+    const verse = verseMatch[1];
+    const ref = chapter ? `${chapter}:${verse}` : `?:${verse}`;
+    const hasZaln = /\\zaln-s\b/.test(line);
+    const wordCount = (line.match(/\\w\s+/g) || []).length;
+    verses.push({ ref, hasZaln, wordCount });
+  }
+
+  const verseCount = verses.length;
+  const alignedVerseCount = verses.filter((v) => v.hasZaln).length;
+  const verseCoverage = verseCount > 0 ? alignedVerseCount / verseCount : 0;
+  const wordMarkerCount = (content.match(/\\w\s+/g) || []).length;
+  const zalnStartCount = (content.match(/\\zaln-s\b/g) || []).length;
+  const missingVerseExamples = verses.filter((v) => !v.hasZaln).slice(0, maxExamples).map((v) => v.ref);
+
+  const reasons = [];
+  if (!malformed.ok) reasons.push('malformed_markup');
+  if (verseCount > 0 && verseCoverage < minVerseCoverage) reasons.push('low_verse_coverage');
+  if (wordMarkerCount < minWordMarkers || zalnStartCount === 0) reasons.push('low_marker_density');
+
+  const summaryParts = [];
+  summaryParts.push(
+    `coverage=${alignedVerseCount}/${verseCount} verses (${(verseCoverage * 100).toFixed(1)}%), markers: \\zaln-s=${zalnStartCount}, \\w=${wordMarkerCount}`
+  );
+  if (!malformed.ok) summaryParts.push(`malformed: ${summarizeAlignedUsfmMarkupFindings(malformed.findings, maxExamples)}`);
+  if (missingVerseExamples.length > 0) summaryParts.push(`no-alignment verses: ${missingVerseExamples.join(', ')}`);
+
+  return {
+    ok: reasons.length === 0,
+    summary: `${reasons.length === 0 ? 'Alignment quality OK' : 'Alignment quality degraded'} for ${alignedUsfm} — ${summaryParts.join(' | ')}`,
+    reasons,
+    malformed,
+    metrics: { verseCount, alignedVerseCount, verseCoverage, wordMarkerCount, zalnStartCount },
+    examples: missingVerseExamples,
+  };
+}
+
 function countWords(words) {
   const counts = {};
   for (const w of words) {
@@ -932,6 +997,7 @@ module.exports = {
   validateAlignmentJson,
   validateAlignedUsfmMarkup,
   summarizeAlignedUsfmMarkupFindings,
+  validateAlignedUsfmCompleteness,
   validateUltBrackets,
   checkUltVoiceMismatch,
 };

--- a/test/api-runner-provider-regressions.test.js
+++ b/test/api-runner-provider-regressions.test.js
@@ -99,6 +99,44 @@ test('aligned USFM markup validator detects malformed trailing word markers and 
   }
 });
 
+test('aligned USFM completeness validator flags low alignment coverage with concrete verse examples', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aligned-completeness-'));
+  const oldBaseDir = process.env.CSKILLBP_DIR;
+  process.env.CSKILLBP_DIR = tempDir;
+
+  const usfmToolsPath = require.resolve('../src/workspace-tools/usfm-tools');
+  delete require.cache[usfmToolsPath];
+  const { validateAlignedUsfmCompleteness: validate } = require('../src/workspace-tools/usfm-tools');
+
+  try {
+    const lowRel = 'output/AI-ULT/ISA/ISA-52-aligned.usfm';
+    const okRel = 'output/AI-ULT/ISA/ISA-53-aligned.usfm';
+    const lowAbs = path.join(tempDir, lowRel);
+    const okAbs = path.join(tempDir, okRel);
+    fs.mkdirSync(path.dirname(lowAbs), { recursive: true });
+    fs.writeFileSync(
+      lowAbs,
+      '\\id ISA\n\\c 52\n\\v 1 \\w one|x\\w* \\w two|x\\w* \\w three|x\\w*\n\\v 2 plain text with no markers\n'
+    );
+    fs.writeFileSync(
+      okAbs,
+      '\\id ISA\n\\c 53\n\\v 1 \\zaln-s |x-strong="H1"\\*\\w one|x\\w* \\w two|x\\w* \\w three|x\\w* \\w four|x\\w* \\w five|x\\w* \\w six|x\\w* \\w seven|x\\w* \\w eight|x\\w* \\w nine|x\\w* \\w ten|x\\w*\\zaln-e\\*\n'
+    );
+
+    const low = validate({ alignedUsfm: lowRel });
+    const ok = validate({ alignedUsfm: okRel });
+
+    assert.equal(low.ok, false);
+    assert.ok(low.reasons.includes('low_verse_coverage'));
+    assert.match(low.summary, /no-alignment verses: 52:1, 52:2|no-alignment verses: 52:2/);
+    assert.equal(ok.ok, true);
+  } finally {
+    if (oldBaseDir == null) delete process.env.CSKILLBP_DIR;
+    else process.env.CSKILLBP_DIR = oldBaseDir;
+    delete require.cache[usfmToolsPath];
+  }
+});
+
 test('openai native alignment finalizer retries and degrades instead of failing on malformed output', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openai-native-align-degraded-'));
   const oldBaseDir = process.env.CSKILLBP_DIR;

--- a/test/generate-pipeline-early-exit.test.js
+++ b/test/generate-pipeline-early-exit.test.js
@@ -278,3 +278,85 @@ test('generatePipeline does not apply initial-pipeline guardrails to direct ULT-
     harness.cleanup();
   }
 });
+
+test('generatePipeline retries alignment once and fails with degraded_alignment when quality stays low', async () => {
+  let alignCalls = 0;
+  const harness = createHarness({
+    runClaudeImpl: async ({ options, tempDir }) => {
+      if (options.skill === 'initial-pipeline') {
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA'), { recursive: true });
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-UST', 'ISA'), { recursive: true });
+        fs.mkdirSync(path.join(tempDir, 'output', 'issues', 'ISA'), { recursive: true });
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA', 'ISA-52.usfm'), '\\id ISA\n\\c 52\n\\v 1 ult\n');
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-UST', 'ISA', 'ISA-52.usfm'), '\\id ISA\n\\c 52\n\\v 1 ust\n');
+        fs.writeFileSync(path.join(tempDir, 'output', 'issues', 'ISA', 'ISA-52.tsv'), 'Reference\tID\nISA 52:1\ta1b2\n');
+        return { subtype: 'success', usage: {}, total_cost_usd: 0 };
+      }
+      if (options.skill === 'align-all-parallel') {
+        alignCalls++;
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA'), { recursive: true });
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-UST', 'ISA'), { recursive: true });
+        const degraded = '\\id ISA\n\\c 52\n\\v 1 \\w one|x\\w* \\w two|x\\w* \\w three|x\\w* \\w four|x\\w* \\w five|x\\w* \\w six|x\\w* \\w seven|x\\w* \\w eight|x\\w* \\w nine|x\\w* \\w ten|x\\w*\n';
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA', 'ISA-52-aligned.usfm'), degraded);
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-UST', 'ISA', 'ISA-52-aligned.usfm'), degraded);
+        return { subtype: 'success', usage: {}, total_cost_usd: 0 };
+      }
+      return { subtype: 'success', usage: {}, total_cost_usd: 0 };
+    },
+  });
+
+  try {
+    await harness.generatePipeline(
+      { _synthetic: true, _book: 'ISA', _startChapter: 52, _endChapter: 52, skill: 'initial-pipeline', operations: 6 },
+      buildMessage('generate isa 52', { sender_id: 7 })
+    );
+
+    assert.equal(alignCalls, 2);
+    assert.ok(harness.checkpoints.some((patch) => patch.current?.errorKind === 'degraded_alignment'));
+    assert.ok(harness.readStatusTexts().some((text) => text.includes('Retrying **align-all-parallel**')));
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('generatePipeline reruns align-all-parallel when first post-align validation fails', async () => {
+  let alignCalls = 0;
+  const harness = createHarness({
+    runClaudeImpl: async ({ options, tempDir }) => {
+      if (options.skill === 'initial-pipeline') {
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA'), { recursive: true });
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-UST', 'ISA'), { recursive: true });
+        fs.mkdirSync(path.join(tempDir, 'output', 'issues', 'ISA'), { recursive: true });
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA', 'ISA-52.usfm'), '\\id ISA\n\\c 52\n\\v 1 ult\n');
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-UST', 'ISA', 'ISA-52.usfm'), '\\id ISA\n\\c 52\n\\v 1 ust\n');
+        fs.writeFileSync(path.join(tempDir, 'output', 'issues', 'ISA', 'ISA-52.tsv'), 'Reference\tID\nISA 52:1\ta1b2\n');
+        return { subtype: 'success', usage: {}, total_cost_usd: 0 };
+      }
+      if (options.skill === 'align-all-parallel') {
+        alignCalls++;
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA'), { recursive: true });
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-UST', 'ISA'), { recursive: true });
+        const degraded = '\\id ISA\n\\c 52\n\\v 1 plain text no milestones\n';
+        const good = '\\id ISA\n\\c 52\n\\v 1 \\zaln-s |x-strong="H1" x-content="א"\\*\\w Joshua|x-occurrence="1" x-occurrences="1"\\w*\\zaln-e\\*\n';
+        const out = alignCalls === 1 ? degraded : good;
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA', 'ISA-52-aligned.usfm'), out);
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-UST', 'ISA', 'ISA-52-aligned.usfm'), out);
+        return { subtype: 'success', usage: {}, total_cost_usd: 0 };
+      }
+      return { subtype: 'success', usage: {}, total_cost_usd: 0 };
+    },
+  });
+
+  try {
+    await harness.generatePipeline(
+      { _synthetic: true, _book: 'ISA', _startChapter: 52, _endChapter: 52, skill: 'initial-pipeline', operations: 6 },
+      buildMessage('generate isa 52', { sender_id: 7 })
+    );
+
+    assert.equal(alignCalls, 2);
+    assert.ok(harness.readStatusTexts().some((text) => text.includes('Alignment validation failed for ISA 52 (attempt 1/2)')));
+    assert.ok(harness.readStatusTexts().some((text) => text.includes('Retrying **align-all-parallel** for ISA 52')));
+  } finally {
+    harness.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary\n- add aligned USFM completeness validator with markup + coverage checks\n- enforce post-alignment validation in generate pipeline\n- retry align-all-parallel once on degraded output, then fail with degraded_alignment\n- improve status/checkpoint observability with validation summaries\n- add regression tests for validator and retry/failure flow\n\n## Verification\n- npm test