### PR TITLE
fix(tqs): deduplicate ID column in TQ post-processing step

### DIFF
--- a/src/tqs-pipeline.js
+++ b/src/tqs-pipeline.js
@@ -8,7 +8,7 @@ const { door43Push, checkConflictingBranches, getRepoFilename } = require('./doo
 const { verifyRepoPush, verifyDcsToken } = require('./repo-verify');
 const { getCheckpoint, setCheckpoint, clearCheckpoint } = require('./pipeline-checkpoints');
 const { recordMetrics, getCumulativeTokens, recordRunSummary } = require('./usage-tracker');
-const { verifyTq } = require('./workspace-tools/misc-tools');
+const { verifyTq, deduplicateTqIds } = require('./workspace-tools/misc-tools');
 const { getChapterCount } = require('./verse-counts');
 const { publishAdminStatus } = require('./admin-status');
 const { dispatchSelfDiagnosis } = require('./self-diagnosis');
@@ -319,6 +319,11 @@ async function tqsPipeline(route, message) {
 
     if (resolvedOutput.normalizedFrom) {
       await status(`Normalized output filename for **${ref}**: ${resolvedOutput.normalizedFrom} -> ${path.basename(outputPath)}`);
+    }
+
+    const dedupResult = deduplicateTqIds({ tsvFile: outputRel });
+    if (!dedupResult.startsWith('No duplicate')) {
+      await status(`**${ref}** post-processing: ${dedupResult}`);
     }
 
     const verifyOutput = verifyTq({ tsvFile: outputRel });

--- a/src/workspace-tools/misc-tools.js
+++ b/src/workspace-tools/misc-tools.js
@@ -335,18 +335,26 @@ function verifyTq({ tsvFile, inputJson }) {
   }
 
   let rowCount = 0;
+  const seenIds = new Map(); // id -> first line number (1-based)
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i].trim();
     if (!line) continue;
     rowCount++;
     const cols = line.split('\t');
     const ref = cols[0] || '';
+    const id = cols[1] || '';
 
     if (cols.length !== 7) errors.push(`Line ${i + 1}: Expected 7 columns, found ${cols.length}`);
     if (!/^\d+:\d+(-\d+)?$/.test(ref)) errors.push(`Line ${i + 1}: Invalid reference "${ref}"`);
     if (!cols[5]) errors.push(`Line ${i + 1}: Empty Question`);
     if (!cols[6]) warnings.push(`Line ${i + 1}: Empty Response`);
-    if (!cols[1]) warnings.push(`Line ${i + 1}: Empty ID`);
+    if (!id) {
+      warnings.push(`Line ${i + 1}: Empty ID`);
+    } else if (seenIds.has(id)) {
+      errors.push(`Line ${i + 1}: Duplicate ID "${id}" (first seen at line ${seenIds.get(id)})`);
+    } else {
+      seenIds.set(id, i + 1);
+    }
     if (/["\u201c\u201d]/.test(cols[5] || '') || /["\u201c\u201d]/.test(cols[6] || '')) {
       warnings.push(`Line ${i + 1}: Direct quotes in Q/A`);
     }
@@ -369,6 +377,62 @@ function verifyTq({ tsvFile, inputJson }) {
   if (warnings.length) { result.push(`${warnings.length} warning(s):`); result.push(...warnings.slice(0, 20)); }
   if (!errors.length && !warnings.length) result.push('All checks passed');
   return result.join('\n');
+}
+
+/**
+ * Deduplicate the ID column of a TQ TSV file in-place.
+ * Any row whose ID collides with a previously seen ID is assigned a freshly
+ * generated unique 4-character random ID (same [a-z][a-z0-9]{3} format used
+ * by the TN pipeline).  The file is rewritten only when at least one duplicate
+ * is found.  Returns a human-readable result string.
+ */
+function deduplicateTqIds({ tsvFile }) {
+  const filePath = path.resolve(CSKILLBP_DIR, tsvFile);
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split('\n');
+
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const letters = 'abcdefghijklmnopqrstuvwxyz';
+  const seenIds = new Set();
+  let duplicatesFixed = 0;
+  const fixedLines = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Always keep header and blank lines as-is
+    if (i === 0 || !line.trim()) {
+      fixedLines.push(line);
+      continue;
+    }
+    const cols = line.split('\t');
+    const id = cols[1] || '';
+    if (id && seenIds.has(id)) {
+      // Collision — generate a new unique ID
+      let newId;
+      let attempts = 0;
+      do {
+        newId = letters[Math.floor(Math.random() * 26)];
+        for (let j = 0; j < 3; j++) newId += chars[Math.floor(Math.random() * 36)];
+        attempts++;
+      } while (seenIds.has(newId) && attempts < 200);
+      cols[1] = newId;
+      seenIds.add(newId);
+      duplicatesFixed++;
+      fixedLines.push(cols.join('\t'));
+    } else {
+      if (id) seenIds.add(id);
+      fixedLines.push(line);
+    }
+  }
+
+  if (duplicatesFixed > 0) {
+    fs.writeFileSync(filePath, fixedLines.join('\n'), 'utf8');
+  }
+
+  const basename = path.basename(filePath);
+  return duplicatesFixed > 0
+    ? `Deduplicated ${duplicatesFixed} duplicate ID(s) in ${basename}`
+    : `No duplicate IDs found in ${basename}`;
 }
 
 /**
@@ -407,4 +471,4 @@ function appendQuickref({ file, strong, hebrew, rendering, book = 'ALL', context
   return `Appended to ${csvName}: ${row}`;
 }
 
-module.exports = { giteaPr, prepareCompare, prepareTq, verifyTq, appendQuickref };
+module.exports = { giteaPr, prepareCompare, prepareTq, verifyTq, deduplicateTqIds, appendQuickref };

--- a/test/tqs-pipeline.test.js
+++ b/test/tqs-pipeline.test.js
@@ -27,7 +27,7 @@ function buildMessage(content, overrides = {}) {
   };
 }
 
-function createHarness({ runClaudeImpl, verifyTqImpl, conflictChapters = new Set() } = {}) {
+function createHarness({ runClaudeImpl, verifyTqImpl, deduplicateTqIdsImpl, conflictChapters = new Set() } = {}) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tqs-pipeline-'));
   const oldBaseDir = process.env.CSKILLBP_DIR;
   const oldStatusFile = process.env.ADMIN_STATUS_FILE;
@@ -115,6 +115,7 @@ function createHarness({ runClaudeImpl, verifyTqImpl, conflictChapters = new Set
   });
   installStub(miscToolsPath, {
     verifyTq: (args) => (verifyTqImpl ? verifyTqImpl(args) : `Verified 1 rows in ${path.basename(args.tsvFile)}\nAll checks passed`),
+    deduplicateTqIds: (args) => (deduplicateTqIdsImpl ? deduplicateTqIdsImpl(args) : `No duplicate IDs found in ${path.basename(args.tsvFile)}`),
   });
 
   const { tqsPipeline } = require('../src/tqs-pipeline');
@@ -321,5 +322,89 @@ test('tqsPipeline blocks push for chapters with conflicting branches', async () 
     assert.ok(harness.readStatusTexts().some((text) => text.includes('conflicting branches')));
   } finally {
     harness.cleanup();
+  }
+});
+
+test('tqsPipeline calls deduplicateTqIds before verify and logs when IDs are fixed', async () => {
+  let dedupCalled = false;
+  const harness = createHarness({
+    runClaudeImpl: async ({ tempDir }) => {
+      const outDir = path.join(tempDir, 'output', 'tq', 'PSA');
+      fs.mkdirSync(outDir, { recursive: true });
+      // Write TSV with duplicate ID 'fhve' — mirrors the Psalms regression (issue #54)
+      fs.writeFileSync(
+        path.join(outDir, 'PSA-005.tsv'),
+        'Reference\tID\tTags\tQuote\tOccurrence\tQuestion\tResponse\n' +
+        '5:1\tfhve\t\t\t1\tWho wrote this psalm?\tDavid\n' +
+        '5:2\tfhve\t\t\t1\tWhat did he request?\tTo be heard\n'
+      );
+      return { subtype: 'success', usage: {}, total_cost_usd: 0 };
+    },
+    deduplicateTqIdsImpl: (_args) => {
+      dedupCalled = true;
+      return 'Deduplicated 1 duplicate ID(s) in PSA-005.tsv';
+    },
+  });
+
+  try {
+    await harness.tqsPipeline(
+      { _synthetic: true, _book: 'PSA', _startChapter: 5, _endChapter: 5, _wholeBook: false },
+      buildMessage('write tqs for psa 5')
+    );
+
+    assert.ok(dedupCalled, 'deduplicateTqIds must be called by the pipeline');
+    assert.equal(harness.pushCalls.length, 1, 'Pipeline must push after dedup fixes duplicate IDs');
+    assert.equal(harness.summaries.at(-1).success, true);
+    assert.ok(
+      harness.readStatusTexts().some((text) => text.includes('Deduplicated')),
+      'Pipeline must emit a status message when duplicate IDs are fixed'
+    );
+  } finally {
+    harness.cleanup();
+  }
+});
+
+// Unit tests for deduplicateTqIds — exercise the real function outside the pipeline harness
+
+test('deduplicateTqIds replaces duplicate IDs in-place and preserves first occurrence', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tq-dedup-'));
+  const oldBaseDir = process.env.CSKILLBP_DIR;
+  process.env.CSKILLBP_DIR = tempDir;
+
+  // Fresh require so the module picks up the overridden CSKILLBP_DIR
+  const miscToolsPath = require.resolve('../src/workspace-tools/misc-tools');
+  delete require.cache[miscToolsPath];
+  const { deduplicateTqIds } = require('../src/workspace-tools/misc-tools');
+
+  try {
+    const tsvContent = [
+      'Reference\tID\tTags\tQuote\tOccurrence\tQuestion\tResponse',
+      '5:1\tfhve\t\t\t1\tQuestion one?\tAnswer one',
+      '5:2\tfhve\t\t\t1\tQuestion two?\tAnswer two',
+      '5:3\taaaa\t\t\t1\tQuestion three?\tAnswer three',
+    ].join('\n') + '\n';
+    fs.writeFileSync(path.join(tempDir, 'PSA-005.tsv'), tsvContent, 'utf8');
+
+    const result = deduplicateTqIds({ tsvFile: 'PSA-005.tsv' });
+
+    assert.ok(result.includes('Deduplicated 1'), `Expected 1 dedup reported, got: ${result}`);
+
+    const fixed = fs.readFileSync(path.join(tempDir, 'PSA-005.tsv'), 'utf8');
+    const dataRows = fixed.split('\n').slice(1).filter((l) => l.trim());
+    const ids = dataRows.map((l) => l.split('\t')[1]);
+
+    assert.equal(new Set(ids).size, ids.length, 'All IDs must be unique after deduplication');
+    assert.equal(ids[0], 'fhve', 'First occurrence of the duplicate ID must be preserved');
+    assert.notEqual(ids[1], 'fhve', 'Second occurrence must be replaced with a new unique ID');
+    assert.equal(ids[2], 'aaaa', 'Non-duplicate rows must remain unchanged');
+
+    // Running again on the already-fixed file should report no duplicates
+    const result2 = deduplicateTqIds({ tsvFile: 'PSA-005.tsv' });
+    assert.ok(result2.startsWith('No duplicate'), `Second run on clean file must report no dupes, got: ${result2}`);
+  } finally {
+    delete require.cache[miscToolsPath];
+    if (oldBaseDir == null) delete process.env.CSKILLBP_DIR;
+    else process.env.CSKILLBP_DIR = oldBaseDir;
+    fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Closes #54.

## What changed

### `src/workspace-tools/misc-tools.js`
- **New `deduplicateTqIds({ tsvFile })`** — reads a TQ TSV file, finds any rows whose `ID` column collides with a previously-seen ID, and replaces each duplicate with a freshly generated 4-char random ID (same `[a-z][a-z0-9]{3}` format used by the TN pipeline). Rewrites the file only when at least one duplicate is fixed; returns a human-readable result string.
- **`verifyTq` hardened** — duplicate IDs are now reported as explicit errors (belt-and-suspenders: if `deduplicateTqIds` somehow misses a collision, `verifyTq` catches it and blocks the push).

### `src/tqs-pipeline.js`
- Calls `deduplicateTqIds({ tsvFile: outputRel })` immediately after output-file normalisation and **before** `verifyTq`. If the dedup function reports changes, the pipeline emits a status message so the fix is visible in the run log.

### `test/tqs-pipeline.test.js`
- Updated `createHarness` to stub `deduplicateTqIds` (default: no-op pass).
- New pipeline regression test: verifies the pipeline calls `deduplicateTqIds`, logs a status message when IDs are fixed, and still pushes successfully.
- New unit test: exercises `deduplicateTqIds` directly against the exact Psalms scenario from the bug report (two rows both carrying ID `fhve`). Confirms first occurrence is preserved, duplicate is renamed, non-duplicate rows are untouched, and a second run on the already-fixed file reports no duplicates.

## Test results
All 9 tests pass (`node --test test/tqs-pipeline.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)