### PR TITLE
fix: send per-chapter Zulip notification as each chapter merges

### DIFF
--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -1423,6 +1423,7 @@ async function generatePipeline(route, message) {
       }
 
       let chapterFailed = false;
+      const chPushStart = Date.now();
 
       // Save checkpoint before door43-push so we can resume here on failure
       setCheckpoint(checkpointRef, {
@@ -1550,6 +1551,12 @@ async function generatePipeline(route, message) {
           current: { chapter: chData.ch, skill: 'door43-push', status: 'succeeded' },
           resume: { chapter: chData.ch, skill: 'door43-push-done' },
         });
+        // Notify user after each chapter merges for multi-chapter runs
+        if (completedChapters.length > 1) {
+          const chPushDuration = ((Date.now() - chPushStart) / 1000).toFixed(1);
+          const repoList = [contentTypes.includes('ult') && 'en_ult', contentTypes.includes('ust') && 'en_ust'].filter(Boolean).join(' and ');
+          await reply(`**${book} ${chData.ch}** content merged to master on ${repoList} (${chPushDuration}s)`);
+        }
       }
     }
     } // end DCS token valid else block

--- a/src/insertion-resume.js
+++ b/src/insertion-resume.js
@@ -92,10 +92,15 @@ async function resumeInsertion(sessionKey, triggerMessage) {
   let success = 0;
   let fail = 0;
 
+  // For multi-chapter deferred runs, notify user as each chapter merges rather than waiting for all
+  const notify = completedChapters.length > 1
+    ? async (text) => replyTo(triggerMessage, text)
+    : null;
+
   if (pipelineType === 'generate') {
-    ({ success, fail } = await runGenerateInsertPhase(completedChapters, username, book));
+    ({ success, fail } = await runGenerateInsertPhase(completedChapters, username, book, notify));
   } else if (pipelineType === 'notes') {
-    ({ success, fail } = await runNotesInsertPhase(completedChapters, username, book));
+    ({ success, fail } = await runNotesInsertPhase(completedChapters, username, book, notify));
   }
 
   // Clear pending state
@@ -146,8 +151,9 @@ async function resumeInsertion(sessionKey, triggerMessage) {
 /**
  * Run repo-insert + repo-verify for ULT and UST per chapter.
  * Pushes to master via the repo-insert skill's merge-to-master workflow.
+ * @param {function} [notify] - optional async callback(text) to send per-chapter Zulip message
  */
-async function runGenerateInsertPhase(completedChapters, username, book) {
+async function runGenerateInsertPhase(completedChapters, username, book, notify) {
   let success = 0;
   let fail = 0;
 
@@ -229,8 +235,14 @@ async function runGenerateInsertPhase(completedChapters, username, book) {
       if (ultVerify.success && ustVerify.success && (verifyUlt || verifyUst)) await status(`Repo verify OK for ${book} ${ch.ch}`);
     }
 
-    if (chapterFailed) fail++;
-    else success++;
+    if (chapterFailed) {
+      fail++;
+    } else {
+      success++;
+      if (notify && completedChapters.length > 1) {
+        await notify(`**${book} ${ch.ch}** content merged to master on en_ult and en_ust`);
+      }
+    }
   }
 
   return { success, fail };
@@ -239,8 +251,9 @@ async function runGenerateInsertPhase(completedChapters, username, book) {
 /**
  * Run repo-insert + repo-verify for TN per chapter.
  * Pushes to master via the repo-insert skill's merge-to-master workflow.
+ * @param {function} [notify] - optional async callback(text) to send per-chapter Zulip message
  */
-async function runNotesInsertPhase(completedChapters, username, book) {
+async function runNotesInsertPhase(completedChapters, username, book, notify) {
   let success = 0;
   let fail = 0;
 
@@ -287,8 +300,14 @@ async function runNotesInsertPhase(completedChapters, username, book) {
       }
     }
 
-    if (chapterFailed) fail++;
-    else success++;
+    if (chapterFailed) {
+      fail++;
+    } else {
+      success++;
+      if (notify && completedChapters.length > 1) {
+        await notify(`**${book} ${ch.ch}** notes merged to master on en_tn`);
+      }
+    }
   }
 
   return { success, fail };


### PR DESCRIPTION
Closes #74.

## Summary

- **`generate-pipeline.js`** (Phase 2 push loop): After each chapter's content is confirmed merged to master on en_ult/en_ust, send a per-chapter Zulip reply to the user when processing multiple chapters. Previously the pipeline sent only a single aggregate message at the end.
- **`insertion-resume.js`** (deferred push, both generate and notes paths): Added an optional `notify` async callback to `runGenerateInsertPhase` and `runNotesInsertPhase`. `resumeInsertion` now creates this callback for multi-chapter deferred runs, so the user receives a message after each individual chapter merges rather than waiting for the final summary.

The existing per-chapter notification in `notes-pipeline.js` (non-deferred path, line 2698) was already correct and is unchanged.

## Test plan

- [ ] Trigger a multi-chapter generate run (e.g. `generate psa 116-118`); confirm individual chapter merge messages appear on Zulip before the final summary.
- [ ] Trigger a multi-chapter notes run where branches conflict; resolve them; say `merged`; confirm individual chapter merge messages appear during the deferred insertion.
- [ ] Confirm single-chapter runs still receive only the final summary (no duplicate intermediate message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)