### PR TITLE
feat(deploy): block deploys while pipelines are running

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,18 +10,59 @@ on:
         description: 'Confirm no pipeline is currently running (yes/no)'
         required: true
         default: 'yes'
+      skip_pipeline_check:
+        description: 'Bypass /health/pipelines guard (use only if bot is unreachable)'
+        required: false
+        default: 'no'
 
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || github.event.inputs.confirm == 'yes' }}
+    env:
+      HEALTH_URL: https://uw-bt-bot.fly.dev/health/pipelines
+      MAX_WAIT_MINUTES: '90'
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Wait for active pipelines to clear
+        if: ${{ github.event.inputs.skip_pipeline_check != 'yes' }}
+        run: |
+          set -u
+          deadline=$(( $(date +%s) + MAX_WAIT_MINUTES * 60 ))
+          unreachable=0
+          while :; do
+            now=$(date +%s)
+            if [ "$now" -ge "$deadline" ]; then
+              echo "::error::Active pipelines did not clear within ${MAX_WAIT_MINUTES} minutes. Use workflow_dispatch with skip_pipeline_check=yes to override after manual verification."
+              exit 1
+            fi
+            if ! body="$(curl -fsS --max-time 30 "$HEALTH_URL")"; then
+              unreachable=$((unreachable + 1))
+              echo "Could not reach $HEALTH_URL (attempt ${unreachable})"
+              if [ "$unreachable" -ge 5 ]; then
+                echo "::error::$HEALTH_URL unreachable after 5 attempts. If the bot is crashed, re-run via workflow_dispatch with skip_pipeline_check=yes."
+                exit 1
+              fi
+              sleep 30
+              continue
+            fi
+            unreachable=0
+            active=$(echo "$body" | jq -r '.active')
+            if [ "$active" = "0" ]; then
+              echo "No active pipelines. Proceeding with deploy."
+              echo "$body" | jq -r '"Bot up since " + .processStartedAt'
+              break
+            fi
+            echo "Active pipelines: $active. Rechecking in 60s."
+            echo "$body" | jq -r '.pipelines[] | "  - " + .pipelineType + " " + (.scope | tostring) + " (age " + (.ageSeconds | tostring) + "s)"'
+            sleep 60
+          done
 
       - name: Deploy
         run: flyctl deploy --remote-only --strategy immediate --ha=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,17 @@ The bot runs as the Fly.io app `uw-bt-bot` (single machine, region `dfw`).
   go through `gh workflow run deploy.yml -f confirm=yes`.
 
 ## Safety
-- **Before redeploying**, check for active pipelines with
+- The deploy workflow polls `https://uw-bt-bot.fly.dev/health/pipelines`
+  before running `flyctl deploy` and waits (up to 90 minutes) for `active`
+  to reach `0`. The endpoint reports `running` checkpoints whose `updatedAt`
+  is after this bot process started and within the last 60 minutes.
+- To bypass the guard (e.g. bot is crashed and unreachable), trigger the
+  workflow manually with `skip_pipeline_check=yes`:
+  `gh workflow run deploy.yml -f confirm=yes -f skip_pipeline_check=yes`.
+- For an ad-hoc check, snapshot fly logs as well:
   `flyctl logs -a uw-bt-bot --no-tail | tail -50`. Look for `[notes] Running`,
   `[generate] Processing`, or `[claude-runner] Starting` lines without a
-  corresponding completion — `--strategy immediate` will kill any in-progress
-  pipeline.
+  corresponding completion.
 - `[claude-runner]` lines that appear between a `[self-diagnosis] Starting`
   and a `[self-diagnosis] Done` boundary belong to the diagnosis sub-agent,
   not a user pipeline — those are safe to interrupt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,22 @@
 # Zulip Bot App
 
+## Runtime
+
+The bot runs as the Fly.io app `uw-bt-bot` (single machine, region `dfw`).
+- Live logs: `flyctl logs -a uw-bt-bot` (or `--no-tail` for a snapshot).
+- Deploy: push to `main` triggers `.github/workflows/deploy.yml`, which runs
+  `flyctl deploy --remote-only --strategy immediate --ha=false`. Manual deploys
+  go through `gh workflow run deploy.yml -f confirm=yes`.
+
 ## Safety
-- **Before rebuilding/restarting the bot**, always run `docker logs zulip-bot --tail 30` and check for active running pipelines. Look for `[notes] Running` or `[generate] Processing` or `[claude-runner] Starting` lines without a corresponding completion. A restart will kill any in-progress pipeline.
-- `[claude-runner]` lines that appear between a `[self-diagnosis] Starting` and a `[self-diagnosis] Done` boundary belong to the diagnosis sub-agent, not a user pipeline — those are safe to interrupt.
-- Rebuild command: `cd /srv/bot/app && docker compose down && docker compose build && docker compose up -d`
+- **Before redeploying**, check for active pipelines with
+  `flyctl logs -a uw-bt-bot --no-tail | tail -50`. Look for `[notes] Running`,
+  `[generate] Processing`, or `[claude-runner] Starting` lines without a
+  corresponding completion — `--strategy immediate` will kill any in-progress
+  pipeline.
+- `[claude-runner]` lines that appear between a `[self-diagnosis] Starting`
+  and a `[self-diagnosis] Done` boundary belong to the diagnosis sub-agent,
+  not a user pipeline — those are safe to interrupt.
 
 ## Branch Awareness
 At the start of a session, run `git branch` to check the current branch. If not on `main`, flag it to the user before making changes — they may have been left on a feature branch from a previous session.
@@ -14,10 +27,13 @@ At the start of a session, run `git branch` to check the current branch. If not 
 
 ## Known Constraints
 
-### Docker container (Chainguard Node.js)
-- No bash, no Python, no native git binary — only Node.js
-- Node v25 (not v18 like the host) — different HTTP behavior
-- `door43-push.js` uses a **custom HTTP handler** (native `https`) instead of isomorphic-git's default `simple-get` module, which aborts on large repos (en_ult, en_ust) under Node v25 in containers. Do not revert to the default `require('isomorphic-git/http/node')`.
+### door43-push HTTP handler
+- `door43-push.js` uses a **custom HTTP handler** (native `https`) instead of
+  isomorphic-git's default `simple-get` module. The default aborts on large
+  repos (en_ult, en_ust) under newer Node versions in containers. Do not
+  revert to `require('isomorphic-git/http/node')`.
+- Originally hardened for the Chainguard container; the constraint persists
+  on Fly.io with the current Node version.
 
 ### Pipeline checkpoints
 - Checkpoint state must be one of: `running`, `failed`, `paused_for_outage`, `paused_for_usage_limit`

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -11,11 +11,41 @@ const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/ser
 const { z } = require('zod');
 const { readSecret } = require('./secrets');
 const { readAdminStatus } = require('./admin-status');
+const { listCheckpoints } = require('./pipeline-checkpoints');
 
 const ADMIN_PORT = Number(process.env.PORT || 8080);
 const MCP_PORT = Number(process.env.MCP_PORT || 3001);
 const MCP_BIND_HOST = process.env.MCP_BIND_HOST || '127.0.0.1';
 const DOOR43_BASE = 'https://git.door43.org/unfoldingWord';
+
+const PROCESS_STARTED_AT_MS = Date.now();
+
+// Checkpoints not touched within this window are treated as crashed/stale even
+// if the bot didn't restart — prevents a hung pipeline from blocking deploys
+// forever.
+const CHECKPOINT_FRESHNESS_MS = 60 * 60 * 1000;
+
+function getActivePipelines() {
+  const now = Date.now();
+  const rows = [];
+  for (const cp of listCheckpoints()) {
+    if (cp?.state !== 'running') continue;
+    const updatedMs = Date.parse(cp.updatedAt || '');
+    if (!Number.isFinite(updatedMs)) continue;
+    // Stale: checkpoint predates this process (left over from a kill).
+    if (updatedMs < PROCESS_STARTED_AT_MS) continue;
+    const ageMs = now - updatedMs;
+    if (ageMs > CHECKPOINT_FRESHNESS_MS) continue;
+    rows.push({
+      key: cp.key,
+      pipelineType: cp.pipelineType,
+      scope: cp.scope,
+      updatedAt: cp.updatedAt,
+      ageSeconds: Math.round(ageMs / 1000),
+    });
+  }
+  return rows;
+}
 
 // ---------------------------------------------------------------------------
 // Book number map
@@ -662,6 +692,17 @@ function createHttpServer() {
     if (req.method === 'GET' && urlPath === '/health') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ ok: true, service: 'bt-pipeline-mcp' }));
+      return;
+    }
+
+    if (req.method === 'GET' && urlPath === '/health/pipelines') {
+      const pipelines = getActivePipelines();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        active: pipelines.length,
+        processStartedAt: new Date(PROCESS_STARTED_AT_MS).toISOString(),
+        pipelines,
+      }));
       return;
     }
 

--- a/test/mcp-server-pipelines-health.test.js
+++ b/test/mcp-server-pipelines-health.test.js
@@ -1,0 +1,110 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+
+function installStub(modulePath, exportsValue) {
+  require.cache[modulePath] = {
+    id: modulePath,
+    filename: modulePath,
+    loaded: true,
+    exports: exportsValue,
+  };
+}
+
+function request(server, reqPath) {
+  return new Promise((resolve, reject) => {
+    const address = server.address();
+    const req = http.request({
+      host: '127.0.0.1',
+      port: address.port,
+      path: reqPath,
+      method: 'GET',
+    }, (res) => {
+      let data = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => resolve({ status: res.statusCode, body: data }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function withServer(makeCheckpoints, handler) {
+  const checkpointsPath = require.resolve('../src/pipeline-checkpoints');
+  const mcpPath = require.resolve('../src/mcp-server');
+  let checkpoints = [];
+  installStub(checkpointsPath, { listCheckpoints: () => checkpoints });
+  delete require.cache[mcpPath];
+  const { createHttpServer } = require('../src/mcp-server');
+  // Module is loaded; PROCESS_STARTED_AT_MS is now fixed. Generate
+  // checkpoints against the post-load clock so "fresh" timestamps land after
+  // the module's start time.
+  checkpoints = typeof makeCheckpoints === 'function'
+    ? makeCheckpoints(Date.now())
+    : makeCheckpoints;
+  const server = createHttpServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  try {
+    await handler(server);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    delete require.cache[mcpPath];
+    delete require.cache[checkpointsPath];
+  }
+}
+
+test('/health/pipelines reports running checkpoints updated since process start', async () => {
+  await withServer((now) => {
+    const fresh = new Date(now + 1000).toISOString();
+    return [
+      { key: 'a', pipelineType: 'generate', state: 'running', updatedAt: fresh, scope: { book: 'TIT', startChapter: 1, endChapter: 1 } },
+      { key: 'b', pipelineType: 'notes',    state: 'failed',  updatedAt: fresh, scope: { book: 'TIT', startChapter: 2, endChapter: 2 } },
+    ];
+  }, async (server) => {
+    const res = await request(server, '/health/pipelines');
+    assert.equal(res.status, 200);
+    const payload = JSON.parse(res.body);
+    assert.equal(payload.active, 1);
+    assert.equal(payload.pipelines.length, 1);
+    assert.equal(payload.pipelines[0].pipelineType, 'generate');
+    assert.equal(payload.pipelines[0].scope.book, 'TIT');
+  });
+});
+
+test('/health/pipelines excludes stale running checkpoints from a previous process', async () => {
+  // Predates process start by definition (1970).
+  const ancient = new Date(0).toISOString();
+  await withServer([
+    { key: 'a', pipelineType: 'generate', state: 'running', updatedAt: ancient, scope: { book: 'TIT' } },
+  ], async (server) => {
+    const res = await request(server, '/health/pipelines');
+    const payload = JSON.parse(res.body);
+    assert.equal(payload.active, 0);
+    assert.equal(payload.pipelines.length, 0);
+  });
+});
+
+test('/health/pipelines excludes pipelines that have not updated within the freshness window', async () => {
+  // Updated 2 hours ago — past the 60-minute freshness window even if it
+  // somehow predates process start in absolute terms.
+  const stale = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+  await withServer([
+    { key: 'a', pipelineType: 'generate', state: 'running', updatedAt: stale, scope: { book: 'TIT' } },
+  ], async (server) => {
+    const res = await request(server, '/health/pipelines');
+    const payload = JSON.parse(res.body);
+    assert.equal(payload.active, 0);
+  });
+});
+
+test('/health/pipelines returns active=0 when there are no running checkpoints', async () => {
+  await withServer([], async (server) => {
+    const res = await request(server, '/health/pipelines');
+    assert.equal(res.status, 200);
+    const payload = JSON.parse(res.body);
+    assert.equal(payload.active, 0);
+    assert.deepEqual(payload.pipelines, []);
+    assert.match(payload.processStartedAt, /^\d{4}-\d{2}-\d{2}T/);
+  });
+});


### PR DESCRIPTION
## Summary
- Auto-deploys on push to main were killing in-progress pipelines (e.g. the 2026-04-30 11:12 UTC deploy interrupted active work). This wires in a pre-deploy guard.
- New public `GET /health/pipelines` endpoint on the bot's admin port reports `running` checkpoints that are fresh (after current process start, within last 60 min). Stale checkpoints from crashed pipelines no longer block deploys.
- `deploy.yml` polls the endpoint every 60s for up to 90 minutes before running `flyctl deploy`. Fails closed after 5 unreachable attempts. New `workflow_dispatch` input `skip_pipeline_check=yes` overrides the guard when the bot is unreachable.

## Test plan
- [x] `node --test test/mcp-server-pipelines-health.test.js` — 4 new tests cover fresh / stale-from-prior-process / past-freshness-window / empty cases
- [x] `node --test test/mcp-server-admin.test.js` — existing admin endpoints still pass
- [ ] After merge: confirm first auto-deploy logs show `No active pipelines. Proceeding with deploy.`
- [ ] After merge: trigger a manual run with `skip_pipeline_check=yes` to verify the override path

## Race note
Small window remains between the final poll and `flyctl deploy --strategy immediate` where a new pipeline can start. Acceptable tradeoff vs. heavier coordination; the manual override input is the escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)