### PR TITLE
[codex] Keep Fly bot machine always restarting

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -25,6 +25,10 @@ kill_timeout = 30
   auto_start_machines = true
   auto_stop_machines = "off"
 
+[[restart]]
+  policy = "always"
+  processes = ["app"]
+
 [[vm]]
   memory = "2gb"
   cpu_kind = "shared"


### PR DESCRIPTION
## Summary

Pins the Fly Machine restart policy for the bot process to `always`.

## Why

The live Fly Machine was using the default `on-failure` policy with retry limits. That handles ordinary crashes, but an always-on Zulip bot should also come back after a clean process exit or after repeated restart attempts.

## Impact

Future deploys keep `uw-bt-bot` configured as always-on. I also updated the live Machine separately so the current runtime already has the same policy.

## Validation

- `fly machine status 781e106b292768 --app uw-bt-bot --display-config` reports `"restart": { "policy": "always" }`
- `curl -fsS https://uw-bt-bot.fly.dev/health` returns `{"ok":true,"service":"bt-pipeline-mcp"}`
- `npm test` passes: 185/185

## Merge note

Do not merge until the active pipeline has finished and GitHub checks have passed.
