### PR TITLE
[codex] Confirm human decision conflicts before filing feedback

### DIFF
--- a/src/human-decision-conflicts.js
+++ b/src/human-decision-conflicts.js
@@ -1,0 +1,471 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const QUICK_REF_FILES = [
+  ['ult_decisions', 'data/quick-ref/ult_decisions.csv'],
+  ['ust_decisions', 'data/quick-ref/ust_decisions.csv'],
+];
+
+const BOOK_ALIASES = {
+  GEN: ['gen', 'genesis'],
+  EXO: ['exo', 'exodus'],
+  LEV: ['lev', 'leviticus'],
+  NUM: ['num', 'numbers'],
+  DEU: ['deu', 'deut', 'deuteronomy'],
+  JOS: ['jos', 'joshua'],
+  JDG: ['jdg', 'judges'],
+  RUT: ['rut', 'ruth'],
+  '1SA': ['1sa', '1 samuel', '1samuel'],
+  '2SA': ['2sa', '2 samuel', '2samuel'],
+  '1KI': ['1ki', '1 kings', '1kings'],
+  '2KI': ['2ki', '2 kings', '2kings'],
+  PSA: ['psa', 'psalm', 'psalms'],
+  ISA: ['isa', 'isaiah'],
+  JER: ['jer', 'jeremiah'],
+  LAM: ['lam', 'lamentations'],
+  EZK: ['ezk', 'ezekiel'],
+  DAN: ['dan', 'daniel'],
+  HOS: ['hos', 'hosea'],
+  JOL: ['jol', 'joel'],
+  AMO: ['amo', 'amos'],
+  OBA: ['oba', 'obadiah'],
+  JON: ['jon', 'jonah'],
+  MIC: ['mic', 'micah'],
+  NAM: ['nam', 'nahum'],
+  HAB: ['hab', 'habakkuk'],
+  ZEP: ['zep', 'zephaniah'],
+  HAG: ['hag', 'haggai'],
+  ZEC: ['zec', 'zechariah'],
+  MAL: ['mal', 'malachi'],
+};
+
+function normalizeText(text) {
+  return String(text || '')
+    .toLowerCase()
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function resolveSkillsRoot(explicitRoot) {
+  if (explicitRoot) return explicitRoot;
+  const candidates = [
+    process.env.CSKILLBP_DIR,
+    path.resolve(__dirname, '../../bp-assistant-skills'),
+    path.resolve(__dirname, '../../cSkillBP'),
+    '/srv/bot/workspace',
+    '/workspace',
+  ].filter(Boolean);
+
+  return candidates.find((candidate) =>
+    fs.existsSync(path.join(candidate, 'data', 'quick-ref'))
+  ) || candidates[0];
+}
+
+function parseCsv(content) {
+  const rows = [];
+  let row = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let index = 0; index < String(content || '').length; index++) {
+    const ch = content[index];
+    const next = content[index + 1];
+
+    if (inQuotes) {
+      if (ch === '"' && next === '"') {
+        field += '"';
+        index += 1;
+      } else if (ch === '"') {
+        inQuotes = false;
+      } else {
+        field += ch;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      row.push(field);
+      field = '';
+    } else if (ch === '\n') {
+      row.push(field.replace(/\r$/, ''));
+      rows.push(row);
+      row = [];
+      field = '';
+    } else {
+      field += ch;
+    }
+  }
+
+  if (field || row.length) {
+    row.push(field.replace(/\r$/, ''));
+    rows.push(row);
+  }
+
+  return rows.filter((items) => items.some((item) => String(item || '').trim()));
+}
+
+function rowToObject(headers, row) {
+  const obj = {};
+  for (let index = 0; index < headers.length; index++) {
+    obj[headers[index]] = row[index] || '';
+  }
+  return obj;
+}
+
+function extractAttribution(notes) {
+  const text = String(notes || '');
+  const match = text.match(/\b(?:Editor|Reported|Reporter|Submitted by):\s*([^.;()]+?)(?:\s*\(|[.;]|$)/i);
+  return match ? match[1].trim() : null;
+}
+
+function loadQuickRefDecisions(skillsRoot) {
+  const decisions = [];
+  for (const [resource, relPath] of QUICK_REF_FILES) {
+    const absPath = path.join(skillsRoot, relPath);
+    if (!fs.existsSync(absPath)) continue;
+    const rows = parseCsv(fs.readFileSync(absPath, 'utf8'));
+    if (rows.length < 2) continue;
+    const headers = rows[0].map((header) => header.trim());
+    for (const row of rows.slice(1)) {
+      const obj = rowToObject(headers, row);
+      if (normalizeText(obj.Source) !== 'human') continue;
+      decisions.push({
+        type: 'quick-ref',
+        resource,
+        sourcePath: relPath,
+        strong: String(obj.Strong || '').trim(),
+        hebrew: String(obj.Hebrew || '').trim(),
+        rendering: String(obj.Rendering || '').trim(),
+        book: String(obj.Book || '').trim().toUpperCase() || 'ALL',
+        context: String(obj.Context || '').trim(),
+        notes: String(obj.Notes || '').trim(),
+        date: String(obj.Date || '').trim() || null,
+        source: String(obj.Source || '').trim(),
+        submittedBy: extractAttribution(obj.Notes),
+        rawText: row.join(','),
+      });
+    }
+  }
+  return decisions;
+}
+
+function splitMarkdownRow(line) {
+  const trimmed = String(line || '').trim();
+  if (!trimmed.startsWith('|') || !trimmed.endsWith('|')) return null;
+  const cells = trimmed.slice(1, -1).split('|').map((cell) => cell.trim());
+  if (cells.every((cell) => /^:?-{3,}:?$/.test(cell))) return null;
+  return cells;
+}
+
+function loadGlossaryDecisions(skillsRoot) {
+  const relPath = 'data/glossary/project_glossary.md';
+  const absPath = path.join(skillsRoot, relPath);
+  if (!fs.existsSync(absPath)) return [];
+
+  const lines = fs.readFileSync(absPath, 'utf8').split(/\r?\n/);
+  let headers = null;
+  const decisions = [];
+  for (const line of lines) {
+    const cells = splitMarkdownRow(line);
+    if (!cells) continue;
+    if (!headers) {
+      headers = cells.map((cell) => normalizeText(cell));
+      continue;
+    }
+    if (cells.length < 3) continue;
+    const get = (names) => {
+      const index = headers.findIndex((header) => names.includes(header));
+      return index >= 0 ? cells[index] || '' : '';
+    };
+    const hebrew = get(['hebrew', 'term']);
+    const strong = get(['strong', "strong's", 'strongs']);
+    const ult = get(['ult', 'ult rendering']);
+    const ust = get(['ust', 'ust rendering']);
+    const notes = get(['notes', 'note']);
+    if (!hebrew && !strong && !ult && !ust && !notes) continue;
+    decisions.push({
+      type: 'glossary',
+      resource: 'project_glossary',
+      sourcePath: relPath,
+      strong: strong.trim(),
+      hebrew: hebrew.trim(),
+      rendering: ult.trim() || ust.trim(),
+      book: 'ALL',
+      context: '',
+      notes: notes.trim(),
+      date: null,
+      source: 'human',
+      submittedBy: extractAttribution(notes),
+      rawText: cells.join(' | '),
+    });
+  }
+  return decisions;
+}
+
+function loadHumanDecisions(skillsRoot) {
+  const root = resolveSkillsRoot(skillsRoot);
+  return [
+    ...loadQuickRefDecisions(root),
+    ...loadGlossaryDecisions(root),
+  ];
+}
+
+function collectReportText({ message, feedbackText, classified }) {
+  const parts = [
+    feedbackText,
+    message?.subject,
+    message?.display_recipient,
+  ];
+  for (const complaint of classified?.complaints || []) {
+    parts.push(complaint.summary, ...(complaint.evidence || []));
+  }
+  for (const issue of classified?.issues || []) {
+    parts.push(issue.title, issue.body);
+  }
+  return parts.filter(Boolean).join('\n');
+}
+
+function detectBooks(text) {
+  const normalized = normalizeText(text);
+  const found = new Set();
+  for (const [book, aliases] of Object.entries(BOOK_ALIASES)) {
+    if (aliases.some((alias) => new RegExp(`\\b${alias.replace(/\s+/g, '\\s+')}\\b`, 'i').test(normalized))) {
+      found.add(book);
+    }
+  }
+  return found;
+}
+
+function bookApplies(decision, reportBooks) {
+  if (!decision.book || decision.book === 'ALL') return true;
+  if (reportBooks.size === 0) return true;
+  return reportBooks.has(decision.book);
+}
+
+function extractRejectedPhrases(notes) {
+  const phrases = [];
+  const text = String(notes || '');
+  const pattern = /\b(?:never|not|do not|don't|avoid)\b[^."'“”']{0,80}(?:"([^"]+)"|'([^']+)'|“([^”]+)”|‘([^’]+)’)/gi;
+  let match;
+  while ((match = pattern.exec(text))) {
+    const phrase = (match[1] || match[2] || match[3] || match[4] || '').trim();
+    if (phrase && !phrases.includes(phrase)) phrases.push(phrase);
+  }
+  return phrases;
+}
+
+function phraseAppearsDesired(text, phrase) {
+  const normalized = normalizeText(text);
+  const normalizedPhrase = normalizeText(phrase);
+  if (!normalizedPhrase) return false;
+
+  let index = normalized.indexOf(normalizedPhrase);
+  while (index >= 0) {
+    const before = normalized.slice(Math.max(0, index - 100), index);
+    const after = normalized.slice(index + normalizedPhrase.length, index + normalizedPhrase.length + 80);
+    const window = `${before} ${normalizedPhrase} ${after}`;
+    const desired = /\b(?:should|please|prefer|expected|expect|needs?|must|correct|change(?:d)?\s+to|use|uses|using|render(?:ed|ing)?\s+(?:as|with|to)?)\b/i.test(window);
+    const negated = /\b(?:actual behavior|wrong|incorrect|bad|avoid|not|never|instead of|should not|do not|don't)\b/i.test(before.slice(-45));
+    if (desired && !negated) return true;
+    index = normalized.indexOf(normalizedPhrase, index + normalizedPhrase.length);
+  }
+  return false;
+}
+
+function scoreDecision(decision, reportText, reportBooks) {
+  if (!bookApplies(decision, reportBooks)) return null;
+
+  const normalized = normalizeText(reportText);
+  const reasons = [];
+  let score = 0;
+
+  for (const phrase of extractRejectedPhrases(decision.notes)) {
+    if (phraseAppearsDesired(reportText, phrase)) {
+      score += 12;
+      reasons.push(`requested rejected phrase "${phrase}"`);
+    } else if (normalized.includes(normalizeText(phrase))) {
+      score += 3;
+      reasons.push(`mentioned rejected phrase "${phrase}"`);
+    }
+  }
+
+  for (const [label, value, points] of [
+    ['Strong', decision.strong, 5],
+    ['Hebrew', decision.hebrew, 5],
+    ['rendering', decision.rendering, 2],
+  ]) {
+    const term = normalizeText(value);
+    if (term && normalized.includes(term)) {
+      score += points;
+      reasons.push(`matched ${label} ${value}`);
+    }
+  }
+
+  if (decision.book && decision.book !== 'ALL' && reportBooks.has(decision.book)) {
+    score += 1;
+    reasons.push(`matched book ${decision.book}`);
+  }
+
+  if (score < 8) return null;
+  return { decision, score, reasons };
+}
+
+function defaultAdjudicateConflict({ candidates }) {
+  const sorted = [...candidates].sort((a, b) => b.score - a.score);
+  const best = sorted.find((candidate) =>
+    candidate.reasons.some((reason) => reason.startsWith('requested rejected phrase'))
+  ) || sorted[0];
+  if (!best) return null;
+  return {
+    decision: best.decision,
+    candidates: sorted,
+    reasons: best.reasons,
+  };
+}
+
+function truncateSummary(text, maxLength = 220) {
+  const trimmed = String(text || '').replace(/\s+/g, ' ').trim();
+  if (trimmed.length <= maxLength) return trimmed;
+  return `${trimmed.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function capitalizeFirst(text) {
+  const trimmed = String(text || '').trim();
+  if (!trimmed) return '';
+  return `${trimmed[0].toUpperCase()}${trimmed.slice(1)}`;
+}
+
+function summarizeHumanFeedback({ feedbackText, classified } = {}) {
+  const complaintSummary = classified?.complaints
+    ?.map((complaint) => complaint?.summary)
+    .find((summary) => String(summary || '').trim());
+  if (complaintSummary) return truncateSummary(capitalizeFirst(complaintSummary));
+
+  const issueTitle = classified?.issues
+    ?.map((issue) => issue?.title)
+    .find((title) => String(title || '').trim());
+  if (issueTitle) return truncateSummary(capitalizeFirst(issueTitle));
+
+  return truncateSummary(capitalizeFirst(feedbackText));
+}
+
+async function findHumanDecisionConflict({
+  message,
+  feedbackText,
+  classified,
+  skillsRoot,
+  adjudicateConflict = defaultAdjudicateConflict,
+} = {}) {
+  if (!classified?.issues?.some((issue) => issue.repo === 'bp-assistant-skills')) return null;
+
+  const reportText = collectReportText({ message, feedbackText, classified });
+  const reportBooks = detectBooks(reportText);
+  const candidates = loadHumanDecisions(skillsRoot)
+    .map((decision) => scoreDecision(decision, reportText, reportBooks))
+    .filter(Boolean)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 8);
+
+  if (candidates.length === 0) return null;
+  const conflict = adjudicateConflict({ message, feedbackText, classified, candidates, reportText }) || null;
+  if (!conflict) return null;
+  return {
+    ...conflict,
+    feedbackSummary: summarizeHumanFeedback({ feedbackText, classified }),
+  };
+}
+
+function formatHumanDate(date) {
+  const match = String(date || '').match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return date || 'an earlier date';
+  const parsed = new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
+  return parsed.toLocaleDateString('en-US', { month: 'long', day: 'numeric', timeZone: 'UTC' });
+}
+
+function summarizeDecision(decision) {
+  const parts = [];
+  if (decision.strong) parts.push(decision.strong);
+  if (decision.hebrew) parts.push(decision.hebrew);
+  if (decision.rendering) parts.push(`"${decision.rendering}"`);
+  return parts.join(' / ') || decision.rawText || 'human decision';
+}
+
+function summarizePriorDecision(decision) {
+  if (!decision) return '';
+  const subjectParts = [];
+  if (decision.strong) subjectParts.push(decision.strong);
+  if (decision.hebrew) subjectParts.push(decision.hebrew);
+
+  const subject = subjectParts.join(' / ');
+  const scope = decision.book && decision.book !== 'ALL' ? ` for ${decision.book}` : '';
+  const rendering = decision.rendering ? `use "${decision.rendering}"${scope}` : `follow the recorded decision${scope}`;
+  const notes = truncateSummary(decision.notes, 180);
+
+  const prefix = subject ? `${subject}: ` : '';
+  return notes
+    ? `${prefix}${rendering}. ${notes}`
+    : `${prefix}${rendering}.`;
+}
+
+function formatDecisionConflictPrompt(conflict) {
+  const decision = conflict?.decision || {};
+  const date = formatHumanDate(decision.date);
+  const lines = [];
+  if (decision.submittedBy) {
+    lines.push(`This conflicts with human decision submitted by ${decision.submittedBy} on ${date}.`);
+  } else if (decision.date) {
+    lines.push(`This conflicts with a human decision recorded on ${date}.`);
+  } else {
+    lines.push('This conflicts with an earlier human decision.');
+  }
+
+  if (conflict?.feedbackSummary) {
+    lines.push('', `Feedback summary: ${conflict.feedbackSummary}`);
+  }
+
+  const priorDecisionSummary = summarizePriorDecision(decision);
+  if (priorDecisionSummary) {
+    lines.push(`Prior decision: ${priorDecisionSummary}`);
+  }
+
+  lines.push('', 'Do you still wish to file this feedback (yes/no)?');
+  return lines.join('\n');
+}
+
+function formatConflictIssueSection(conflict) {
+  if (!conflict?.decision) return '';
+  const decision = conflict.decision;
+  const source = summarizeDecision(decision);
+  const attribution = decision.submittedBy
+    ? `${decision.submittedBy} on ${formatHumanDate(decision.date)}`
+    : decision.date
+      ? `human decision recorded on ${formatHumanDate(decision.date)}`
+      : 'earlier human decision';
+  return [
+    '## Conflicts with prior human decision',
+    '',
+    `This feedback was confirmed for filing even though it appears to conflict with ${attribution}.`,
+    '',
+    `Decision: ${source}`,
+    decision.notes ? `Notes: ${decision.notes}` : '',
+  ].filter((line) => line !== '').join('\n');
+}
+
+module.exports = {
+  findHumanDecisionConflict,
+  formatDecisionConflictPrompt,
+  formatConflictIssueSection,
+  loadHumanDecisions,
+  parseCsv,
+  resolveSkillsRoot,
+  summarizePriorDecision,
+  summarizeHumanFeedback,
+  _extractRejectedPhrases: extractRejectedPhrases,
+  _phraseAppearsDesired: phraseAppearsDesired,
+};

--- a/src/issue-report-pipeline.js
+++ b/src/issue-report-pipeline.js
@@ -8,6 +8,11 @@ const {
   createGithubIssue,
   updateGithubIssue,
 } = require('./github-issues');
+const {
+  findHumanDecisionConflict,
+  formatDecisionConflictPrompt,
+  formatConflictIssueSection,
+} = require('./human-decision-conflicts');
 
 let _query = null;
 async function getQuery() {
@@ -22,6 +27,7 @@ const VALID_REPOS = new Set(['bp-assistant', 'bp-assistant-skills']);
 const VALID_LABELS = new Set(['bug', 'enhancement', 'ai-quality', 'template-compliance']);
 const TRIGGER_RE = /^(?:report|feedback|issue|bug)[:\s]\s*([\s\S]+)/i;
 const CLASSIFIER_MAX_TOKENS = [2048, 8192];
+const pendingHumanDecisionConflicts = new Map();
 
 const SYSTEM_PROMPT = `You are an issue classifier for a Bible translation AI pipeline with two GitHub repositories:
 
@@ -409,6 +415,99 @@ function summarizeIssues(issues) {
     .join(' and ');
 }
 
+function buildPendingConflictKey(message) {
+  if (message?.type === 'stream') {
+    return `stream-${message.display_recipient}-${message.subject}-${message.sender_id}`;
+  }
+  return `dm-${message?.sender_id}`;
+}
+
+function setPendingHumanDecisionConflict(message, pending) {
+  pendingHumanDecisionConflicts.set(buildPendingConflictKey(message), {
+    ...pending,
+    createdAt: new Date().toISOString(),
+  });
+}
+
+function getPendingHumanDecisionConflict(message) {
+  return pendingHumanDecisionConflicts.get(buildPendingConflictKey(message)) || null;
+}
+
+function clearPendingHumanDecisionConflict(message) {
+  pendingHumanDecisionConflicts.delete(buildPendingConflictKey(message));
+}
+
+function addConflictSectionToBody(body, conflict) {
+  const section = formatConflictIssueSection(conflict);
+  if (!section) return body;
+  return `${String(body || '').trim()}\n\n${section}`;
+}
+
+async function createIssuesForClassifiedReport({ message, classified, deps, conflict = null }) {
+  const githubToken = deps.readSecret('github_token', 'GITHUB_TOKEN');
+  if (!githubToken) throw new Error('github_token secret not configured');
+
+  const plannedIssues = classified.issues.map((issue) => ({
+    ...issue,
+    body: conflict ? addConflictSectionToBody(issue.body, conflict) : issue.body,
+  }));
+
+  const issueRecords = [];
+  for (const issuePlan of plannedIssues) {
+    const marker = buildIssueMarker(message.id, issuePlan.id);
+    const dedupeMarker = buildIssueDedupeMarker(message.id, issuePlan.repo, issuePlan.complaint_ids);
+    const existing = await searchExistingIssueByMarkers(
+      deps.fetchImpl,
+      githubToken,
+      issuePlan.repo,
+      [dedupeMarker, marker]
+    );
+    if (existing) {
+      issueRecords.push({ ...existing, issue_id: issuePlan.id, complaint_ids: issuePlan.complaint_ids });
+      continue;
+    }
+
+    const created = await createGithubIssue(deps.fetchImpl, githubToken, issuePlan.repo, {
+      title: issuePlan.title,
+      body: injectMetadata(issuePlan.body, [dedupeMarker, marker]),
+      labels: issuePlan.labels,
+    });
+    console.log(`[issue-report] Created ${issuePlan.repo}#${created.number}: ${issuePlan.title}`);
+    issueRecords.push({ ...created, issue_id: issuePlan.id, complaint_ids: issuePlan.complaint_ids });
+  }
+
+  if (issueRecords.length > 1) {
+    const bodyById = new Map(plannedIssues.map((issue) => [issue.id, issue.body]));
+    for (const issueRecord of issueRecords) {
+      const issuePlan = plannedIssues.find((issue) => issue.id === issueRecord.issue_id);
+      if (!issuePlan) {
+        throw new Error(`Classifier returned issue ${issueRecord.issue_id} without a matching plan`);
+      }
+      const desiredBody = addOrReplaceRelatedIssueSection(
+        injectMetadata(bodyById.get(issueRecord.issue_id), [
+          buildIssueDedupeMarker(message.id, issueRecord.repo, issuePlan.complaint_ids),
+          buildIssueMarker(message.id, issueRecord.issue_id),
+        ]),
+        issueRecord.repo,
+        issueRecords.filter((candidate) => candidate.issue_id !== issueRecord.issue_id),
+        classified.ownership
+      );
+      if (desiredBody !== issueRecord.body) {
+        const updated = await updateGithubIssue(
+          deps.fetchImpl,
+          githubToken,
+          issueRecord.repo,
+          issueRecord.number,
+          { body: desiredBody }
+        );
+        issueRecord.body = updated.body;
+      }
+    }
+  }
+
+  return issueRecords;
+}
+
 function getRuntimeDeps(overrides = {}) {
   return {
     runClassifierQuery: overrides.runClassifierQuery || ((args) => runAgentSdkClassifierQuery({
@@ -421,6 +520,12 @@ function getRuntimeDeps(overrides = {}) {
     removeReaction: overrides.removeReaction || removeReaction,
     readSecret: overrides.readSecret || readSecret,
     fetchImpl: overrides.fetchImpl || fetch,
+    findHumanDecisionConflict: overrides.findHumanDecisionConflict || ((args) => findHumanDecisionConflict({
+      ...args,
+      skillsRoot: overrides.skillsRoot,
+      adjudicateConflict: overrides.adjudicateConflict,
+    })),
+    setPendingHumanDecisionConflict: overrides.setPendingHumanDecisionConflict || setPendingHumanDecisionConflict,
   };
 }
 
@@ -443,62 +548,16 @@ async function issueReportPipeline(route, message, overrides = {}) {
 
   try {
     const classified = await classifyIssueReport(deps, buildClassifierInput(message, feedbackText));
-    const githubToken = deps.readSecret('github_token', 'GITHUB_TOKEN');
-    if (!githubToken) throw new Error('github_token secret not configured');
 
-    const issueRecords = [];
-    for (const issuePlan of classified.issues) {
-      const marker = buildIssueMarker(message.id, issuePlan.id);
-      const dedupeMarker = buildIssueDedupeMarker(message.id, issuePlan.repo, issuePlan.complaint_ids);
-      const existing = await searchExistingIssueByMarkers(
-        deps.fetchImpl,
-        githubToken,
-        issuePlan.repo,
-        [dedupeMarker, marker]
-      );
-      if (existing) {
-        issueRecords.push({ ...existing, issue_id: issuePlan.id, complaint_ids: issuePlan.complaint_ids });
-        continue;
-      }
-
-      const created = await createGithubIssue(deps.fetchImpl, githubToken, issuePlan.repo, {
-        title: issuePlan.title,
-        body: injectMetadata(issuePlan.body, [dedupeMarker, marker]),
-        labels: issuePlan.labels,
-      });
-      console.log(`[issue-report] Created ${issuePlan.repo}#${created.number}: ${issuePlan.title}`);
-      issueRecords.push({ ...created, issue_id: issuePlan.id, complaint_ids: issuePlan.complaint_ids });
+    const conflict = await deps.findHumanDecisionConflict({ message, feedbackText, classified });
+    if (conflict) {
+      deps.setPendingHumanDecisionConflict(message, { route, message, classified, conflict });
+      await sendReplyWith(message, formatDecisionConflictPrompt(conflict), deps);
+      try { await deps.removeReaction(message.id, 'eyes'); } catch (_) {}
+      return;
     }
 
-    if (issueRecords.length > 1) {
-      const bodyById = new Map(classified.issues.map((issue) => [issue.id, issue.body]));
-      for (const issueRecord of issueRecords) {
-        const issuePlan = classified.issues.find((issue) => issue.id === issueRecord.issue_id);
-        if (!issuePlan) {
-          throw new Error(`Classifier returned issue ${issueRecord.issue_id} without a matching plan`);
-        }
-        const desiredBody = addOrReplaceRelatedIssueSection(
-          injectMetadata(bodyById.get(issueRecord.issue_id), [
-            buildIssueDedupeMarker(message.id, issueRecord.repo, issuePlan.complaint_ids),
-            buildIssueMarker(message.id, issueRecord.issue_id),
-          ]),
-          issueRecord.repo,
-          issueRecords.filter((candidate) => candidate.issue_id !== issueRecord.issue_id),
-          classified.ownership
-        );
-        if (desiredBody !== issueRecord.body) {
-          const updated = await updateGithubIssue(
-            deps.fetchImpl,
-            githubToken,
-            issueRecord.repo,
-            issueRecord.number,
-            { body: desiredBody }
-          );
-          issueRecord.body = updated.body;
-        }
-      }
-    }
-
+    const issueRecords = await createIssuesForClassifiedReport({ message, classified, deps });
     await sendReplyWith(message, `Filed ${summarizeIssues(issueRecords)}.`, deps);
 
     try { await deps.removeReaction(message.id, 'eyes'); } catch (_) {}
@@ -511,12 +570,59 @@ async function issueReportPipeline(route, message, overrides = {}) {
   }
 }
 
+async function handlePendingHumanDecisionConflictReply(message, options = {}, overrides = {}) {
+  const pending = getPendingHumanDecisionConflict(message);
+  if (!pending) return false;
+
+  const isYes = options.isYes || (() => false);
+  const isNo = options.isNo || (() => false);
+  const deps = getRuntimeDeps(overrides);
+
+  if (message.sender_id !== pending.message.sender_id) return true;
+
+  if (isYes(message.content)) {
+    clearPendingHumanDecisionConflict(message);
+    try { await deps.addReaction(message.id, 'working_on_it'); } catch (_) {}
+    try {
+      const issueRecords = await createIssuesForClassifiedReport({
+        message: pending.message,
+        classified: pending.classified,
+        deps,
+        conflict: pending.conflict,
+      });
+      await sendReplyWith(pending.message, `Filed ${summarizeIssues(issueRecords)}.`, deps);
+      try { await deps.removeReaction(message.id, 'working_on_it'); } catch (_) {}
+      try { await deps.addReaction(message.id, 'check'); } catch (_) {}
+    } catch (err) {
+      console.error('[issue-report] Error filing confirmed conflict report:', err.message);
+      await sendReplyWith(pending.message, `Failed to file issue: ${err.message}`, deps);
+      try { await deps.removeReaction(message.id, 'working_on_it'); } catch (_) {}
+      try { await deps.addReaction(message.id, 'warning'); } catch (_) {}
+    }
+    return true;
+  }
+
+  if (isNo(message.content)) {
+    clearPendingHumanDecisionConflict(message);
+    await sendReplyWith(pending.message, 'No issue filed.', deps);
+    return true;
+  }
+
+  clearPendingHumanDecisionConflict(message);
+  return false;
+}
+
 module.exports = {
   issueReportPipeline,
+  handlePendingHumanDecisionConflictReply,
   _extractFeedbackText: extractFeedbackText,
   _buildClassifierInput: buildClassifierInput,
   _parseClassifierOutput: parseClassifierOutput,
   _buildIssueMarker: buildIssueMarker,
   _buildIssueDedupeMarker: buildIssueDedupeMarker,
   _addOrReplaceRelatedIssueSection: addOrReplaceRelatedIssueSection,
+  _buildPendingConflictKey: buildPendingConflictKey,
+  _getPendingHumanDecisionConflict: getPendingHumanDecisionConflict,
+  _clearPendingHumanDecisionConflict: clearPendingHumanDecisionConflict,
+  _createIssuesForClassifiedReport: createIssuesForClassifiedReport,
 };

--- a/src/router.js
+++ b/src/router.js
@@ -12,6 +12,7 @@ const { resumeInsertion } = require('./insertion-resume');
 const { normalizeBookName, isValidBook } = require('./pipeline-utils');
 const { isTransientOutageError } = require('./claude-runner');
 const { publishAdminStatus } = require('./admin-status');
+const { handlePendingHumanDecisionConflictReply } = require('./issue-report-pipeline');
 
 // In-memory pending confirmations for stream messages
 const pendingConfirmations = new Map();
@@ -916,6 +917,9 @@ async function routeMessage(message) {
       return;
     }
   } else {
+    const handledIssueReportConflict = await handlePendingHumanDecisionConflictReply(message, { isYes, isNo });
+    if (handledIssueReportConflict) return;
+
     // Check for pending confirmation BEFORE auth check — otherwise non-authorized
     // users talking in a topic with a pending confirmation get an unauthorized reply
     // instead of being silently ignored.

--- a/test/issue-report-pipeline.test.js
+++ b/test/issue-report-pipeline.test.js
@@ -1,12 +1,24 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const {
   issueReportPipeline,
+  handlePendingHumanDecisionConflictReply,
   _extractFeedbackText,
   _buildClassifierInput,
   _parseClassifierOutput,
+  _clearPendingHumanDecisionConflict,
 } = require('../src/issue-report-pipeline');
+const {
+  findHumanDecisionConflict,
+  formatDecisionConflictPrompt,
+  loadHumanDecisions,
+  summarizePriorDecision,
+  summarizeHumanFeedback,
+} = require('../src/human-decision-conflicts');
 
 function buildMessage(overrides = {}) {
   return {
@@ -33,8 +45,19 @@ function buildClassifierResult(payload) {
   };
 }
 
+function createEmptySkillsRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bp-empty-skills-'));
+  fs.mkdirSync(path.join(root, 'data/quick-ref'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'data/glossary'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'data/quick-ref/ult_decisions.csv'), 'Strong,Hebrew,Rendering,Book,Context,Notes,Date,Source\n');
+  fs.writeFileSync(path.join(root, 'data/quick-ref/ust_decisions.csv'), 'Strong,Hebrew,Rendering,Book,Context,Notes,Date,Source\n');
+  fs.writeFileSync(path.join(root, 'data/glossary/project_glossary.md'), '');
+  return root;
+}
+
 function createRuntime({ classifierPayload, fetchImpl, sentReplies, classifierInputs }) {
   return {
+    skillsRoot: createEmptySkillsRoot(),
     runClassifierQuery: async ({ classifierInput }) => {
       classifierInputs.push(classifierInput);
       return buildClassifierResult(classifierPayload);
@@ -145,6 +168,52 @@ function buildClassifierPayload({ complaints, ownership, issues }) {
   return { complaints, ownership, issues };
 }
 
+function createSkillsRoot({ withAttribution = false } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bp-skills-decisions-'));
+  fs.mkdirSync(path.join(root, 'data/quick-ref'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'data/glossary'), { recursive: true });
+  const notes = withAttribution
+    ? '"Never \'Yahweh of hosts\'. Always \'Yahweh of Armies\'. Submitted by: Chris Smith."'
+    : '"Never \'Yahweh of hosts\' (archaic). Always \'Yahweh of Armies\'. See H6635b entry."';
+  fs.writeFileSync(path.join(root, 'data/quick-ref/ult_decisions.csv'), [
+    'Strong,Hebrew,Rendering,Book,Context,Notes,Date,Source',
+    `H3068+H6635,יְהוָה צְבָאוֹת,Yahweh of Armies,ALL,divine title throughout Isaiah,${notes},2026-04-21,human`,
+    'H9999,דמה,unrelated,ALL,unrelated,AI-only row,2026-04-21,AI',
+  ].join('\n'));
+  fs.writeFileSync(path.join(root, 'data/quick-ref/ust_decisions.csv'), 'Strong,Hebrew,Rendering,Book,Context,Notes,Date,Source\n');
+  fs.writeFileSync(path.join(root, 'data/glossary/project_glossary.md'), [
+    '| Hebrew | Strong | ULT | UST | Notes |',
+    '|---|---|---|---|---|',
+    '| צְבָאוֹת | H6635 | armies | hosts | ULT: "Yahweh of Armies" (not "hosts"). |',
+  ].join('\n'));
+  return root;
+}
+
+function buildJeremiahHostsPayload() {
+  return buildClassifierPayload({
+    complaints: [{
+      id: 'c1',
+      summary: 'Jeremiah notes should use Yahweh of hosts',
+      evidence: ['Please use Yahweh of hosts in Jeremiah notes.'],
+      likely_layers: ['bp-assistant-skills'],
+    }],
+    ownership: {
+      repositories: ['bp-assistant-skills'],
+      primary_repo: 'bp-assistant-skills',
+      secondary_repo: null,
+      rationale: 'Skill-side translation preference.',
+    },
+    issues: [{
+      id: 'i1',
+      repo: 'bp-assistant-skills',
+      complaint_ids: ['c1'],
+      title: 'Use Yahweh of hosts in Jeremiah notes',
+      body: '## Summary\n\nJeremiah notes should use Yahweh of hosts instead of Yahweh of Armies.\n\n## Steps to Reproduce\n\n1. Run tn-writer for Jeremiah.\n\n## Expected Behavior\n\nUse Yahweh of hosts.\n\n## Actual Behavior\n\nUses Yahweh of Armies.\n\n## Reporter\n\nProof Reader',
+      labels: ['bug'],
+    }],
+  });
+}
+
 test('extractFeedbackText strips Zulip mentions and explicit trigger prefixes', () => {
   const feedback = _extractFeedbackText('@**bp-bot** feedback: Split snippets still happen in Psalm 38');
   assert.equal(feedback, 'Split snippets still happen in Psalm 38');
@@ -237,6 +306,158 @@ test('parseClassifierOutput accepts valid fenced JSON', () => {
   const parsed = _parseClassifierOutput(wrapInJsonFence(JSON.stringify(payload)));
   assert.equal(parsed.complaints[0].id, 'c1');
   assert.equal(parsed.issues[0].repo, 'bp-assistant-skills');
+});
+
+test('human decision conflict parser detects rejected Yahweh of hosts preference', async () => {
+  const skillsRoot = createSkillsRoot();
+  const decisions = loadHumanDecisions(skillsRoot);
+  assert.ok(decisions.some((decision) => decision.strong === 'H3068+H6635' && decision.source === 'human'));
+  assert.ok(decisions.every((decision) => decision.rendering !== 'unrelated'));
+
+  const conflict = await findHumanDecisionConflict({
+    message: buildMessage({ subject: 'Jeremiah BP' }),
+    feedbackText: 'Please use Yahweh of hosts in Jeremiah notes.',
+    classified: buildJeremiahHostsPayload(),
+    skillsRoot,
+  });
+
+  assert.equal(conflict.decision.strong, 'H3068+H6635');
+  assert.equal(conflict.decision.date, '2026-04-21');
+  assert.equal(conflict.feedbackSummary, 'Jeremiah notes should use Yahweh of hosts');
+  assert.match(formatDecisionConflictPrompt(conflict), /^This conflicts with a human decision recorded on April 21\./);
+  assert.match(formatDecisionConflictPrompt(conflict), /Feedback summary: Jeremiah notes should use Yahweh of hosts/);
+  assert.match(formatDecisionConflictPrompt(conflict), /Prior decision: H3068\+H6635 \/ יְהוָה צְבָאוֹת: use "Yahweh of Armies"\. Never 'Yahweh of hosts'/);
+});
+
+test('human decision conflict prompt uses submitter when decision notes contain one', async () => {
+  const skillsRoot = createSkillsRoot({ withAttribution: true });
+  const conflict = await findHumanDecisionConflict({
+    message: buildMessage({ subject: 'Jeremiah BP' }),
+    feedbackText: 'Please use Yahweh of hosts in Jeremiah notes.',
+    classified: buildJeremiahHostsPayload(),
+    skillsRoot,
+  });
+
+  assert.match(formatDecisionConflictPrompt(conflict), /submitted by Chris Smith on April 21/);
+});
+
+test('summarizeHumanFeedback prefers classifier complaint summary and normalizes capitalization', () => {
+  const summary = summarizeHumanFeedback({
+    feedbackText: 'please use rescue for hiphils of H5337',
+    classified: {
+      complaints: [{ summary: 'use rescue for Hiphil forms of H5337' }],
+      issues: [{ title: 'Fallback title' }],
+    },
+  });
+
+  assert.equal(summary, 'Use rescue for Hiphil forms of H5337');
+});
+
+test('summarizePriorDecision includes rendering scope and notes', () => {
+  const summary = summarizePriorDecision({
+    strong: 'H5337',
+    hebrew: 'נָצַל',
+    rendering: 'deliver',
+    book: 'ALL',
+    notes: "Project preference: 'deliver' not 'rescue' for נצל Hiphil. Editor ISA 47:14.",
+  });
+
+  assert.equal(
+    summary,
+    "H5337 / נָצַל: use \"deliver\". Project preference: 'deliver' not 'rescue' for נצל Hiphil. Editor ISA 47:14."
+  );
+});
+
+test('issueReportPipeline pauses skills issue when feedback conflicts with human decision', async () => {
+  const message = buildMessage({
+    subject: 'Jeremiah BP',
+    content: 'feedback: Please use Yahweh of hosts in Jeremiah notes.',
+  });
+  _clearPendingHumanDecisionConflict(message);
+  const classifierInputs = [];
+  const sentReplies = [];
+  const { fetchImpl, store } = createGithubFetchStub();
+  const runtime = createRuntime({
+    classifierPayload: buildJeremiahHostsPayload(),
+    fetchImpl,
+    sentReplies,
+    classifierInputs,
+  });
+
+  await issueReportPipeline({}, message, { ...runtime, skillsRoot: createSkillsRoot() });
+
+  assert.equal(store.issues['bp-assistant-skills'].length, 0);
+  assert.equal(store.postsByRepo['bp-assistant-skills'], 0);
+  assert.match(sentReplies[0].text, /^This conflicts with a human decision recorded on April 21\./);
+  assert.match(sentReplies[0].text, /Feedback summary: Jeremiah notes should use Yahweh of hosts/);
+  assert.match(sentReplies[0].text, /Do you still wish to file this feedback \(yes\/no\)\?/);
+  _clearPendingHumanDecisionConflict(message);
+});
+
+test('confirmed human-decision conflict files issue with conflict section and markers', async () => {
+  const message = buildMessage({
+    subject: 'Jeremiah BP',
+    content: 'feedback: Please use Yahweh of hosts in Jeremiah notes.',
+  });
+  _clearPendingHumanDecisionConflict(message);
+  const classifierInputs = [];
+  const sentReplies = [];
+  const { fetchImpl, store } = createGithubFetchStub();
+  const runtime = createRuntime({
+    classifierPayload: buildJeremiahHostsPayload(),
+    fetchImpl,
+    sentReplies,
+    classifierInputs,
+  });
+
+  await issueReportPipeline({}, message, { ...runtime, skillsRoot: createSkillsRoot() });
+  const handled = await handlePendingHumanDecisionConflictReply(
+    buildMessage({ ...message, content: 'yes', id: 5000 }),
+    {
+      isYes: (content) => /^yes$/i.test(String(content).trim()),
+      isNo: (content) => /^no$/i.test(String(content).trim()),
+    },
+    runtime
+  );
+
+  assert.equal(handled, true);
+  assert.equal(store.issues['bp-assistant-skills'].length, 1);
+  assert.match(store.issues['bp-assistant-skills'][0].body, /## Conflicts with prior human decision/);
+  assert.match(store.issues['bp-assistant-skills'][0].body, /issue-report:4242:i1/);
+  assert.match(store.issues['bp-assistant-skills'][0].body, /issue-report:4242:bp-assistant-skills:c1/);
+  assert.match(sentReplies[1].text, /Filed \[\*\*bp-assistant-skills#1\*\*\]/);
+});
+
+test('declined human-decision conflict clears pending report without filing', async () => {
+  const message = buildMessage({
+    subject: 'Jeremiah BP',
+    content: 'feedback: Please use Yahweh of hosts in Jeremiah notes.',
+  });
+  _clearPendingHumanDecisionConflict(message);
+  const classifierInputs = [];
+  const sentReplies = [];
+  const { fetchImpl, store } = createGithubFetchStub();
+  const runtime = createRuntime({
+    classifierPayload: buildJeremiahHostsPayload(),
+    fetchImpl,
+    sentReplies,
+    classifierInputs,
+  });
+
+  await issueReportPipeline({}, message, { ...runtime, skillsRoot: createSkillsRoot() });
+  const handled = await handlePendingHumanDecisionConflictReply(
+    buildMessage({ ...message, content: 'no', id: 5001 }),
+    {
+      isYes: (content) => /^yes$/i.test(String(content).trim()),
+      isNo: (content) => /^no$/i.test(String(content).trim()),
+    },
+    runtime
+  );
+
+  assert.equal(handled, true);
+  assert.equal(store.issues['bp-assistant-skills'].length, 0);
+  assert.equal(store.postsByRepo['bp-assistant-skills'], 0);
+  assert.equal(sentReplies[1].text, 'No issue filed.');
 });
 
 test('issueReportPipeline retries classifier when JSON is truncated at max_tokens', async () => {


### PR DESCRIPTION
## Summary
- Add an up-front human decision conflict gate for issue-report intake.
- Summarize the conflicting prior decision in the Zulip yes/no prompt.
- Preserve classified issue plans so confirmed feedback files with conflict context.

## Validation
- npm test
- bash /home/ubuntu/.claude/scripts/verify.sh (fails: repo has no eslint.config.js, so ESLint exits before checks continue)