### PR TITLE
fix: self-heal cross-chapter TQ ID collisions in door43-push

### DIFF
--- a/src/door43-push.js
+++ b/src/door43-push.js
@@ -69,7 +69,7 @@ const { getVerseCount } = require('./verse-counts');
 const { insertTnRows } = require('./lib/insert-tn-rows');
 const { insertUsfmVerses } = require('./lib/insert-usfm-verses');
 const { validateTnTsv } = require('./workspace-tools/quality-tools');
-const { checkTqWholeBookIds } = require('./workspace-tools/misc-tools');
+const { fixTqWholeBookIds } = require('./workspace-tools/misc-tools');
 const { readSecret } = require('./secrets');
 
 const GITEA_API = 'https://git.door43.org/api/v1';
@@ -850,26 +850,29 @@ async function door43Push(opts) {
       }
     }
 
-    // Step 3c: Post-insertion duplicate-ID guard (TQ only)
-    // Scans the assembled whole-book TQ TSV for colliding row IDs and aborts
-    // before any git commit if duplicates are found.  Mirrors the TN CI gate
-    // above and catches cross-chapter collisions that the per-chapter verifyTq
-    // check cannot see (e.g. fx0w used in PSA 52 and again in PSA 53).
+    // Step 3c: Post-insertion duplicate-ID self-healing (TQ only)
+    // After insertTnRows merges the new chapter into the whole-book file,
+    // fixTqWholeBookIds scans for cross-chapter ID collisions (which the
+    // per-chapter deduplicateTqIds step cannot see) and remaps any duplicates
+    // to fresh unique IDs before the git commit.  This makes the pipeline
+    // self-healing for the rare random collision rather than fatally aborting.
+    // Only reverts and throws if the fix itself fails (ID space exhausted).
     if (type === 'tq') {
       const bookFilePathFull = path.join(repoDir, repoFilename);
-      const tqIdCheck = checkTqWholeBookIds(bookFilePathFull);
-      if (tqIdCheck.duplicates.length > 0) {
-        // Revert so we don't leave the local clone in a broken state
+      try {
+        const fixResult = fixTqWholeBookIds(bookFilePathFull);
+        if (fixResult.fixed > 0) {
+          const detailLines = fixResult.details.map(d => `  ${d}`).join('\n');
+          console.warn(`${LOG_PREFIX} Auto-fixed ${fixResult.fixed} cross-chapter TQ ID collision(s) in ${repoFilename}:\n${detailLines}`);
+        } else {
+          console.log(`${LOG_PREFIX} Post-insertion TQ duplicate-ID check passed for ${repoFilename} (no collisions)`);
+        }
+      } catch (fixErr) {
+        // In-place fix failed (e.g. ID space exhausted) — revert and abort
         await git.checkout({ fs, dir: repoDir, filepaths: [repoFilename], force: true });
-        const summary = tqIdCheck.duplicates.slice(0, 5)
-          .map(d => `  "${d.id}" first at line ${d.firstLine}, duplicate at line ${d.dupLine}`)
-          .join('\n');
-        let details = `Duplicate TQ row IDs detected in ${repoFilename} — ${tqIdCheck.duplicates.length} collision(s) after insertion:\n${summary}`;
-        if (tqIdCheck.duplicates.length > 5) details += `\n  ... and ${tqIdCheck.duplicates.length - 5} more`;
-        console.error(`${LOG_PREFIX} ${details}`);
-        throw new Error(details);
+        console.error(`${LOG_PREFIX} ${fixErr.message}`);
+        throw fixErr;
       }
-      console.log(`${LOG_PREFIX} Post-insertion TQ duplicate-ID check passed for ${repoFilename} (${tqIdCheck.uniqueCount} unique IDs scanned)`);
     }
 
     // Step 4: Commit and push

--- a/src/workspace-tools/misc-tools.js
+++ b/src/workspace-tools/misc-tools.js
@@ -503,4 +503,74 @@ function checkTqWholeBookIds(bookFilePath) {
   return { duplicates, uniqueCount: seenIds.size };
 }
 
-module.exports = { giteaPr, prepareCompare, prepareTq, verifyTq, deduplicateTqIds, checkTqWholeBookIds, appendQuickref };
+/**
+ * Detect and remap duplicate row IDs in a TQ whole-book TSV file (in-place).
+ *
+ * After `insertTnRows` merges a new chapter into the whole-book file any ID
+ * from the new chapter that collides with an already-committed ID is silently
+ * remapped to a fresh unique ID before the git commit.  This makes the
+ * `door43-push` step self-healing for the rare random cross-chapter collision
+ * rather than fatal.
+ *
+ * The ID format mirrors `deduplicateTqIds`: first character is a lowercase
+ * letter, remaining three characters are lowercase letters or digits.
+ *
+ * @param {string} bookFilePath - Absolute path to the whole-book TQ TSV file
+ * @returns {{ fixed: number, details: string[] }}
+ *   fixed   — number of IDs remapped (0 = no collisions, file untouched)
+ *   details — one human-readable line per remapped ID
+ * @throws {Error} if ID-space is exhausted (should never happen in practice)
+ */
+function fixTqWholeBookIds(bookFilePath) {
+  const content = fs.readFileSync(bookFilePath, 'utf8');
+  const lines = content.split('\n');
+
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const letters = 'abcdefghijklmnopqrstuvwxyz';
+  const seenIds = new Set();
+  let fixed = 0;
+  const details = [];
+  const fixedLines = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Always keep header (i === 0) and blank lines as-is
+    if (i === 0 || !line.trim()) {
+      fixedLines.push(line);
+      continue;
+    }
+    const cols = line.split('\t');
+    const id = cols[1] || '';
+    if (id && seenIds.has(id)) {
+      // Collision — generate a fresh unique ID not already in the whole-book file
+      let newId;
+      let attempts = 0;
+      do {
+        newId = letters[Math.floor(Math.random() * 26)];
+        for (let j = 0; j < 3; j++) newId += chars[Math.floor(Math.random() * 36)];
+        attempts++;
+      } while (seenIds.has(newId) && attempts < 500);
+      if (attempts >= 500) {
+        throw new Error(
+          `fixTqWholeBookIds: exhausted ID space replacing duplicate "${id}" at line ${i + 1} of ${path.basename(bookFilePath)}`
+        );
+      }
+      cols[1] = newId;
+      seenIds.add(newId);
+      fixed++;
+      details.push(`line ${i + 1}: "${id}" → "${newId}"`);
+      fixedLines.push(cols.join('\t'));
+    } else {
+      if (id) seenIds.add(id);
+      fixedLines.push(line);
+    }
+  }
+
+  if (fixed > 0) {
+    fs.writeFileSync(bookFilePath, fixedLines.join('\n'), 'utf8');
+  }
+
+  return { fixed, details };
+}
+
+module.exports = { giteaPr, prepareCompare, prepareTq, verifyTq, deduplicateTqIds, checkTqWholeBookIds, fixTqWholeBookIds, appendQuickref };


### PR DESCRIPTION
Closes #71.

## Summary

- **Root cause**: `deduplicateTqIds` in `tqs-pipeline.js` only deduplicates IDs within the single chapter output file. It seeds its `seenIds` Set from scratch, so it cannot detect collisions with IDs already committed to the whole-book TSV from prior chapters. The 4-character random IDs have a meaningful collision probability once ~1300 rows have been committed.
- **Old behaviour**: `checkTqWholeBookIds` in `door43-push.js` step 3c detected the cross-chapter collision, reverted the file, and threw — causing the entire pipeline run to fail.
- **New behaviour**: `fixTqWholeBookIds` (added to `misc-tools.js`) performs the same scan but remaps any duplicate IDs to fresh unique IDs and rewrites the file before the git commit. The push step is now self-healing. It only reverts+throws if ID-space is exhausted (practically impossible).

## Changes

| File | Change |
|------|--------|
| `src/workspace-tools/misc-tools.js` | Add `fixTqWholeBookIds(bookFilePath)` — detects and remaps duplicate IDs in the whole-book TSV in-place; export alongside `checkTqWholeBookIds` |
| `src/door43-push.js` | Step 3c: replace abort-only `checkTqWholeBookIds` call with self-healing `fixTqWholeBookIds`; import updated accordingly |

## Test plan

- [x] Syntax check: `node --check` passes on both changed files
- [x] Functional test: synthetic TSV with a duplicate `ym1e` row — `fixTqWholeBookIds` remapped it, `checkTqWholeBookIds` confirmed zero duplicates remain after fix
- [ ] Resume the PSA 116–120 pipeline from checkpoint `{ chapter: 118, skill: "door43-push" }` to exercise the live path

🤖 Generated with [Claude Code](https://claude.com/claude-code)