### PR TITLE
fix: resume initial pipeline early exits

### DIFF
--- a/src/claude-runner.js
+++ b/src/claude-runner.js
@@ -129,6 +129,7 @@ function buildOptions({
 async function runClaudeOnce({
   prompt,
   cwd,
+  resume,
   model,
   betas,
   allowedTools,
@@ -191,6 +192,7 @@ async function runClaudeOnce({
 
   const options = buildOptions({
     cwd,
+    resume,
     model,
     betas,
     allowedTools,

--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -43,6 +43,22 @@ const INITIAL_PIPELINE_COMPLETION_GUARDRAIL = [
   'If any of those required outputs are missing, continue the pipeline or return a failure instead of success.',
 ].join(' ');
 
+function buildInitialPipelineContinuationPrompt({ book, chapter, missing = [], observed = [] }) {
+  const chapterTag = buildChapterTag(book, chapter);
+  return [
+    `Continue the existing initial-pipeline run for ${book} ${chapter}.`,
+    'Do not invoke a slash command. Resume from the artifacts already on disk and finish the remaining pipeline waves.',
+    `Current missing final outputs: ${missing.length ? missing.join(', ') : 'unknown'}.`,
+    `Observed artifacts: ${observed.length ? observed.join(', ') : '(none)'}.`,
+    'Wave 1 and Wave 2 outputs are intermediate only.',
+    `Complete Wave 3 challenge/defend, Wave 4 merge/revision, Wave 5 verification if needed, and Wave 6 UST generation for ${book} ${chapter}.`,
+    'Before returning success, verify these final files exist and are non-empty:',
+    `output/AI-ULT/${book}/${chapterTag}.usfm`,
+    `output/issues/${book}/${chapterTag}.tsv`,
+    `output/AI-UST/${book}/${chapterTag}.usfm`,
+  ].join('\n');
+}
+
 function hasFreshFlag(content) {
   return /--fresh\b/i.test(String(content || '')) || /--new\b/i.test(String(content || ''));
 }
@@ -434,13 +450,15 @@ async function generatePipeline(route, message) {
 
   const tokensBefore = getCumulativeTokens();
   let success = Number(existingCheckpoint?.success || 0);
-  let fail = Number(existingCheckpoint?.fail || 0);
+  let fail = existingCheckpoint?.state === 'failed' ? 0 : Number(existingCheckpoint?.fail || 0);
   const completedChapters = Array.isArray(existingCheckpoint?.completedChapters) ? [...existingCheckpoint.completedChapters] : []; // Phase 1 results for non-file-response users
   let abortForUsageLimit = false;
   let abortForOutage = false;
   let usageLimitTag = null;
   let resumeChapter = Number(existingCheckpoint?.resume?.chapter || start);
   let resumeSkill = existingCheckpoint?.resume?.skill || null;
+  let resumeSessionId = existingCheckpoint?.resume?.sessionId || null;
+  let resumeMode = existingCheckpoint?.resume?.mode || null;
 
   const canResumeFromCheckpoint = (
     existingCheckpoint?.resume?.chapter != null &&
@@ -452,13 +470,20 @@ async function generatePipeline(route, message) {
   } else {
     resumeChapter = start;
     resumeSkill = null;
+    resumeSessionId = null;
+    resumeMode = null;
   }
   setCheckpoint(checkpointRef, {
     state: 'running',
     success,
     fail,
     completedChapters,
-    resume: { chapter: resumeChapter, skill: resumeSkill },
+    resume: {
+      chapter: resumeChapter,
+      skill: resumeSkill,
+      sessionId: resumeSessionId || undefined,
+      mode: resumeMode || undefined,
+    },
   });
 
   // =========================================================================
@@ -480,6 +505,13 @@ async function generatePipeline(route, message) {
     let claudeResult = null;
     let sdkError = null;
     const runInitialSkill = !(ch === resumeChapter && resumeSkill === 'align-all-parallel');
+    const resumeInitialPipelineEarlyExit = (
+      ch === resumeChapter &&
+      isInitialPipelineSkill &&
+      resumeSkill === 'initial-pipeline' &&
+      resumeMode === 'continue_after_early_exit' &&
+      !!resumeSessionId
+    );
     let directUstContext = null;
     let directUstUltPath = null;
 
@@ -515,20 +547,48 @@ async function generatePipeline(route, message) {
         fail,
         completedChapters,
         current: { chapter: ch, skill: skill, status: 'running', startedAt: new Date(chapterStart).toISOString() },
-        resume: { chapter: ch, skill },
+        resume: resumeInitialPipelineEarlyExit
+          ? { chapter: ch, skill, sessionId: resumeSessionId, mode: resumeMode }
+          : { chapter: ch, skill },
       });
-      // Delete expected outputs so Claude must recreate them (prevents stale-mtime false failures on resume)
+      // Delete expected outputs so Claude must recreate them (prevents stale-mtime false failures on resume).
+      // When resuming an early-exited initial-pipeline session, keep the ULT/Wave 2 artifacts
+      // so the resumed session can continue downstream instead of restarting the chapter.
       const vDel = hasVerseRange ? `${book}-${ch}-vv${verseStart}-${verseEnd}` : `${book}-${ch}`;
-      for (const rel of [`output/AI-ULT/${vDel}.usfm`, `output/AI-UST/${vDel}.usfm`]) {
-        const resolved = resolveOutputFile(rel, book);
-        if (resolved) {
-          try { fs.unlinkSync(path.resolve(CSKILLBP_DIR, resolved)); } catch (_) { /* fine if missing */ }
+      if (!resumeInitialPipelineEarlyExit) {
+        for (const rel of [`output/AI-ULT/${vDel}.usfm`, `output/AI-UST/${vDel}.usfm`]) {
+          const resolved = resolveOutputFile(rel, book);
+          if (resolved) {
+            try { fs.unlinkSync(path.resolve(CSKILLBP_DIR, resolved)); } catch (_) { /* fine if missing */ }
+          }
         }
       }
       try {
         const timeoutMs = calcSkillTimeout(book, ch, route.operations || 6);
         const skillRef = hasVerseRange ? `${book} ${ch}:${verseStart}-${verseEnd}` : `${book} ${ch}`;
         let initialPrompt = skillRef;
+        let invocationSkill = skill;
+        let invocationResume = null;
+        if (resumeInitialPipelineEarlyExit) {
+          const resumeStatus = getInitialPipelineOutputStatus({
+            book,
+            chapter: ch,
+            verseStart: hasVerseRange ? verseStart : null,
+            verseEnd: hasVerseRange ? verseEnd : null,
+          });
+          const observedArtifacts = [
+            ...Object.values(resumeStatus.found),
+            ...resumeStatus.observedTempArtifacts,
+          ];
+          initialPrompt = buildInitialPipelineContinuationPrompt({
+            book,
+            chapter: ch,
+            missing: resumeStatus.missing,
+            observed: observedArtifacts,
+          });
+          invocationSkill = null;
+          invocationResume = resumeSessionId;
+        }
         if (skill === 'UST-gen') {
           const existingUlt = resolveOutputFile(`output/AI-ULT/${hasVerseRange ? `${book}-${ch}-vv${verseStart}-${verseEnd}` : `${book}-${ch}`}.usfm`, book)
             || discoverFreshOutput('output/AI-ULT', book, new RegExp(`^${book}-0*${ch}(-(?!.*aligned).*)?\\.usfm$`), null);
@@ -553,7 +613,8 @@ async function generatePipeline(route, message) {
             cwd: CSKILLBP_DIR,
             model,
             betas,
-            skill,
+            skill: invocationSkill,
+            resume: invocationResume,
             appendSystemPrompt: isInitialPipelineSkill ? INITIAL_PIPELINE_COMPLETION_GUARDRAIL : undefined,
             tools: DEFAULT_RESTRICTED_TOOLS,
             disallowedTools: ['Bash'],
@@ -617,11 +678,11 @@ async function generatePipeline(route, message) {
     const chPat = new RegExp(`^${book}-0*${ch}(-(?!.*aligned).*)?\.usfm$`);
     // Single-verse runs may leave the UST unchanged (Claude deems existing content sufficient).
     // In that case freshness is not a useful signal — just check that the file exists.
-    const freshnessMs = (runInitialSkill && !hasVerseRange) ? chapterStart : null;
-    const ultRel = discoverFreshOutput('output/AI-ULT', book, chPat, freshnessMs);
-    const ustRel = discoverFreshOutput('output/AI-UST', book, chPat, freshnessMs);
-    const hasUlt = !!ultRel;
-    const hasUst = !!ustRel;
+    const freshnessMs = (runInitialSkill && !hasVerseRange && !resumeInitialPipelineEarlyExit) ? chapterStart : null;
+    let ultRel = discoverFreshOutput('output/AI-ULT', book, chPat, freshnessMs);
+    let ustRel = discoverFreshOutput('output/AI-UST', book, chPat, freshnessMs);
+    let hasUlt = !!ultRel;
+    let hasUst = !!ustRel;
 
     // Log timing
     const logLine = `${new Date().toISOString()} | ${book} ${ch} | sdk=${sdkSuccess} | ult=${hasUlt} | ust=${hasUst} | duration=${duration}s\n`;
@@ -694,55 +755,122 @@ async function generatePipeline(route, message) {
     }
 
     if (runInitialSkill && isInitialPipelineSkill && !isDryRun) {
-      const initialPipelineStatus = getInitialPipelineOutputStatus({
+      let initialPipelineStatus = getInitialPipelineOutputStatus({
         book,
         chapter: ch,
         verseStart: hasVerseRange ? verseStart : null,
         verseEnd: hasVerseRange ? verseEnd : null,
       });
       if (initialPipelineStatus.missing.length > 0) {
-        const observedArtifacts = [
+        let observedArtifacts = [
           ...Object.values(initialPipelineStatus.found),
           ...initialPipelineStatus.observedTempArtifacts,
         ];
-        const observedLabel = observedArtifacts.length > 0
-          ? ` Observed artifacts: ${observedArtifacts.join(', ')}.`
-          : '';
-        console.error(
-          `[generate] initial-pipeline exited before final outputs for ${book} ${ch}; missing=${initialPipelineStatus.missing.join(', ')}; observed=${observedArtifacts.join(', ')}`
-        );
-        const earlyExitEvent = await status(
-          `Failed to generate **${book} ${ch}**: initial-pipeline exited before writing required outputs ` +
-          `(missing: ${initialPipelineStatus.missing.join(', ')}).${observedLabel}`
-        );
-        fail++;
-        setCheckpoint(checkpointRef, {
-          state: 'failed',
-          success,
-          fail,
-          completedChapters,
-          current: {
-            chapter: ch,
-            skill,
-            status: 'failed',
-            errorKind: 'initial_pipeline_early_exit',
-            outputStatus: 'incomplete',
-            missingOutputs: initialPipelineStatus.missing,
-            observedArtifacts,
-          },
-          resume: { chapter: ch, skill },
-        });
-        fireDiagnosis(earlyExitEvent, {
-          checkpoint: getCheckpoint(checkpointRef),
-          errorText: [
-            `Skill: ${skill}`,
-            `Chapter: ${book} ${ch}`,
-            'Claude returned subtype=success before final required outputs existed.',
-            `Missing outputs: ${initialPipelineStatus.missing.join(', ')}`,
-            `Observed artifacts: ${observedArtifacts.length > 0 ? observedArtifacts.join(', ') : '(none)'}`,
-          ].join('\n'),
-        });
-        continue;
+        let continuationErrorText = null;
+        if (!resumeInitialPipelineEarlyExit && claudeResult?.session_id) {
+          await status(
+            `initial-pipeline returned success before final outputs for **${book} ${ch}**; ` +
+            `resuming the same session to finish missing outputs (${initialPipelineStatus.missing.join(', ')}).`
+          );
+          try {
+            const continuationResult = await runClaude({
+              prompt: buildInitialPipelineContinuationPrompt({
+                book,
+                chapter: ch,
+                missing: initialPipelineStatus.missing,
+                observed: observedArtifacts,
+              }),
+              cwd: CSKILLBP_DIR,
+              model,
+              betas,
+              resume: claudeResult.session_id,
+              appendSystemPrompt: INITIAL_PIPELINE_COMPLETION_GUARDRAIL,
+              tools: DEFAULT_RESTRICTED_TOOLS,
+              disallowedTools: ['Bash'],
+              disableLocalSettings: true,
+              forceNoAutoBashSandbox: true,
+              timeoutMs: calcSkillTimeout(book, ch, route.operations || 6),
+              onProgress: ({ turnCount, lastTool, elapsedMs, timedOut }) => {
+                const elapsed = Math.round(elapsedMs / 60000);
+                const suffix = timedOut ? ' — **timed out**, aborting' : '';
+                return status(`Still continuing **${book} ${ch}** (initial-pipeline) — ${elapsed}min, ${turnCount} tool calls${lastTool ? `, last: \`${lastTool}\`` : ''}${suffix}`);
+              },
+            });
+            if (!continuationResult || continuationResult.subtype !== 'success') {
+              continuationErrorText = continuationResult
+                ? (continuationResult.error || continuationResult.result || `non-success subtype: "${continuationResult.subtype}"`)
+                : 'continuation returned no result';
+            } else {
+              claudeResult = continuationResult;
+              initialPipelineStatus = getInitialPipelineOutputStatus({
+                book,
+                chapter: ch,
+                verseStart: hasVerseRange ? verseStart : null,
+                verseEnd: hasVerseRange ? verseEnd : null,
+              });
+              observedArtifacts = [
+                ...Object.values(initialPipelineStatus.found),
+                ...initialPipelineStatus.observedTempArtifacts,
+              ];
+              ultRel = discoverFreshOutput('output/AI-ULT', book, chPat, freshnessMs);
+              ustRel = discoverFreshOutput('output/AI-UST', book, chPat, freshnessMs);
+              hasUlt = !!ultRel;
+              hasUst = !!ustRel;
+            }
+          } catch (err) {
+            continuationErrorText = err.message || String(err);
+            console.error(`[generate] initial-pipeline continuation error for ${book} ${ch}: ${continuationErrorText}`);
+          }
+        }
+        if (initialPipelineStatus.missing.length === 0) {
+          await status(`initial-pipeline continuation completed required outputs for **${book} ${ch}**.`);
+        } else {
+          const observedLabel = observedArtifacts.length > 0
+            ? ` Observed artifacts: ${observedArtifacts.join(', ')}.`
+            : '';
+          console.error(
+            `[generate] initial-pipeline exited before final outputs for ${book} ${ch}; missing=${initialPipelineStatus.missing.join(', ')}; observed=${observedArtifacts.join(', ')}`
+          );
+          const earlyExitEvent = await status(
+            `Failed to generate **${book} ${ch}**: initial-pipeline exited before writing required outputs ` +
+            `(missing: ${initialPipelineStatus.missing.join(', ')}).${observedLabel}`
+          );
+          fail++;
+          setCheckpoint(checkpointRef, {
+            state: 'failed',
+            success,
+            fail,
+            completedChapters,
+            current: {
+              chapter: ch,
+              skill,
+              status: 'failed',
+              errorKind: 'initial_pipeline_early_exit',
+              outputStatus: 'incomplete',
+              missingOutputs: initialPipelineStatus.missing,
+              observedArtifacts,
+              continuationError: continuationErrorText || undefined,
+            },
+            resume: {
+              chapter: ch,
+              skill,
+              sessionId: claudeResult?.session_id || resumeSessionId || null,
+              mode: 'continue_after_early_exit',
+            },
+          });
+          fireDiagnosis(earlyExitEvent, {
+            checkpoint: getCheckpoint(checkpointRef),
+            errorText: [
+              `Skill: ${skill}`,
+              `Chapter: ${book} ${ch}`,
+              'Claude returned subtype=success before final required outputs existed.',
+              `Missing outputs: ${initialPipelineStatus.missing.join(', ')}`,
+              `Observed artifacts: ${observedArtifacts.length > 0 ? observedArtifacts.join(', ') : '(none)'}`,
+              continuationErrorText ? `Continuation error: ${continuationErrorText}` : null,
+            ].filter(Boolean).join('\n'),
+          });
+          continue;
+        }
       }
     }
 
@@ -1456,7 +1584,9 @@ async function generatePipeline(route, message) {
     ? `${book} ${start}:${verseStart}-${verseEnd}`
     : `${book} ${start}\u2013${end}`;
   await status(`Generation complete for **${finalLabel}**: ${success} succeeded, ${fail} failed.`);
-  clearCheckpoint(checkpointRef);
+  if (fail === 0) {
+    clearCheckpoint(checkpointRef);
+  }
 }
 
 module.exports = {

--- a/test/generate-pipeline-early-exit.test.js
+++ b/test/generate-pipeline-early-exit.test.js
@@ -27,7 +27,7 @@ function buildMessage(content, overrides = {}) {
   };
 }
 
-function createHarness({ runClaudeImpl }) {
+function createHarness({ runClaudeImpl, initialCheckpoint = null }) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'generate-pipeline-'));
   const oldBaseDir = process.env.CSKILLBP_DIR;
   const oldStatusFile = process.env.ADMIN_STATUS_FILE;
@@ -70,7 +70,8 @@ function createHarness({ runClaudeImpl }) {
     uploads: [],
   };
   const runClaudeCalls = [];
-  const checkpoints = [];
+  const checkpoints = initialCheckpoint ? [initialCheckpoint] : [];
+  const clearedCheckpoints = [];
   const runSummaries = [];
   const diagnosisCalls = [];
 
@@ -140,7 +141,9 @@ function createHarness({ runClaudeImpl }) {
       checkpoints.push(patch);
       return patch;
     },
-    clearCheckpoint: () => {},
+    clearCheckpoint: () => {
+      clearedCheckpoints.push(true);
+    },
   });
   installStub(pipelineContextPath, {
     buildGenerateContext: () => ({ contextPath: 'tmp/context.json', dirPath: 'tmp/pipeline/ISA-52' }),
@@ -160,6 +163,7 @@ function createHarness({ runClaudeImpl }) {
     sent,
     runClaudeCalls,
     checkpoints,
+    clearedCheckpoints,
     runSummaries,
     diagnosisCalls,
     readStatusTexts() {
@@ -194,16 +198,26 @@ function createHarness({ runClaudeImpl }) {
   };
 }
 
-test('generatePipeline classifies initial-pipeline early exit when only Wave 2 artifacts exist', async () => {
+test('generatePipeline resumes the same initial-pipeline session after Wave 2 early exit', async () => {
   const harness = createHarness({
     runClaudeImpl: async ({ options, tempDir }) => {
+      if (options.resume === 'session-isa-52') {
+        assert.equal(options.skill, undefined);
+        assert.match(options.prompt, /Continue the existing initial-pipeline run/);
+        assert.match(options.prompt, /Wave 3/);
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-UST', 'ISA'), { recursive: true });
+        fs.mkdirSync(path.join(tempDir, 'output', 'issues', 'ISA'), { recursive: true });
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-UST', 'ISA', 'ISA-52.usfm'), '\\id ISA\n\\c 52\n\\v 1 ust\n');
+        fs.writeFileSync(path.join(tempDir, 'output', 'issues', 'ISA', 'ISA-52.tsv'), 'isa\t52:1\tfigs-activepassive\tYou were sold\n');
+        return { subtype: 'success', usage: {}, total_cost_usd: 0, session_id: 'session-isa-52' };
+      }
       fs.mkdirSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA'), { recursive: true });
       fs.mkdirSync(path.join(tempDir, 'tmp', 'pipeline-ISA-52'), { recursive: true });
       fs.writeFileSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA', 'ISA-52.usfm'), '\\id ISA\n\\c 52\n\\v 1 test\n');
       fs.writeFileSync(path.join(tempDir, 'tmp', 'pipeline-ISA-52', 'wave2_structure.tsv'), 'isa\t52:1\tfigs-activepassive\tYou were sold\n');
       fs.writeFileSync(path.join(tempDir, 'tmp', 'pipeline-ISA-52', 'wave2_rhetoric.tsv'), 'isa\t52:1\tfigs-doublet\tAwake, awake\n');
       assert.match(options.appendSystemPrompt, /Do not return success/i);
-      return { subtype: 'success', usage: {}, total_cost_usd: 0 };
+      return { subtype: 'success', usage: {}, total_cost_usd: 0, session_id: 'session-isa-52' };
     },
   });
 
@@ -213,11 +227,59 @@ test('generatePipeline classifies initial-pipeline early exit when only Wave 2 a
       buildMessage('generate isa 52')
     );
 
-    assert.equal(harness.runClaudeCalls.length, 1);
+    assert.equal(harness.runClaudeCalls.length, 2);
+    assert.equal(harness.runClaudeCalls[1].resume, 'session-isa-52');
+    const statusTexts = harness.readStatusTexts();
+    assert.ok(statusTexts.some((text) => text.includes('resuming the same session')));
+    assert.ok(statusTexts.some((text) => text.includes('continuation completed required outputs')));
+    assert.equal(harness.checkpoints.some((patch) => patch.current?.errorKind === 'initial_pipeline_early_exit'), false);
+    assert.equal(harness.diagnosisCalls.length, 0);
+    assert.equal(harness.sent.uploads.length, 2);
+    assert.equal(harness.clearedCheckpoints.length, 1);
+    assert.deepEqual(harness.runSummaries.at(-1), {
+      pipeline: 'generate',
+      book: 'ISA',
+      startCh: 52,
+      endCh: 52,
+      tokensBefore: 0,
+      success: true,
+      userId: 42,
+    });
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('generatePipeline preserves failed checkpoint when initial-pipeline continuation remains incomplete', async () => {
+  const harness = createHarness({
+    runClaudeImpl: async ({ options, tempDir }) => {
+      fs.mkdirSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA'), { recursive: true });
+      fs.mkdirSync(path.join(tempDir, 'tmp', 'pipeline-ISA-52'), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA', 'ISA-52.usfm'), '\\id ISA\n\\c 52\n\\v 1 test\n');
+      fs.writeFileSync(path.join(tempDir, 'tmp', 'pipeline-ISA-52', 'wave2_structure.tsv'), 'isa\t52:1\tfigs-activepassive\tYou were sold\n');
+      fs.writeFileSync(path.join(tempDir, 'tmp', 'pipeline-ISA-52', 'wave2_rhetoric.tsv'), 'isa\t52:1\tfigs-doublet\tAwake, awake\n');
+      if (options.resume === 'session-isa-52') {
+        return { subtype: 'success', usage: {}, total_cost_usd: 0, session_id: 'session-isa-52' };
+      }
+      return { subtype: 'success', usage: {}, total_cost_usd: 0, session_id: 'session-isa-52' };
+    },
+  });
+
+  try {
+    await harness.generatePipeline(
+      { _synthetic: true, _book: 'ISA', _startChapter: 52, _endChapter: 52, skill: 'initial-pipeline', operations: 6 },
+      buildMessage('generate isa 52')
+    );
+
+    assert.equal(harness.runClaudeCalls.length, 2);
     const statusTexts = harness.readStatusTexts();
     assert.ok(statusTexts.some((text) => text.includes('initial-pipeline exited before writing required outputs')));
     assert.ok(statusTexts.some((text) => text.includes('issues TSV, UST')));
-    assert.ok(harness.checkpoints.some((patch) => patch.current?.errorKind === 'initial_pipeline_early_exit'));
+    const failure = harness.checkpoints.find((patch) => patch.current?.errorKind === 'initial_pipeline_early_exit');
+    assert.ok(failure);
+    assert.equal(failure.resume.sessionId, 'session-isa-52');
+    assert.equal(failure.resume.mode, 'continue_after_early_exit');
+    assert.equal(harness.clearedCheckpoints.length, 0);
     assert.equal(harness.diagnosisCalls.length, 1);
     assert.equal(harness.diagnosisCalls[0].event.severity, 'error');
     assert.equal(harness.diagnosisCalls[0].checkpoint.current.errorKind, 'initial_pipeline_early_exit');
@@ -263,6 +325,63 @@ test('generatePipeline accepts initial-pipeline success when final ULT, issues, 
     assert.equal(harness.sent.uploads.length, 2);
     assert.ok(harness.sent.stream.some(({ text }) => text.includes('ISA 52 ULT.usfm')));
     assert.ok(harness.sent.stream.some(({ text }) => text.includes('ISA 52 UST.usfm')));
+    assert.equal(harness.diagnosisCalls.length, 0);
+    assert.equal(harness.clearedCheckpoints.length, 1);
+    assert.equal(harness.runSummaries.at(-1).success, true);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('generatePipeline resumes initial-pipeline early-exit checkpoint without deleting existing ULT', async () => {
+  const initialCheckpoint = {
+    state: 'failed',
+    success: 0,
+    fail: 1,
+    completedChapters: [],
+    current: {
+      chapter: 52,
+      skill: 'initial-pipeline',
+      status: 'failed',
+      errorKind: 'initial_pipeline_early_exit',
+    },
+    resume: {
+      chapter: 52,
+      skill: 'initial-pipeline',
+      sessionId: 'session-resume-52',
+      mode: 'continue_after_early_exit',
+    },
+  };
+  const harness = createHarness({
+    initialCheckpoint,
+    runClaudeImpl: async ({ options, tempDir }) => {
+      assert.equal(options.resume, 'session-resume-52');
+      assert.equal(options.skill, null);
+      assert.match(options.prompt, /Continue the existing initial-pipeline run/);
+      assert.ok(fs.existsSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA', 'ISA-52.usfm')));
+      fs.mkdirSync(path.join(tempDir, 'output', 'AI-UST', 'ISA'), { recursive: true });
+      fs.mkdirSync(path.join(tempDir, 'output', 'issues', 'ISA'), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, 'output', 'AI-UST', 'ISA', 'ISA-52.usfm'), '\\id ISA\n\\c 52\n\\v 1 ust\n');
+      fs.writeFileSync(path.join(tempDir, 'output', 'issues', 'ISA', 'ISA-52.tsv'), 'isa\t52:1\tfigs-activepassive\tYou were sold\n');
+      return { subtype: 'success', usage: {}, total_cost_usd: 0, session_id: 'session-resume-52' };
+    },
+  });
+
+  try {
+    fs.mkdirSync(path.join(harness.tempDir, 'output', 'AI-ULT', 'ISA'), { recursive: true });
+    fs.mkdirSync(path.join(harness.tempDir, 'tmp', 'pipeline-ISA-52'), { recursive: true });
+    fs.writeFileSync(path.join(harness.tempDir, 'output', 'AI-ULT', 'ISA', 'ISA-52.usfm'), '\\id ISA\n\\c 52\n\\v 1 existing ult\n');
+    fs.writeFileSync(path.join(harness.tempDir, 'tmp', 'pipeline-ISA-52', 'wave2_structure.tsv'), 'isa\t52:1\tfigs-activepassive\tYou were sold\n');
+    fs.writeFileSync(path.join(harness.tempDir, 'tmp', 'pipeline-ISA-52', 'wave2_rhetoric.tsv'), 'isa\t52:1\tfigs-doublet\tAwake, awake\n');
+
+    await harness.generatePipeline(
+      { _synthetic: true, _book: 'ISA', _startChapter: 52, _endChapter: 52, skill: 'initial-pipeline', operations: 6 },
+      buildMessage('generate isa 52')
+    );
+
+    assert.equal(harness.runClaudeCalls.length, 1);
+    assert.equal(harness.runClaudeCalls[0].resume, 'session-resume-52');
+    assert.equal(fs.readFileSync(path.join(harness.tempDir, 'output', 'AI-ULT', 'ISA', 'ISA-52.usfm'), 'utf8'), '\\id ISA\n\\c 52\n\\v 1 existing ult\n');
     assert.equal(harness.diagnosisCalls.length, 0);
     assert.equal(harness.runSummaries.at(-1).success, true);
   } finally {


### PR DESCRIPTION
## Summary
- resume the same Claude session once when initial-pipeline reports success before final outputs exist
- preserve failed early-exit checkpoints with session id and continuation mode
- resume early-exit checkpoints without deleting existing ULT/Wave 2 artifacts

## Tests
- node --test test/generate-pipeline-early-exit.test.js
- npm test