### PR TITLE
fix: defend decision-conflict gate against false positives

### DIFF
--- a/src/human-decision-conflicts.js
+++ b/src/human-decision-conflicts.js
@@ -217,18 +217,25 @@ function loadHumanDecisions(skillsRoot) {
 }
 
 function collectReportText({ message, feedbackText, classified }) {
-  const parts = [
+  const verbatimParts = [
     feedbackText,
     message?.subject,
     message?.display_recipient,
   ];
+  const paraphrasedParts = [];
   for (const complaint of classified?.complaints || []) {
-    parts.push(complaint.summary, ...(complaint.evidence || []));
+    paraphrasedParts.push(complaint.summary, ...(complaint.evidence || []));
   }
   for (const issue of classified?.issues || []) {
-    parts.push(issue.title, issue.body);
+    paraphrasedParts.push(issue.title, issue.body);
   }
-  return parts.filter(Boolean).join('\n');
+  const verbatim = verbatimParts.filter(Boolean).join('\n');
+  const paraphrased = paraphrasedParts.filter(Boolean).join('\n');
+  return {
+    verbatim,
+    paraphrased,
+    combined: [verbatim, paraphrased].filter(Boolean).join('\n'),
+  };
 }
 
 function detectBooks(text) {
@@ -248,14 +255,24 @@ function bookApplies(decision, reportBooks) {
   return reportBooks.has(decision.book);
 }
 
+const REJECTED_PHRASE_STOPWORDS = new Set([
+  'not', 'the', 'a', 'an', 'of', 'to', 'and', 'or', 'is', 'it',
+  'that', 'this', 'as', 'in', 'on', 'for', 'with', 'by',
+]);
+
 function extractRejectedPhrases(notes) {
   const phrases = [];
   const text = String(notes || '');
-  const pattern = /\b(?:never|not|do not|don't|avoid)\b[^."'“”']{0,80}(?:"([^"]+)"|'([^']+)'|“([^”]+)”|‘([^’]+)’)/gi;
-  let match;
-  while ((match = pattern.exec(text))) {
-    const phrase = (match[1] || match[2] || match[3] || match[4] || '').trim();
-    if (phrase && !phrases.includes(phrase)) phrases.push(phrase);
+  // Lookbehind skips keywords sitting inside quoted renderings (e.g. 'avoid'
+  // in "use 'avoid' not 'stay away from'") — those are the desired rendering,
+  // not a rejection clause.
+  const pattern = /(?<!['"“”‘’])\b(?:never|not|do not|don't|avoid)\b[^."'“”']{0,80}(?:"([^"]+)"|'([^']+)'|“([^”]+)”|‘([^’]+)’)/gi;
+  let m;
+  while ((m = pattern.exec(text))) {
+    const phrase = (m[1] || m[2] || m[3] || m[4] || '').trim();
+    if (!phrase) continue;
+    if (REJECTED_PHRASE_STOPWORDS.has(phrase.toLowerCase())) continue;
+    if (!phrases.includes(phrase)) phrases.push(phrase);
   }
   return phrases;
 }
@@ -281,18 +298,34 @@ function phraseAppearsDesired(text, phrase) {
 function scoreDecision(decision, reportText, reportBooks) {
   if (!bookApplies(decision, reportBooks)) return null;
 
-  const normalized = normalizeText(reportText);
+  const verbatim = reportText?.verbatim || '';
+  const paraphrased = reportText?.paraphrased || '';
+  const combined = reportText?.combined || `${verbatim}\n${paraphrased}`;
+  const verbatimNormalized = normalizeText(verbatim);
+  const combinedNormalized = normalizeText(combined);
+
   const reasons = [];
   let score = 0;
+  let hasVerbatimRejectedHit = false;
 
   for (const phrase of extractRejectedPhrases(decision.notes)) {
-    if (phraseAppearsDesired(reportText, phrase)) {
+    const normalizedPhrase = normalizeText(phrase);
+    const inVerbatim = verbatimNormalized.includes(normalizedPhrase);
+    const inCombined = combinedNormalized.includes(normalizedPhrase);
+
+    if (phraseAppearsDesired(verbatim, phrase)) {
       score += 12;
+      hasVerbatimRejectedHit = true;
       reasons.push(`requested rejected phrase "${phrase}"`);
-    } else if (normalized.includes(normalizeText(phrase))) {
+    } else if (phraseAppearsDesired(paraphrased, phrase)) {
+      score += 4;
+      reasons.push(`requested rejected phrase "${phrase}" (paraphrased)`);
+    } else if (inCombined) {
       score += 3;
       reasons.push(`mentioned rejected phrase "${phrase}"`);
     }
+
+    if (inVerbatim) hasVerbatimRejectedHit = true;
   }
 
   for (const [label, value, points] of [
@@ -301,7 +334,7 @@ function scoreDecision(decision, reportText, reportBooks) {
     ['rendering', decision.rendering, 2],
   ]) {
     const term = normalizeText(value);
-    if (term && normalized.includes(term)) {
+    if (term && combinedNormalized.includes(term)) {
       score += points;
       reasons.push(`matched ${label} ${value}`);
     }
@@ -313,6 +346,14 @@ function scoreDecision(decision, reportText, reportBooks) {
   }
 
   if (score < 8) return null;
+
+  // Anchor requirement: a decision with no Strong number and no Hebrew term is
+  // just a free-text rule. Without a literal hit on a rejected phrase in the
+  // user's verbatim feedback, we have no real evidence the topic matches —
+  // only the LLM-paraphrased issue body, which can introduce incidental words.
+  const hasAnchor = Boolean(normalizeText(decision.strong) || normalizeText(decision.hebrew));
+  if (!hasAnchor && !hasVerbatimRejectedHit) return null;
+
   return { decision, score, reasons };
 }
 
@@ -365,7 +406,7 @@ async function findHumanDecisionConflict({
   if (!classified?.issues?.some((issue) => issue.repo === 'bp-assistant-skills')) return null;
 
   const reportText = collectReportText({ message, feedbackText, classified });
-  const reportBooks = detectBooks(reportText);
+  const reportBooks = detectBooks(reportText.combined);
   const candidates = loadHumanDecisions(skillsRoot)
     .map((decision) => scoreDecision(decision, reportText, reportBooks))
     .filter(Boolean)

--- a/test/issue-report-pipeline.test.js
+++ b/test/issue-report-pipeline.test.js
@@ -329,6 +329,52 @@ test('human decision conflict parser detects rejected Yahweh of hosts preference
   assert.match(formatDecisionConflictPrompt(conflict), /Prior decision: H3068\+H6635 \/ יְהוָה צְבָאוֹת: use "Yahweh of Armies"\. Never 'Yahweh of hosts'/);
 });
 
+test('human decision conflict ignores unrelated UST word-choice rule on Hebrew alignment feedback', async () => {
+  // Regression: 2026-05-05 — Grant Ailie filed feedback about Hebrew/waw verb
+  // alignment and the bot incorrectly cited a UST decision ('avoid' not 'stay
+  // away from'). The rejected-phrase regex over-extracted "not" from the notes
+  // and matched the LLM-paraphrased "is not pairing" in the issue body.
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bp-skills-decisions-fp-'));
+  fs.mkdirSync(path.join(root, 'data/quick-ref'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'data/glossary'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'data/quick-ref/ult_decisions.csv'), 'Strong,Hebrew,Rendering,Book,Context,Notes,Date,Source\n');
+  fs.writeFileSync(path.join(root, 'data/quick-ref/ust_decisions.csv'), [
+    'Strong,Hebrew,Rendering,Book,Context,Notes,Date,Source',
+    `,,avoid,ALL,"88:8,18 friends distancing","UST: 'avoid' not 'stay away from'. More concise. Editor PSA 88.",2026-02-17,human`,
+  ].join('\n'));
+  fs.writeFileSync(path.join(root, 'data/glossary/project_glossary.md'), '');
+
+  const conflict = await findHumanDecisionConflict({
+    message: buildMessage({ subject: 'Psalm 88' }),
+    feedbackText: 'in the ULT align the Hebrew verbs with the Hebrew word containing the waw that they are connected to',
+    classified: buildClassifierPayload({
+      complaints: [{
+        id: 'c1',
+        summary: 'ULT alignment is not pairing Hebrew verbs with the waw-prefixed Hebrew word they are grammatically connected to',
+        evidence: ['align the Hebrew verbs with the Hebrew word containing the waw'],
+        likely_layers: ['bp-assistant-skills'],
+      }],
+      ownership: {
+        repositories: ['bp-assistant-skills'],
+        primary_repo: 'bp-assistant-skills',
+        secondary_repo: null,
+        rationale: 'ULT alignment data lives in skills.',
+      },
+      issues: [{
+        id: 'i1',
+        repo: 'bp-assistant-skills',
+        complaint_ids: ['c1'],
+        title: 'ULT should pair Hebrew verbs with their waw-prefixed companion word',
+        body: '## Summary\n\nULT alignment is not pairing the Hebrew verb with the waw-containing word it is grammatically connected to.\n\n## Expected Behavior\n\nThe verb should align with the waw-prefixed word.',
+        labels: ['bug'],
+      }],
+    }),
+    skillsRoot: root,
+  });
+
+  assert.equal(conflict, null);
+});
+
 test('human decision conflict prompt uses submitter when decision notes contain one', async () => {
   const skillsRoot = createSkillsRoot({ withAttribution: true });
   const conflict = await findHumanDecisionConflict({


### PR DESCRIPTION
## Summary
- Stop unrelated human decisions from triggering the conflict-gate prompt on incidental word collisions in LLM-paraphrased issue bodies
- Tighten `extractRejectedPhrases` regex with a lookbehind so keywords inside quoted renderings don't capture spurious phrases
- Add stopword filter and an anchor requirement (no Strong/Hebrew → must hit verbatim)

## Why
On 2026-05-05 Grant Ailie filed feedback about Hebrew/waw verb alignment in the ULT. The bot replied that this conflicted with a UST word-choice decision (`'avoid'` not `'stay away from'`, Editor PSA 88) — completely unrelated. Root cause: the regex extracted the literal word "not" as a rejected phrase from `'avoid' not 'stay away from'`, then matched it against the LLM-generated complaint summary "is not pairing... should pair".

## Test plan
- [x] `npm test` — 196/196 pass, including new regression test for the Grant Ailie scenario
- [x] Manual replay against real `bp-assistant-skills` data: `findHumanDecisionConflict` returns `null` for Grant's exact message; legitimate phrase extraction unchanged for 59/68 keyword-bearing decisions

Generated with [Claude Code](https://claude.com/claude-code)