### PR TITLE
fix: add post-insertion duplicate-ID guard for TQ whole-book TSV

### DIFF
--- a/src/door43-push.js
+++ b/src/door43-push.js
@@ -69,6 +69,7 @@ const { getVerseCount } = require('./verse-counts');
 const { insertTnRows } = require('./lib/insert-tn-rows');
 const { insertUsfmVerses } = require('./lib/insert-usfm-verses');
 const { validateTnTsv } = require('./workspace-tools/quality-tools');
+const { checkTqWholeBookIds } = require('./workspace-tools/misc-tools');
 const { readSecret } = require('./secrets');
 
 const GITEA_API = 'https://git.door43.org/api/v1';
@@ -847,6 +848,28 @@ async function door43Push(opts) {
 
         console.log(`${LOG_PREFIX} Door43 CI validation passed for chapter ${chapter} in ${repoFilename}`);
       }
+    }
+
+    // Step 3c: Post-insertion duplicate-ID guard (TQ only)
+    // Scans the assembled whole-book TQ TSV for colliding row IDs and aborts
+    // before any git commit if duplicates are found.  Mirrors the TN CI gate
+    // above and catches cross-chapter collisions that the per-chapter verifyTq
+    // check cannot see (e.g. fx0w used in PSA 52 and again in PSA 53).
+    if (type === 'tq') {
+      const bookFilePathFull = path.join(repoDir, repoFilename);
+      const tqIdCheck = checkTqWholeBookIds(bookFilePathFull);
+      if (tqIdCheck.duplicates.length > 0) {
+        // Revert so we don't leave the local clone in a broken state
+        await git.checkout({ fs, dir: repoDir, filepaths: [repoFilename], force: true });
+        const summary = tqIdCheck.duplicates.slice(0, 5)
+          .map(d => `  "${d.id}" first at line ${d.firstLine}, duplicate at line ${d.dupLine}`)
+          .join('\n');
+        let details = `Duplicate TQ row IDs detected in ${repoFilename} — ${tqIdCheck.duplicates.length} collision(s) after insertion:\n${summary}`;
+        if (tqIdCheck.duplicates.length > 5) details += `\n  ... and ${tqIdCheck.duplicates.length - 5} more`;
+        console.error(`${LOG_PREFIX} ${details}`);
+        throw new Error(details);
+      }
+      console.log(`${LOG_PREFIX} Post-insertion TQ duplicate-ID check passed for ${repoFilename} (${tqIdCheck.uniqueCount} unique IDs scanned)`);
     }
 
     // Step 4: Commit and push

--- a/src/workspace-tools/misc-tools.js
+++ b/src/workspace-tools/misc-tools.js
@@ -471,4 +471,36 @@ function appendQuickref({ file, strong, hebrew, rendering, book = 'ALL', context
   return `Appended to ${csvName}: ${row}`;
 }
 
-module.exports = { giteaPr, prepareCompare, prepareTq, verifyTq, deduplicateTqIds, appendQuickref };
+/**
+ * Scan a TQ whole-book TSV file for duplicate row IDs.
+ *
+ * Reads every data row (skipping the header and blank lines) and collects any
+ * ID value that appears more than once.  This catches cross-chapter collisions
+ * that the per-chapter verifyTq / deduplicateTqIds check cannot detect — those
+ * tools operate on a single chapter file while this function operates on the
+ * assembled whole-book file (e.g. tq_PSA.tsv after insertTnRows).
+ *
+ * @param {string} bookFilePath - Absolute path to the whole-book TQ TSV file
+ * @returns {{ duplicates: Array<{id: string, firstLine: number, dupLine: number}>, uniqueCount: number }}
+ */
+function checkTqWholeBookIds(bookFilePath) {
+  const content = fs.readFileSync(bookFilePath, 'utf8');
+  const lines = content.split('\n');
+  const seenIds = new Map(); // id → first 1-based line number
+  const duplicates = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    const cols = line.split('\t');
+    const id = cols[1] || '';
+    if (!id) continue;
+    if (seenIds.has(id)) {
+      duplicates.push({ id, firstLine: seenIds.get(id), dupLine: i + 1 });
+    } else {
+      seenIds.set(id, i + 1);
+    }
+  }
+  return { duplicates, uniqueCount: seenIds.size };
+}
+
+module.exports = { giteaPr, prepareCompare, prepareTq, verifyTq, deduplicateTqIds, checkTqWholeBookIds, appendQuickref };

--- a/test/tqs-pipeline.test.js
+++ b/test/tqs-pipeline.test.js
@@ -364,6 +364,84 @@ test('tqsPipeline calls deduplicateTqIds before verify and logs when IDs are fix
   }
 });
 
+// Unit tests for checkTqWholeBookIds — post-insertion cross-chapter duplicate guard
+
+test('checkTqWholeBookIds returns no duplicates for a clean whole-book TQ file', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tq-wholecheck-'));
+  try {
+    const miscToolsPath = require.resolve('../src/workspace-tools/misc-tools');
+    delete require.cache[miscToolsPath];
+    const { checkTqWholeBookIds } = require('../src/workspace-tools/misc-tools');
+
+    const tsvContent = [
+      'Reference\tID\tTags\tQuote\tOccurrence\tQuestion\tResponse',
+      '52:1\tabc1\t\t\t1\tQuestion A?\tAnswer A',
+      '52:2\tabc2\t\t\t1\tQuestion B?\tAnswer B',
+      '53:1\tabc3\t\t\t1\tQuestion C?\tAnswer C',
+      '53:2\tabc4\t\t\t1\tQuestion D?\tAnswer D',
+    ].join('\n') + '\n';
+    const bookFile = path.join(tempDir, 'tq_PSA.tsv');
+    fs.writeFileSync(bookFile, tsvContent, 'utf8');
+
+    const result = checkTqWholeBookIds(bookFile);
+    assert.equal(result.duplicates.length, 0, 'No duplicates expected in a clean file');
+    assert.equal(result.uniqueCount, 4, 'Should count 4 unique IDs');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('checkTqWholeBookIds detects cross-chapter duplicate IDs (the PSA-53 regression)', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tq-wholecheck-'));
+  try {
+    const miscToolsPath = require.resolve('../src/workspace-tools/misc-tools');
+    delete require.cache[miscToolsPath];
+    const { checkTqWholeBookIds } = require('../src/workspace-tools/misc-tools');
+
+    // Simulate the regression: fx0w used in chapter 52 and again in chapter 53
+    const tsvContent = [
+      'Reference\tID\tTags\tQuote\tOccurrence\tQuestion\tResponse',
+      '52:1\tabc1\t\t\t1\tQuestion A?\tAnswer A',
+      '52:2\tfx0w\t\t\t1\tQuestion B?\tAnswer B',
+      '53:2\tfx0w\t\t\t1\tQuestion C?\tAnswer C',
+      '53:2-3\tabc4\t\t\t1\tQuestion D?\tAnswer D',
+    ].join('\n') + '\n';
+    const bookFile = path.join(tempDir, 'tq_PSA.tsv');
+    fs.writeFileSync(bookFile, tsvContent, 'utf8');
+
+    const result = checkTqWholeBookIds(bookFile);
+    assert.equal(result.duplicates.length, 1, 'Should detect exactly one duplicate collision');
+    assert.equal(result.duplicates[0].id, 'fx0w', 'Should identify fx0w as the duplicate ID');
+    assert.equal(result.duplicates[0].firstLine, 3, 'First occurrence should be at line 3 (1-based, skipping header)');
+    assert.equal(result.duplicates[0].dupLine, 4, 'Duplicate should be at line 4');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('checkTqWholeBookIds detects same-chapter duplicate IDs', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tq-wholecheck-'));
+  try {
+    const miscToolsPath = require.resolve('../src/workspace-tools/misc-tools');
+    delete require.cache[miscToolsPath];
+    const { checkTqWholeBookIds } = require('../src/workspace-tools/misc-tools');
+
+    const tsvContent = [
+      'Reference\tID\tTags\tQuote\tOccurrence\tQuestion\tResponse',
+      '53:2\tfx0w\t\t\t1\tQuestion A?\tAnswer A',
+      '53:2-3\tfx0w\t\t\t1\tQuestion B?\tAnswer B',
+    ].join('\n') + '\n';
+    const bookFile = path.join(tempDir, 'tq_PSA.tsv');
+    fs.writeFileSync(bookFile, tsvContent, 'utf8');
+
+    const result = checkTqWholeBookIds(bookFile);
+    assert.equal(result.duplicates.length, 1, 'Should detect same-chapter duplicate');
+    assert.equal(result.duplicates[0].id, 'fx0w');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 // Unit tests for deduplicateTqIds — exercise the real function outside the pipeline harness
 
 test('deduplicateTqIds replaces duplicate IDs in-place and preserves first occurrence', () => {


### PR DESCRIPTION
Closes #67.

## Problem

The TQ pipeline's per-chapter `verifyTq` / `deduplicateTqIds` checks operate on a single chapter file (e.g. `PSA-053.tsv`) and cannot detect cross-chapter ID collisions. After `insertTnRows` assembles the whole-book `tq_PSA.tsv`, no uniqueness scan was performed before the git commit, allowing a duplicate row ID (`fx0w` shared between Psalm 53:2 and 53:2-3) to be pushed to Door43 and break downstream tooling.

## Solution

**`src/workspace-tools/misc-tools.js`** — adds `checkTqWholeBookIds(bookFilePath)`:
- Reads the assembled whole-book TQ TSV
- Returns `{ duplicates, uniqueCount }` where each duplicate carries `{ id, firstLine, dupLine }`
- Pure function with no network dependencies; exported for direct testing

**`src/door43-push.js`** — wires in Step 3c immediately after `insertContent` for `type === 'tq'`:
- Calls `checkTqWholeBookIds` on the assembled book file
- On collision: reverts the local clone via `git.checkout({ force: true })` and throws an error (aborting before any git commit), matching the pattern of the TN CI gate (Step 3b)
- On clean pass: logs unique-ID count for observability

**`test/tqs-pipeline.test.js`** — three new unit tests:
- Clean whole-book file → no duplicates reported
- Cross-chapter collision (`fx0w` in PSA 52 and again in PSA 53) → detected
- Same-chapter collision (`fx0w` in 53:2 and 53:2-3) → detected

All 12 tests in `tqs-pipeline.test.js` pass. The `quality-tools` and `pipeline-regressions` test failures are pre-existing environment issues (`zod`/`dotenv` missing) unrelated to this change.