### PR TITLE
fix(review-gate): pass --restart no when configuring reviewer machine

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -64,7 +64,9 @@ jobs:
           REVIEW_PROVIDER: claude
         run: |
           set -euo pipefail
-          flyctl machine update "$FLY_MACHINE_ID" --app "$FLY_APP_NAME" --yes --skip-start \
+          # --restart no keeps the machine from auto-looping on non-zero exits,
+          # so the wait-for-stopped poll observes a clean terminal state.
+          flyctl machine update "$FLY_MACHINE_ID" --app "$FLY_APP_NAME" --yes --skip-start --restart no \
             --env "RUN_MODE=pr-review" \
             --env "PR_REVIEW_REPO=${REVIEW_REPO}" \
             --env "PR_REVIEW_NUMBER=${REVIEW_PR}" \


### PR DESCRIPTION
The reviewer machine's restart policy persists at \"on-fail\" (Fly's default), so a non-zero exit from \`run-pr-review.js\` auto-loops the machine and the wait-for-stopped poll never observes a clean terminal state. We saw this on PR #39: codex 401 → exit 1 → Fly auto-restart → workflow stuck in poll loop until the test was canceled.

Pass \`--restart no\` on the same \`flyctl machine update\` call that already sets the pr-review env vars. The machine API accepts \"no\" even though the app-config validator does not (see prior fly.toml attempt that flyctl rejected with \"invalid restart policy: no\").

Pairs with deferredreward/bp-assistant-auto-issue-handler#24 (does the same in the wake-up workflows).

Same admin-merge caveat: this PR's gate runs the workflow as defined in main, which still doesn't pin restart=no. Admin-merge and the next PR will use the new behavior.