### PR TITLE
fix(review-gate): poll machine state via list, not status --json

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -83,12 +83,15 @@ jobs:
           set -euo pipefail
           flyctl machine start "$FLY_MACHINE_ID" --app "$FLY_APP_NAME"
           # Poll until the machine returns to a stopped state (entrypoint exited).
-          # Cap at ~15 minutes; review runs typically finish in a few minutes.
+          # `flyctl machine status` doesn't accept --json, so use `machines list
+          # --json` and filter by id. Cap at ~15 minutes; review runs typically
+          # finish in a few minutes.
           deadline=$((SECONDS + 900))
           state=""
           while [ "$SECONDS" -lt "$deadline" ]; do
-            state="$(flyctl machine status "$FLY_MACHINE_ID" --app "$FLY_APP_NAME" --json 2>/dev/null \
-              | node -e "let s=''; process.stdin.on('data',c=>s+=c); process.stdin.on('end',()=>{ try { const j=JSON.parse(s); process.stdout.write(String(j.state||j.Status||'')); } catch { process.stdout.write(''); } });" \
+            state="$(flyctl machines list --app "$FLY_APP_NAME" --json 2>/dev/null \
+              | node -e "let s=''; process.stdin.on('data',c=>s+=c); process.stdin.on('end',()=>{ try { const j=JSON.parse(s); const m=Array.isArray(j)?j.find(x=>x&&x.id===process.argv[1]):null; if (m) process.stdout.write(String(m.state||'')); } catch {} });" \
+                "$FLY_MACHINE_ID" \
               || echo "")"
             if [ "$state" = "stopped" ] || [ "$state" = "destroyed" ]; then
               break


### PR DESCRIPTION
\`flyctl machine status\` doesn't support \`--json\`:

\`\`\`
Error: unknown flag: --json
\`\`\`

The current polling step pipes stderr to \`/dev/null\` and feeds stdout to a node parser, so the failure was silent and \`state\` was always empty. The loop ran out the clock every time — even for a perfectly successful review — and exited 1 with \"Machine did not return to stopped state within timeout (last state: )\". The \`Read review result from logs\` step had no \`if: always()\`, so it was skipped, and we never reported the actual PASS/FAIL.

This is exactly what just happened on PR #39's last gate run: the reviewer machine started, ran review, exited cleanly at 03:36:51, but the workflow's poll didn't notice and timed out at 03:47:06 with last state empty.

Use \`flyctl machines list --app ... --json\` (which IS supported) and filter to the target ID.

Same admin-merge caveat — this PR's own gate runs main's broken poll.