### PR TITLE
fix: run review gate with claude-only until codex auth is wired

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -59,7 +59,9 @@ jobs:
           REVIEW_PR: ${{ github.event.pull_request.number }}
           REVIEW_BASE: ${{ github.event.pull_request.base.sha }}
           REVIEW_HEAD: ${{ github.event.pull_request.head.sha }}
-          REVIEW_PROVIDER: both
+          # Codex-on-Fly needs an OPENAI_API_KEY secret on the reviewer app
+          # before "both" works; until then, run claude-only.
+          REVIEW_PROVIDER: claude
         run: |
           set -euo pipefail
           flyctl machine update "$FLY_MACHINE_ID" --app "$FLY_APP_NAME" --yes --skip-start \


### PR DESCRIPTION
## Summary

Codex on the reviewer Fly machine has no \`OPENAI_API_KEY\` set, so the codex provider fails with 401 \`Missing bearer or basic authentication\`. \`PR_REVIEW_PROVIDER=both\` then fail-fast aborts the whole review and emits a FAIL marker even on clean diffs.

Switch to \`claude\` only for now. Restore \`both\` after \`OPENAI_API_KEY\` is added as a Fly secret on \`bp-assistant-auto-issue-handler\`.

## Note about merging this PR

Same caveat as before: this PR's gate runs the workflow as defined in main, which still has \`provider: both\`. So this PR's gate will fail with the codex 401. **Admin-merge / bypass the failing check** to land this; then subsequent PRs (including #39) will use claude-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)