### PR TITLE
Fix Fly redeploy volume constraint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,6 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy
-        run: flyctl deploy --remote-only --strategy immediate
+        run: flyctl deploy --remote-only --strategy immediate --ha=false
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
Deploy workflow now uses --ha=false to avoid requiring an unattached workspace_vol when replacing a machine in this single-volume app.

## Why
Recent deploy runs failed with: "requires an unattached workspace_vol volume".

## Validation
- Updated .github/workflows/deploy.yml deploy command only.
- No app code changes.