### PR TITLE
fix: emit router-dispatch failures to admin-status for auto intake

### DIFF
--- a/plans/router-failure-intake-investigation-2026-04-29.md
+++ b/plans/router-failure-intake-investigation-2026-04-29.md
@@ -1,14 +1,8 @@
-# Router Failure Intake Investigation (2026-04-29)
+# Router Failure Intake Investigation
 
-## Incident
-- Timestamp: `2026-04-29T15:53:59.737Z`
-- Scope: `ZEC 5`
-- Log line: `Pipeline "write-notes" failed: ctx is not defined`
-
-## What Happened
-- The `write-notes` run completed `tn-quality-check` successfully.
-- Before `door43-push`, `notes-pipeline` hit a runtime error from an out-of-scope `ctx` reference near final canonical quote sync.
-- The router catch logged the failure, but the failure was not emitted as an admin-status event.
+## Problem
+- Router dispatch failures were being logged to stderr only.
+- Those failures were not emitted as structured admin-status events.
 
 ## Why Auto Self-Analyze Missed It
 1. Router dispatch failures were only logged to stderr.
@@ -22,4 +16,3 @@
 - Added router-level failure publication (`source=router`, `phase=router-dispatch`, `severity=error`).
 - Added pipeline type mapping and scope inference for router dispatch failures.
 - Added regression test to enforce admin-status event emission when `runPipeline` rejects.
-- Added selector test coverage for router-dispatch failures to ensure they are eligible and deduped.

--- a/plans/router-failure-intake-investigation-2026-04-29.md
+++ b/plans/router-failure-intake-investigation-2026-04-29.md
@@ -1,0 +1,25 @@
+# Router Failure Intake Investigation (2026-04-29)
+
+## Incident
+- Timestamp: `2026-04-29T15:53:59.737Z`
+- Scope: `ZEC 5`
+- Log line: `Pipeline "write-notes" failed: ctx is not defined`
+
+## What Happened
+- The `write-notes` run completed `tn-quality-check` successfully.
+- Before `door43-push`, `notes-pipeline` hit a runtime error from an out-of-scope `ctx` reference near final canonical quote sync.
+- The router catch logged the failure, but the failure was not emitted as an admin-status event.
+
+## Why Auto Self-Analyze Missed It
+1. Router dispatch failures were only logged to stderr.
+   - `router.js` catch did not publish structured failure events via `publishAdminStatus`.
+   - The pipeline-failure selector consumes `admin-status.jsonl`, so router-only logs were invisible to it.
+2. Pipeline failure handler is mode-gated in Fly automation.
+   - Dedicated flow runs only when `PIPELINE_FAILURE_RUN_MODE=failure-handler`.
+   - If running in hourly issue mode, failures are not processed by the dedicated failure-handler path.
+
+## Fix Implemented In This Branch
+- Added router-level failure publication (`source=router`, `phase=router-dispatch`, `severity=error`).
+- Added pipeline type mapping and scope inference for router dispatch failures.
+- Added regression test to enforce admin-status event emission when `runPipeline` rejects.
+- Added selector test coverage for router-dispatch failures to ensure they are eligible and deduped.

--- a/src/router.js
+++ b/src/router.js
@@ -11,6 +11,7 @@ const { listCheckpoints } = require('./pipeline-checkpoints');
 const { resumeInsertion } = require('./insertion-resume');
 const { normalizeBookName, isValidBook } = require('./pipeline-utils');
 const { isTransientOutageError } = require('./claude-runner');
+const { publishAdminStatus } = require('./admin-status');
 
 // In-memory pending confirmations for stream messages
 const pendingConfirmations = new Map();
@@ -399,6 +400,51 @@ function getPipelineType(route) {
   return null;
 }
 
+function getAdminPipelineType(route) {
+  if (route?.type === 'sdk') return 'generate';
+  if (route?.type === 'notes') return 'notes';
+  if (route?.type === 'tqs') return 'tqs';
+  if (route?.type === 'issue-report') return 'issue-report';
+  return 'system';
+}
+
+function inferRouteScope(route, message) {
+  if (route?._book && Number.isFinite(route?._startChapter) && Number.isFinite(route?._endChapter)) {
+    const start = route._startChapter;
+    const end = route._endChapter;
+    const scope = start === end ? `${route._book} ${start}` : `${route._book} ${start}-${end}`;
+    if (Number.isFinite(route?._verseStart) && Number.isFinite(route?._verseEnd) && start === end) {
+      return `${route._book} ${start}:${route._verseStart}-${route._verseEnd}`;
+    }
+    return scope;
+  }
+
+  const content = String(message?.content || '');
+  const match = content.match(/\b([1-3]?[A-Za-z]{2,})\s+(\d+(?::\d+(?:[-–—]\d+)?)?(?:\s*[-–—]\s*\d+)?)\b/);
+  if (!match) return null;
+  const book = normalizeBookName(match[1]);
+  if (!book) return null;
+  return `${book} ${String(match[2]).replace(/\s+/g, '')}`;
+}
+
+async function publishRouterFailure(route, message, err) {
+  const routeName = route?.name || 'unknown';
+  const errorMessage = err?.message || String(err);
+  const statusMessage = `Pipeline "${routeName}" failed: ${errorMessage}`;
+  try {
+    await publishAdminStatus({
+      source: 'router',
+      pipelineType: getAdminPipelineType(route),
+      scope: inferRouteScope(route, message),
+      phase: 'router-dispatch',
+      severity: 'error',
+      message: statusMessage,
+    });
+  } catch (statusErr) {
+    console.error(`[router] Failed to publish admin status for pipeline failure: ${statusErr.message}`);
+  }
+}
+
 function getResumeCheckpoint(route, sessionKey, captures) {
   const pipelineType = getPipelineType(route);
   if (!pipelineType) return null;
@@ -778,7 +824,10 @@ function firePipeline(route, message) {
   }
 
   runPipeline(route, message)
-    .catch(err => console.error(`[router] Pipeline "${route.name}" failed: ${err.message}`))
+    .catch(async (err) => {
+      console.error(`[router] Pipeline "${route.name}" failed: ${err.message}`);
+      await publishRouterFailure(route, message, err);
+    })
     .finally(() => {
       if (keys) {
         for (const k of keys) activePipelines.delete(k);

--- a/test/router-failure-admin-status.test.js
+++ b/test/router-failure-admin-status.test.js
@@ -1,0 +1,139 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function installStub(modulePath, exportsValue) {
+  require.cache[modulePath] = {
+    id: modulePath,
+    filename: modulePath,
+    loaded: true,
+    exports: exportsValue,
+  };
+}
+
+test('router publishes admin-status event when pipeline dispatch throws', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'router-failure-status-'));
+  const oldStatusFile = process.env.ADMIN_STATUS_FILE;
+  process.env.ADMIN_STATUS_FILE = path.join(tempDir, 'admin-status.jsonl');
+
+  const routerPath = require.resolve('../src/router');
+  const configPath = require.resolve('../src/config');
+  const pipelineRunnerPath = require.resolve('../src/pipeline-runner');
+  const zulipPath = require.resolve('../src/zulip-client');
+  const sessionStorePath = require.resolve('../src/session-store');
+  const verseCountsPath = require.resolve('../src/verse-counts');
+  const intentClassifierPath = require.resolve('../src/intent-classifier');
+  const usageTrackerPath = require.resolve('../src/usage-tracker');
+  const pendingMergesPath = require.resolve('../src/pending-merges');
+  const checkpointsPath = require.resolve('../src/pipeline-checkpoints');
+  const insertionResumePath = require.resolve('../src/insertion-resume');
+  const pipelineUtilsPath = require.resolve('../src/pipeline-utils');
+  const claudeRunnerPath = require.resolve('../src/claude-runner');
+
+  delete require.cache[routerPath];
+
+  installStub(configPath, {
+    adminUserId: 100,
+    authorizedUserIds: [100],
+    unauthorizedReply: 'nope',
+    dmDefaultPipeline: null,
+    routes: [
+      {
+        name: 'write-notes',
+        match: '/write notes(?:\\s+for)?\\s+(\\w+)\\s+(\\d+)/i',
+        type: 'notes',
+        reply: false,
+      },
+    ],
+  });
+  installStub(pipelineRunnerPath, {
+    runPipeline: async () => {
+      throw new Error('ctx is not defined');
+    },
+  });
+  installStub(zulipPath, {
+    sendMessage: async () => {},
+    sendDM: async () => {},
+    addReaction: async () => {},
+    removeReaction: async () => {},
+  });
+  installStub(sessionStorePath, {
+    getSession: () => null,
+    clearSession: () => {},
+    hasActiveStreamSession: () => false,
+  });
+  installStub(verseCountsPath, {
+    getTotalVerses: () => 1,
+    getChapterCount: () => 1,
+  });
+  installStub(intentClassifierPath, {
+    classifyIntent: async () => ({ intent: 'unknown' }),
+  });
+  installStub(usageTrackerPath, {
+    preflightCheck: async () => ({ decision: 'allow', estimate: {} }),
+    estimateTokens: () => 0,
+  });
+  installStub(pendingMergesPath, {
+    getPendingMerge: () => null,
+    clearPendingMerge: () => {},
+    getAllPendingMerges: () => [],
+  });
+  installStub(checkpointsPath, {
+    getCheckpoint: () => null,
+    setCheckpoint: () => {},
+    clearCheckpoint: () => {},
+    listCheckpoints: () => [],
+  });
+  installStub(insertionResumePath, {
+    resumeInsertion: async () => {},
+  });
+  installStub(pipelineUtilsPath, {
+    normalizeBookName: (value) => String(value || '').trim().toUpperCase().slice(0, 3),
+    isValidBook: () => true,
+  });
+  installStub(claudeRunnerPath, {
+    isTransientOutageError: () => false,
+  });
+
+  try {
+    const { routeMessage } = require('../src/router');
+    await routeMessage({
+      id: 9001,
+      type: 'private',
+      sender_id: 100,
+      sender_full_name: 'Admin User',
+      content: 'write notes for zech 5',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.equal(fs.existsSync(process.env.ADMIN_STATUS_FILE), true);
+    const events = fs.readFileSync(process.env.ADMIN_STATUS_FILE, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    const latest = events[events.length - 1];
+    assert.equal(latest.pipelineType, 'notes');
+    assert.equal(latest.phase, 'router-dispatch');
+    assert.equal(latest.severity, 'error');
+    assert.equal(latest.scope, 'ZEC 5');
+    assert.match(latest.message, /ctx is not defined/i);
+  } finally {
+    delete require.cache[routerPath];
+    delete require.cache[configPath];
+    delete require.cache[pipelineRunnerPath];
+    delete require.cache[zulipPath];
+    delete require.cache[sessionStorePath];
+    delete require.cache[verseCountsPath];
+    delete require.cache[intentClassifierPath];
+    delete require.cache[usageTrackerPath];
+    delete require.cache[pendingMergesPath];
+    delete require.cache[checkpointsPath];
+    delete require.cache[insertionResumePath];
+    delete require.cache[pipelineUtilsPath];
+    delete require.cache[claudeRunnerPath];
+    if (oldStatusFile == null) delete process.env.ADMIN_STATUS_FILE;
+    else process.env.ADMIN_STATUS_FILE = oldStatusFile;
+  }
+});

--- a/test/router-failure-admin-status.test.js
+++ b/test/router-failure-admin-status.test.js
@@ -50,7 +50,7 @@ test('router publishes admin-status event when pipeline dispatch throws', async 
   });
   installStub(pipelineRunnerPath, {
     runPipeline: async () => {
-      throw new Error('ctx is not defined');
+      throw new Error('simulated pipeline failure');
     },
   });
   installStub(zulipPath, {
@@ -104,7 +104,7 @@ test('router publishes admin-status event when pipeline dispatch throws', async 
       type: 'private',
       sender_id: 100,
       sender_full_name: 'Admin User',
-      content: 'write notes for zech 5',
+      content: 'write notes for psa 39',
     });
 
     await new Promise((resolve) => setTimeout(resolve, 25));
@@ -117,8 +117,8 @@ test('router publishes admin-status event when pipeline dispatch throws', async 
     assert.equal(latest.pipelineType, 'notes');
     assert.equal(latest.phase, 'router-dispatch');
     assert.equal(latest.severity, 'error');
-    assert.equal(latest.scope, 'ZEC 5');
-    assert.match(latest.message, /ctx is not defined/i);
+    assert.equal(latest.scope, 'PSA 39');
+    assert.match(latest.message, /simulated pipeline failure/i);
   } finally {
     delete require.cache[routerPath];
     delete require.cache[configPath];


### PR DESCRIPTION
## Summary
- publish structured admin-status error events when router dispatch catches a pipeline rejection
- infer pipeline type and scope for router-level failures
- add a regression test proving router dispatch failures are emitted as admin-status errors
- add an investigation note describing the reporting gap and why intake missed router-only failures

## Why
Router-level failures were only logged to stderr, so failure intake that reads admin-status events could miss them.

## Testing
- `npm test -- test/router-failure-admin-status.test.js`

## Scope
This PR only fixes router failure reporting/intake visibility. It does not change pipeline business logic.
