### PR TITLE
fix(self-diagnosis): repair common JSON failures and capture raw output

### DIFF
--- a/src/self-diagnosis.js
+++ b/src/self-diagnosis.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
 const { runClaude } = require('./claude-runner');
 const { publishAdminStatus, readAdminStatus } = require('./admin-status');
 const { readSecret } = require('./secrets');
@@ -13,6 +15,9 @@ const DEFAULT_REPO = 'bp-assistant';
 const SKILLS_REPO = 'bp-assistant-skills';
 const VALID_REPOS = new Set([DEFAULT_REPO, SKILLS_REPO]);
 const FINGERPRINT_PREFIX = 'pipeline-failure-fingerprint:';
+const RAW_DIR = process.env.SELF_DIAGNOSIS_RAW_DIR
+  || path.resolve(__dirname, '../data/self-diagnosis-raw');
+const MAX_FALLBACK_BODY_CHARS = 50000;
 
 // Vendored from bp-assistant-auto-issue-handler/src/pipeline-failure-handler.js
 // Source-of-truth: keep these three functions byte-identical so the
@@ -152,23 +157,60 @@ function buildContextSummary(event, contextEvents, checkpoint, errorText) {
   return lines.join('\n');
 }
 
+// Most common diagnosis-agent failure: literal newlines / tabs / CRs sit
+// unescaped inside a JSON string value (typically the markdown body), making
+// JSON.parse choke. Walk the candidate, escape control chars while inside a
+// string, and also strip a few other common offenders (trailing commas).
+function repairAgentJson(candidate) {
+  let out = '';
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < candidate.length; i++) {
+    const ch = candidate[i];
+    if (escape) { out += ch; escape = false; continue; }
+    if (ch === '\\') { out += ch; escape = true; continue; }
+    if (ch === '"') { inString = !inString; out += ch; continue; }
+    if (inString) {
+      if (ch === '\n') { out += '\\n'; continue; }
+      if (ch === '\r') { out += '\\r'; continue; }
+      if (ch === '\t') { out += '\\t'; continue; }
+    }
+    out += ch;
+  }
+  return out.replace(/,(\s*[}\]])/g, '$1');
+}
+
+function tryParseDiagnosisJson(candidate) {
+  try { return JSON.parse(candidate); } catch { /* fall through */ }
+  const startIdx = candidate.indexOf('{');
+  const endIdx = candidate.lastIndexOf('}');
+  if (startIdx >= 0 && endIdx > startIdx) {
+    const sliced = candidate.slice(startIdx, endIdx + 1);
+    try { return JSON.parse(sliced); } catch { /* fall through */ }
+    try { return JSON.parse(repairAgentJson(sliced)); } catch { /* fall through */ }
+  }
+  try { return JSON.parse(repairAgentJson(candidate)); } catch { /* fall through */ }
+  return null;
+}
+
+// Lower-bar check: does this raw text look like an attempt at the diagnosis
+// JSON shape? Used to decide whether to file a fallback issue with the raw
+// text vs. just logging the failure.
+function looksLikeDiagnosisAttempt(raw) {
+  if (!raw || typeof raw !== 'string') return false;
+  if (!raw.includes('{')) return false;
+  return /"\s*(repo|title|body|classification)\s*"\s*:/i.test(raw);
+}
+
 function extractDiagnosisJson(raw) {
   if (!raw || typeof raw !== 'string') {
     throw new Error('Diagnosis agent returned no text');
   }
   const fenceMatch = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
   const candidate = fenceMatch ? fenceMatch[1].trim() : raw.trim();
-  let parsed;
-  try {
-    parsed = JSON.parse(candidate);
-  } catch {
-    const startIdx = candidate.indexOf('{');
-    const endIdx = candidate.lastIndexOf('}');
-    if (startIdx >= 0 && endIdx > startIdx) {
-      parsed = JSON.parse(candidate.slice(startIdx, endIdx + 1));
-    } else {
-      throw new Error(`Diagnosis agent returned invalid JSON: ${candidate.slice(0, 200)}`);
-    }
+  const parsed = tryParseDiagnosisJson(candidate);
+  if (parsed === null) {
+    throw new Error(`Diagnosis agent returned invalid JSON: ${candidate.slice(0, 1000)}`);
   }
   if (!parsed || typeof parsed !== 'object') {
     throw new Error('Diagnosis agent returned non-object JSON');
@@ -226,6 +268,67 @@ function appendFingerprintMarker(body, fingerprint) {
   return `${body.trimEnd()}\n\n${marker}\n`;
 }
 
+function persistRawDiagnosisOutput(fingerprint, raw) {
+  try {
+    fs.mkdirSync(RAW_DIR, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const file = path.join(RAW_DIR, `${fingerprint}-${ts}.txt`);
+    fs.writeFileSync(file, String(raw || ''), 'utf8');
+    return file;
+  } catch (err) {
+    console.error(`[self-diagnosis] Failed to persist raw output: ${err.message}`);
+    return null;
+  }
+}
+
+function buildFallbackDiagnosis(event, rawText, parseError, contextSummary) {
+  const targetRepo = classifyRepo(event);
+  const scopeLabel = event.scope || event.pipelineType || 'event';
+  const title = `Pipeline failure: ${event.pipelineType || 'unknown'} ${scopeLabel} — diagnosis JSON parse failed`
+    .slice(0, 120);
+  const truncatedRaw = String(rawText || '').slice(0, MAX_FALLBACK_BODY_CHARS);
+  const truncationNote = String(rawText || '').length > MAX_FALLBACK_BODY_CHARS
+    ? `\n\n_(raw output truncated to ${MAX_FALLBACK_BODY_CHARS} chars)_`
+    : '';
+  const body = [
+    '## Summary',
+    'The self-diagnosis agent ran but returned output that could not be parsed as JSON.',
+    'Filing this issue with the raw agent output so a human (or the auto-issue-handler) can triage.',
+    '',
+    '## Failure event',
+    `- pipelineType: ${event.pipelineType || '(unknown)'}`,
+    `- scope: ${event.scope || '(none)'}`,
+    `- phase: ${event.phase || '(none)'}`,
+    `- severity: ${event.severity || '(unknown)'}`,
+    `- message: ${event.message || '(none)'}`,
+    '',
+    '## Parse error',
+    '```',
+    String(parseError && parseError.message ? parseError.message : parseError).slice(0, 2000),
+    '```',
+    '',
+    '## Raw diagnosis agent output',
+    '```',
+    truncatedRaw + truncationNote,
+    '```',
+    '',
+    '## Diagnosis context (what the agent was given)',
+    '<details><summary>Click to expand</summary>',
+    '',
+    '```',
+    String(contextSummary || '').slice(0, 8000),
+    '```',
+    '</details>',
+  ].join('\n');
+  return {
+    repo: targetRepo,
+    title,
+    body,
+    labels: ['bug', 'pipeline-failure', 'self-diagnosis-parse-failure'],
+    classification: 'self-diagnosis-parse-failure',
+  };
+}
+
 async function dispatchSelfDiagnosis({
   event,
   checkpoint = null,
@@ -276,7 +379,24 @@ async function dispatchSelfDiagnosis({
 
     const contextSummary = buildContextSummary(event, recentEvents, checkpoint, errorText);
     const rawText = await runDiagnosisAgent({ contextSummary, runClaudeImpl });
-    const diagnosis = extractDiagnosisJson(rawText);
+    let diagnosis;
+    let usedFallback = false;
+    let parseError = null;
+    try {
+      diagnosis = extractDiagnosisJson(rawText);
+    } catch (err) {
+      parseError = err;
+      const rawPath = persistRawDiagnosisOutput(fingerprint, rawText);
+      if (rawPath) {
+        console.error(`[self-diagnosis] Persisted unparseable raw output to ${rawPath}`);
+      }
+      if (!looksLikeDiagnosisAttempt(rawText)) {
+        throw err;
+      }
+      console.error(`[self-diagnosis] JSON parse failed (${err.message.slice(0, 200)}); filing fallback issue with raw output`);
+      diagnosis = buildFallbackDiagnosis(event, rawText, err, contextSummary);
+      usedFallback = true;
+    }
 
     const finalRepo = VALID_REPOS.has(diagnosis.repo) ? diagnosis.repo : targetRepo;
     const finalBody = appendFingerprintMarker(diagnosis.body, fingerprint);
@@ -297,8 +417,9 @@ async function dispatchSelfDiagnosis({
       });
     } catch (_) { /* non-fatal */ }
 
-    console.log(`[self-diagnosis] Done (action=created issue=${finalRepo}#${created.number})`);
-    return { ok: true, action: 'created', issue: created, fingerprint, classification: diagnosis.classification };
+    const action = usedFallback ? 'created-fallback' : 'created';
+    console.log(`[self-diagnosis] Done (action=${action} issue=${finalRepo}#${created.number}${usedFallback ? ' parse-error=' + (parseError && parseError.message ? parseError.message.slice(0, 120) : 'unknown') : ''})`);
+    return { ok: true, action, issue: created, fingerprint, classification: diagnosis.classification };
   } catch (err) {
     const reason = err && err.message ? err.message : String(err);
     console.error(`[self-diagnosis] Failed: ${reason}`);
@@ -323,6 +444,9 @@ module.exports = {
   classifyRepo,
   normalizeSignature,
   extractDiagnosisJson,
+  repairAgentJson,
+  looksLikeDiagnosisAttempt,
+  buildFallbackDiagnosis,
   buildContextSummary,
   appendFingerprintMarker,
   FINGERPRINT_PREFIX,

--- a/test/self-diagnosis.test.js
+++ b/test/self-diagnosis.test.js
@@ -3,11 +3,20 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const RAW_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'self-diagnosis-raw-'));
+process.env.SELF_DIAGNOSIS_RAW_DIR = RAW_DIR;
+
 const {
   dispatchSelfDiagnosis,
   buildFingerprint,
   classifyRepo,
   extractDiagnosisJson,
+  repairAgentJson,
+  looksLikeDiagnosisAttempt,
   appendFingerprintMarker,
   FINGERPRINT_PREFIX,
 } = require('../src/self-diagnosis');
@@ -133,6 +142,49 @@ test('extractDiagnosisJson parses fenced JSON from agent output', () => {
   assert.equal(parsed.classification, 'skills');
 });
 
+test('extractDiagnosisJson repairs unescaped newlines inside string values', () => {
+  // Body has literal newlines instead of \n escapes — the most common mode
+  // we've seen the diagnosis agent emit.
+  const broken = `\`\`\`json
+{
+  "repo": "bp-assistant-skills",
+  "title": "Pipeline failure: tqs PSA 6 — bad chapter padding",
+  "body": "## Summary
+A real newline is inside this string, which technically violates JSON.
+
+## Failure signal
+something broke",
+  "labels": ["bug", "pipeline-failure"],
+  "classification": "skills"
+}
+\`\`\``;
+  const parsed = extractDiagnosisJson(broken);
+  assert.equal(parsed.repo, 'bp-assistant-skills');
+  assert.match(parsed.body, /## Summary/);
+  assert.match(parsed.body, /## Failure signal/);
+});
+
+test('repairAgentJson fixes unescaped newlines in strings without touching whitespace between fields', () => {
+  const broken = `{\n  "a": "line1\nline2",\n  "b": 3\n}`;
+  const repaired = repairAgentJson(broken);
+  const parsed = JSON.parse(repaired);
+  assert.equal(parsed.a, 'line1\nline2');
+  assert.equal(parsed.b, 3);
+});
+
+test('repairAgentJson strips trailing commas', () => {
+  const broken = '{"a": 1, "b": [1, 2, 3,], }';
+  assert.deepEqual(JSON.parse(repairAgentJson(broken)), { a: 1, b: [1, 2, 3] });
+});
+
+test('looksLikeDiagnosisAttempt distinguishes agent JSON from arbitrary text', () => {
+  assert.equal(looksLikeDiagnosisAttempt('not even close to JSON'), false);
+  assert.equal(looksLikeDiagnosisAttempt('{ "repo": "bp-assistant", "title": "x" }'), true);
+  assert.equal(looksLikeDiagnosisAttempt('```json\n{\n  "title": "x"\n}\n```'), true);
+  assert.equal(looksLikeDiagnosisAttempt(''), false);
+  assert.equal(looksLikeDiagnosisAttempt(null), false);
+});
+
 test('extractDiagnosisJson rejects invalid repo', () => {
   const bad = `\`\`\`json
 { "repo": "evil-repo", "title": "x", "body": "y" }
@@ -235,4 +287,45 @@ test('dispatchSelfDiagnosis returns invalid-event for missing message', async ()
   const result = await dispatchSelfDiagnosis({ event: { severity: 'error' } });
   assert.equal(result.ok, false);
   assert.equal(result.reason, 'invalid-event');
+});
+
+test('dispatchSelfDiagnosis files a fallback issue when JSON parse fails on diagnosis-shaped output', async () => {
+  // Truncated / unparseable but clearly a diagnosis attempt — mirrors the
+  // PSA 6 failure mode we hit in production.
+  const brokenRaw = `\`\`\`json
+{
+  "repo": "bp-assistant-skills",
+  "title": "Pipeline failure: tqs PSA 6 — tq-writer uses 2-digit chapter padding instead of 3-digit",
+  "body": "## Summary
+A real newline that breaks JSON parsing.
+
+## Failure signal
+something happened`;
+  const event = makePsa1Event();
+  const calls = {};
+  const fetchImpl = createGithubFetchStub({ captureCalls: calls });
+  const result = await dispatchSelfDiagnosis({
+    event,
+    runClaudeImpl: makeRunClaudeStub(brokenRaw),
+    fetchImpl,
+    readSecretImpl: () => 'fake-token',
+    readAdminStatusImpl: () => [event],
+  });
+  // It might either repair successfully OR fall back. Both are acceptable
+  // outcomes — the contract is that an issue gets filed.
+  assert.equal(result.ok, true);
+  assert.equal(calls.createCount, 1);
+  assert.match(calls.lastCreateBody.body, /pipeline-failure-fingerprint:/);
+  if (result.action === 'created-fallback') {
+    assert.match(calls.lastCreateBody.title, /diagnosis JSON parse failed/);
+    assert.match(calls.lastCreateBody.body, /Raw diagnosis agent output/);
+    assert.match(calls.lastCreateBody.body, /tq-writer uses 2-digit chapter padding/);
+    assert.ok(
+      calls.lastCreateBody.labels.includes('self-diagnosis-parse-failure'),
+      'fallback issue should carry the self-diagnosis-parse-failure label',
+    );
+    // Raw output should also have been persisted to disk for inspection.
+    const files = fs.readdirSync(RAW_DIR);
+    assert.ok(files.length > 0, 'expected raw output to be persisted on parse failure');
+  }
 });


### PR DESCRIPTION
## Summary

The self-diagnosis agent occasionally returns JSON that `JSON.parse` rejects — most commonly because the markdown body contains literal newlines instead of `\n` escapes. The previous code lost the raw output and surfaced only a 200-char excerpt in the error, leaving no way to recover the diagnosis or even see what was produced.

Recent example from PSA 6:
```
Self-diagnosis failed for PSA 6: Diagnosis agent returned invalid JSON: {

  "repo": "bp-assistant-skills",
  "title": "Pipeline failure: tqs PSA 6 — tq-writer uses 2-digit chapter padding instead of 3-digit",
  "body": "## Summary\nA
```

## Changes

- **`repairAgentJson()`** — escapes unescaped `\n` / `\r` / `\t` *inside string values* and strips trailing commas. Three-stage parse attempt: raw → outer-brace-bounded slice → repaired.
- **Persist raw output to disk** on parse failure under `data/self-diagnosis-raw/{fingerprint}-{timestamp}.txt` (overridable via `SELF_DIAGNOSIS_RAW_DIR`).
- **Fallback issue creation** — when the raw text looks like a real diagnosis attempt but can't be parsed, file a GitHub issue carrying the raw output, the parse error, and the original diagnosis context. Labelled `self-diagnosis-parse-failure`. Fingerprint marker still applies so duplicates dedup.
- Error excerpt widened from 200 → 1000 chars.
- New `created-fallback` action in the dispatch return value.

The "garbage" failure mode (raw text that doesn't even look like JSON) still fails closed, so we don't spam issues from totally unrelated agent output.

## Test plan

- [x] `node --test test/self-diagnosis.test.js` — 14 pass, 2 skipped (sibling repo not present)
- [x] Existing fingerprint / idempotency / garbage-input tests still pass
- [x] New tests cover: repair of unescaped newlines, trailing-comma fix, `looksLikeDiagnosisAttempt` heuristic, fallback-issue flow including raw-output persistence
- [ ] Confirm in production that the next parse-failure either repairs cleanly or shows up as a `self-diagnosis-parse-failure` issue with the full raw output

🤖 Generated with [Claude Code](https://claude.com/claude-code)