### PR TITLE
fix: block deploys after interrupted pipelines

### DIFF
--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -33,8 +33,6 @@ function getActivePipelines() {
     if (cp?.state !== 'running') continue;
     const updatedMs = Date.parse(cp.updatedAt || '');
     if (!Number.isFinite(updatedMs)) continue;
-    // Stale: checkpoint predates this process (left over from a kill).
-    if (updatedMs < PROCESS_STARTED_AT_MS) continue;
     const ageMs = now - updatedMs;
     if (ageMs > CHECKPOINT_FRESHNESS_MS) continue;
     rows.push({
@@ -43,6 +41,7 @@ function getActivePipelines() {
       scope: cp.scope,
       updatedAt: cp.updatedAt,
       ageSeconds: Math.round(ageMs / 1000),
+      interrupted: updatedMs < PROCESS_STARTED_AT_MS,
     });
   }
   return rows;

--- a/test/mcp-server-pipelines-health.test.js
+++ b/test/mcp-server-pipelines-health.test.js
@@ -83,8 +83,9 @@ test('/health/pipelines reports running checkpoints updated since process start'
   });
 });
 
-test('/health/pipelines excludes stale running checkpoints from a previous process', async () => {
-  // Predates process start by definition (1970).
+test('/health/pipelines excludes old running checkpoints from a previous process', async () => {
+  // Predates process start by definition (1970) and is far outside the
+  // freshness window.
   const ancient = new Date(0).toISOString();
   await withServer([
     { key: 'a', pipelineType: 'generate', state: 'running', updatedAt: ancient, scope: { book: 'TIT' } },
@@ -94,6 +95,22 @@ test('/health/pipelines excludes stale running checkpoints from a previous proce
     assert.equal(payload.active, 0);
     assert.equal(payload.pipelines.length, 0);
   });
+});
+
+test('/health/pipelines reports recent running checkpoints from a previous process', async () => {
+  const startedAt = Date.now();
+  await withServer((now) => {
+    const interrupted = new Date(now - 10 * 60 * 1000).toISOString();
+    return [
+      { key: 'a', pipelineType: 'generate', state: 'running', updatedAt: interrupted, scope: { book: 'HOS', startChapter: 12, endChapter: 12 } },
+    ];
+  }, async (server) => {
+    const res = await request(server, '/health/pipelines');
+    const payload = JSON.parse(res.body);
+    assert.equal(payload.active, 1);
+    assert.equal(payload.pipelines[0].scope.book, 'HOS');
+    assert.equal(payload.pipelines[0].interrupted, true);
+  }, { processStartedAtMs: startedAt });
 });
 
 test('/health/pipelines excludes pipelines that have not updated within the freshness window', async () => {


### PR DESCRIPTION
## Summary
- Keep recent running checkpoints visible to /health/pipelines even after the bot process restarts
- Mark those entries as interrupted so deploy logs can explain why they are blocking
- Add regression coverage for the HOS 12 style case where a restart happened after the checkpoint update

## Investigation
- bp-assistant-skills deploy run 25330275897 did run the guard, but /health/pipelines returned active=0
- Live checkpoint stream_81_English_Book_Packages_Bot_testing__generate__HOS_12_12_na_na was still state=running and updatedAt=2026-05-04T16:14:09.926Z
- The bot process reported processStartedAt=2026-05-04T16:22:45.260Z, so the previous logic filtered the active checkpoint out as pre-process

## Verification
- node --test test/mcp-server-pipelines-health.test.js
- npm test
- git diff --check

Note: bash /home/ubuntu/.claude/scripts/verify.sh still fails before project checks because ESLint 10 cannot find eslint.config.* in this repo.