### PR TITLE
chore: set REVIEW_PROVIDER=claude in review-gate workflow

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -59,7 +59,7 @@ jobs:
           REVIEW_PR: ${{ github.event.pull_request.number }}
           REVIEW_BASE: ${{ github.event.pull_request.base.sha }}
           REVIEW_HEAD: ${{ github.event.pull_request.head.sha }}
-          REVIEW_PROVIDER: both
+          REVIEW_PROVIDER: claude
         run: |
           set -euo pipefail
           # --restart no keeps the machine from auto-looping on non-zero exits,


### PR DESCRIPTION
Codex has been removed from the review pipeline. Update the workflow env var from `both` to `claude` for clarity — `both` was already coerced to `['claude']` after the provider removal.