### PR TITLE
fix: use in-place Fly deploy strategy in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,6 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy
-        run: flyctl deploy --remote-only
+        run: flyctl deploy --remote-only --strategy immediate
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary\n- change deploy workflow to use \n- avoids replacement-machine volume attach failures for \n\n## Why\nRolling replacement requires unattached spare volumes; immediate strategy updates in place on existing attached volume.