### PR TITLE
fix: classify terminal 0-failure summaries as success

### DIFF
--- a/src/admin-status.js
+++ b/src/admin-status.js
@@ -38,6 +38,14 @@ function inferPhase(message) {
 
 function inferSeverity(message) {
   const plain = stripMarkup(message).toLowerCase();
+  const terminalSummary = plain.match(/\b(\d+)\s+succeeded\b.*\b(\d+)\s+failed\b/);
+  if (terminalSummary) {
+    const failedCount = Number(terminalSummary[2]);
+    return failedCount === 0 ? 'success' : 'error';
+  }
+  if (/\b(done|complete|completed|ok|merged to master|restored)\b/.test(plain) && /\b0\s+failed\b/.test(plain)) {
+    return 'success';
+  }
   if (/\b(failed|error|aborting|abort)\b/.test(plain)) return 'error';
   if (/\b(done|complete|completed|ok|merged to master|restored)\b/.test(plain)) return 'success';
   if (/\b(paused|waiting|deferred|skipped|missing|blocked|could not|invalid|retry window exhausted)\b/.test(plain)) return 'warn';

--- a/test/admin-status.test.js
+++ b/test/admin-status.test.js
@@ -41,3 +41,14 @@ test('publishAdminStatus persists events and readAdminStatus returns newest firs
   }
 });
 
+test('inferSeverity treats "succeeded with 0 failed" terminal summaries as success', () => {
+  const { inferSeverity } = require('../src/admin-status');
+  const severity = inferSeverity('Generation complete for **ZEC 4-4**: 1 succeeded, 0 failed.');
+  assert.equal(severity, 'success');
+});
+
+test('inferSeverity treats terminal failures as error', () => {
+  const { inferSeverity } = require('../src/admin-status');
+  assert.equal(inferSeverity('Notes pipeline for PSA 39 failed — all 1 chapter(s) had errors.'), 'error');
+  assert.equal(inferSeverity('Generation complete for **ZEC 4-4**: 0 succeeded, 1 failed.'), 'error');
+});


### PR DESCRIPTION
## Summary\n- fix admin status severity inference for terminal summaries that include both success and failure counts\n- classify messages like '1 succeeded, 0 failed' as success\n- add regression tests for success and failure terminal summary strings\n\n## Verification\n- npm test