### PR TITLE
fix(deploy): treat 404 from /health/pipelines as bootstrap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,9 +42,14 @@ jobs:
               echo "::error::Active pipelines did not clear within ${MAX_WAIT_MINUTES} minutes. Use workflow_dispatch with skip_pipeline_check=yes to override after manual verification."
               exit 1
             fi
-            if ! body="$(curl -fsS --max-time 30 "$HEALTH_URL")"; then
+            http_code=$(curl -sS -o /tmp/health.body -w '%{http_code}' --max-time 30 "$HEALTH_URL" || echo "000")
+            if [ "$http_code" = "404" ]; then
+              echo "::warning::$HEALTH_URL returned 404 — running bot does not expose the guard endpoint. Proceeding with deploy."
+              break
+            fi
+            if [ "$http_code" != "200" ]; then
               unreachable=$((unreachable + 1))
-              echo "Could not reach $HEALTH_URL (attempt ${unreachable})"
+              echo "Could not reach $HEALTH_URL (HTTP ${http_code}, attempt ${unreachable})"
               if [ "$unreachable" -ge 5 ]; then
                 echo "::error::$HEALTH_URL unreachable after 5 attempts. If the bot is crashed, re-run via workflow_dispatch with skip_pipeline_check=yes."
                 exit 1
@@ -52,6 +57,7 @@ jobs:
               sleep 30
               continue
             fi
+            body="$(cat /tmp/health.body)"
             unreachable=0
             active=$(echo "$body" | jq -r '.active')
             if [ "$active" = "0" ]; then


### PR DESCRIPTION
## Summary
- Follow-up to #47. The first auto-deploy after the guard landed failed because the *running* bot predated the endpoint — curl returned 404, the guard treated it as unreachable, and aborted after 5 retries. Bootstrapping required a manual `workflow_dispatch` with `skip_pipeline_check=yes`.
- Distinguish HTTP status codes in the guard:
  - `200` → parse and act on the response (existing behavior).
  - `404` → bot is up but lacks the endpoint. Log a warning and proceed.
  - anything else (connection failure, 5xx) → retry as before.
- Same robustness if the endpoint is ever renamed or temporarily removed.

## Test plan
- [ ] Next push to main — confirm deploy logs show `No active pipelines. Proceeding with deploy.` (the new bot has the endpoint, so this is the happy path now).
- [ ] If the endpoint were absent: deploy log would show the `::warning::` line and proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)