### PR TITLE
fix: add PR link to merge-conflict deferral message

### DIFF
--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -1361,7 +1361,10 @@ async function generatePipeline(route, message) {
       const sessionKey = stream
         ? `stream-${stream}-${topic}`
         : `dm-${message.sender_id}`;
-      const branchList = dedupedConflicts.map(c => `\`${c.branch}\` (${c.repo})`).join(', ');
+      const branchList = dedupedConflicts.map(c =>
+        c.pr ? `[${c.branch}](https://git.door43.org/unfoldingWord/${c.repo}/pulls/${c.pr}) (${c.repo})`
+          : `\`${c.branch}\` (${c.repo})`
+      ).join(', ');
       const fileList = [...new Set(dedupedConflicts.map(c => `\`${c.file}\``))].join(', ');
 
       setPendingMerge(sessionKey, {

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -2709,7 +2709,10 @@ async function notesPipeline(route, message) {
       : `dm-${message.sender_id}`;
     const repoName = REPO_MAP['tn'];
     const targetFile = getRepoFilename('tn', book);
-    const branchList = deferredConflicts.map(c => `\`${c.branch}\``).join(', ');
+    const branchList = deferredConflicts.map(c =>
+      c.pr ? `[${c.branch}](https://git.door43.org/unfoldingWord/${repoName}/pulls/${c.pr})`
+        : `\`${c.branch}\``
+    ).join(', ');
 
     setPendingMerge(sessionKey, {
       sessionKey,


### PR DESCRIPTION
Closes #69.

When the bot detects a conflicting user branch and defers a push, it now renders the conflicting branch name as a **clickable Gitea PR link** so the user can navigate directly to the PR in one click.

### What changed
- `src/notes-pipeline.js`: `branchList` now wraps each conflict entry as a Markdown link `[branch](https://git.door43.org/unfoldingWord/<repo>/pulls/<N>)` when a PR number is available; falls back to the plain backtick name otherwise.
- `src/generate-pipeline.js`: same treatment for the generate-pipeline conflict message (which also includes the repo name in the display text).

### What was already present (no change needed)
Both pipeline messages already included "say **merged** or **done** so I can proceed with the insertion." The `merged`/`done` keyword instruction was already in the message at the time this issue was filed; this PR completes the fix by adding the branch link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)