### PR TITLE
Force Claude OAuth for SDK flows

### DIFF
--- a/resources/claude-skills/issue-report/SKILL.md
+++ b/resources/claude-skills/issue-report/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: issue-report
+description: Classify a proofreader feedback report into repo-scoped GitHub issue plans for bp-assistant and bp-assistant-skills. Return JSON only.
+---
+
+# Issue Report Classifier
+
+You classify one user feedback report for a Bible translation AI pipeline.
+
+The user prompt contains structured context such as reporter name, message id, stream/topic, attachments, image URLs, and the freeform feedback text.
+
+## Repository ownership
+
+1. **bp-assistant** (app repo): Zulip bot infrastructure, message routing, pipeline dispatch, Docker/Fly setup, auth, Claude SDK usage, context packaging, tool/MCP exposure, preprocessing, post-processing, chunking, merging, and infrastructure behavior.
+2. **bp-assistant-skills** (skills repo): AI behavior and prompts, translation note writing, quality checks, template compliance, alternate translation handling, note formatting, split snippets, issue identification, and TN-writing guidance.
+
+## Output contract
+
+Return ONLY valid JSON in this exact shape:
+
+```json
+{
+  "complaints": [
+    {
+      "id": "c1",
+      "summary": "one atomic complaint from the report",
+      "evidence": ["short direct quote or paraphrase from the report"],
+      "likely_layers": ["bp-assistant"]
+    }
+  ],
+  "ownership": {
+    "repositories": ["bp-assistant"],
+    "primary_repo": "bp-assistant",
+    "secondary_repo": null,
+    "rationale": "short explanation of why these repo assignments fit"
+  },
+  "issues": [
+    {
+      "id": "i1",
+      "repo": "bp-assistant",
+      "complaint_ids": ["c1"],
+      "title": "concise issue title (under 72 chars)",
+      "body": "well-formatted GitHub issue body in markdown with sections: ## Summary, ## Steps to Reproduce (if applicable), ## Expected Behavior, ## Actual Behavior, ## Reporter",
+      "labels": ["bug"]
+    }
+  ]
+}
+```
+
+## Rules
+
+- First decompose the report into atomic complaints. Do not skip this step.
+- Complaints stay atomic, but issue creation stays repo-scoped: return at most one issue per repo.
+- When multiple complaints belong to the same repo, combine them into a single well-structured issue and include all relevant complaint_ids.
+- Every issue must reference one or more complaint_ids from the complaints array.
+- Use repository ownership based on root cause, not shallow keyword matching.
+- Open issues in both repos only when the report plausibly spans both layers.
+- Keep repo targets limited to `bp-assistant` and `bp-assistant-skills`.
+- When both repos are implicated, choose a `primary_repo` and `secondary_repo`.
+- Each repo listed in `ownership.repositories` must appear in exactly one issue.
+- Return JSON only. No markdown fences. No prose before or after the JSON.

--- a/src/anthropic-env.js
+++ b/src/anthropic-env.js
@@ -1,0 +1,29 @@
+const ANTHROPIC_API_KEY_ALIAS = 'BP_ANTHROPIC_API_KEY';
+
+function getAnthropicApiKey() {
+  const direct = String(process.env.ANTHROPIC_API_KEY || '').trim();
+  if (direct) return direct;
+
+  const aliased = String(process.env[ANTHROPIC_API_KEY_ALIAS] || '').trim();
+  return aliased || null;
+}
+
+function prioritizeClaudeOauth() {
+  const oauthToken = String(process.env.CLAUDE_CODE_OAUTH_TOKEN || '').trim();
+  const apiKey = String(process.env.ANTHROPIC_API_KEY || '').trim();
+
+  if (apiKey && !process.env[ANTHROPIC_API_KEY_ALIAS]) {
+    process.env[ANTHROPIC_API_KEY_ALIAS] = apiKey;
+  }
+
+  if (oauthToken && apiKey) {
+    delete process.env.ANTHROPIC_API_KEY;
+    console.log('[auth] Removed ambient ANTHROPIC_API_KEY so Claude SDK uses OAuth token');
+  }
+}
+
+module.exports = {
+  ANTHROPIC_API_KEY_ALIAS,
+  getAnthropicApiKey,
+  prioritizeClaudeOauth,
+};

--- a/src/auth-refresh.js
+++ b/src/auth-refresh.js
@@ -9,6 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 const https = require('https');
+const { prioritizeClaudeOauth } = require('./anthropic-env');
 
 const CREDENTIALS_PATH = path.join(
   process.env.CLAUDE_CONFIG_DIR || path.join(require('os').homedir(), '.claude'),
@@ -45,6 +46,7 @@ async function ensureFreshToken() {
       if (token) process.env.CLAUDE_CODE_OAUTH_TOKEN = token;
     } catch (_) {}
   }
+  prioritizeClaudeOauth();
   if (process.env.CLAUDE_CODE_OAUTH_TOKEN) {
     return true;
   }

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { ANTHROPIC_API_KEY_ALIAS } = require('./anthropic-env');
 
 function readSecretFile(filePath) {
   if (!filePath) return null;
@@ -26,6 +27,10 @@ function readSecret(name, envFallback) {
 
   if (envFallback && process.env[envFallback]) {
     return process.env[envFallback];
+  }
+
+  if (envFallback === 'ANTHROPIC_API_KEY' && process.env[ANTHROPIC_API_KEY_ALIAS]) {
+    return process.env[ANTHROPIC_API_KEY_ALIAS];
   }
 
   return null;

--- a/src/workspace-tools/optimize-tools.js
+++ b/src/workspace-tools/optimize-tools.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const Anthropic = require('@anthropic-ai/sdk');
 const { resolveProviderModel } = require('../api-runner/provider-config');
+const { getAnthropicApiKey } = require('../anthropic-env');
 
 const CSKILLBP_DIR = process.env.CSKILLBP_DIR || '/srv/bot/workspace';
 
@@ -36,7 +37,7 @@ async function optimizeIssuesResolved() {
     }
   }
 
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const apiKey = getAnthropicApiKey();
   if (!apiKey) {
     return 'Skipped: ANTHROPIC_API_KEY not set';
   }

--- a/test/anthropic-env.test.js
+++ b/test/anthropic-env.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ANTHROPIC_API_KEY_ALIAS, getAnthropicApiKey, prioritizeClaudeOauth } = require('../src/anthropic-env');
+const { readSecret } = require('../src/secrets');
+
+function snapshotEnv(keys) {
+  return Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+}
+
+function restoreEnv(snapshot) {
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value == null) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+test('prioritizeClaudeOauth removes ambient Anthropic API key when OAuth token is present', () => {
+  const keys = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY', ANTHROPIC_API_KEY_ALIAS];
+  const before = snapshotEnv(keys);
+
+  try {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-token';
+    process.env.ANTHROPIC_API_KEY = 'anthropic-key';
+    delete process.env[ANTHROPIC_API_KEY_ALIAS];
+
+    prioritizeClaudeOauth();
+
+    assert.equal(process.env.ANTHROPIC_API_KEY, undefined);
+    assert.equal(process.env[ANTHROPIC_API_KEY_ALIAS], 'anthropic-key');
+    assert.equal(getAnthropicApiKey(), 'anthropic-key');
+  } finally {
+    restoreEnv(before);
+  }
+});
+
+test('readSecret falls back to quarantined Anthropic API key alias for explicit API paths', () => {
+  const keys = ['ANTHROPIC_API_KEY', ANTHROPIC_API_KEY_ALIAS];
+  const before = snapshotEnv(keys);
+
+  try {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env[ANTHROPIC_API_KEY_ALIAS] = 'anthropic-key';
+
+    assert.equal(readSecret('anthropic_api_key', 'ANTHROPIC_API_KEY'), 'anthropic-key');
+  } finally {
+    restoreEnv(before);
+  }
+});


### PR DESCRIPTION
Move issue-report onto the Claude SDK skill path, quarantine the Anthropic API key for explicit API use only, and add regression coverage for auth precedence and SDK-backed issue filing.

#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
