### PR TITLE
fix: verifyRepoPush false-negative + diagnosis JSON fence parse (closes #79)

### DIFF
--- a/src/repo-verify.js
+++ b/src/repo-verify.js
@@ -133,6 +133,38 @@ async function verifyRepoPush({ repo, stagingBranch, since }) {
       };
     }
 
+    // Fallback: Gitea's head-filter is unreliable once the branch is deleted —
+    // the association is silently dropped and the PR disappears from head-filtered
+    // queries.  Scan the most recent closed PRs without a head filter and look
+    // for one whose head branch matches the staging branch and was merged within
+    // the verification window.
+    try {
+      const recentRes = await apiGet(
+        `/repos/${ORG}/${repo}/pulls?state=closed&limit=20`,
+        token,
+      );
+      if (recentRes.status === 200 && Array.isArray(recentRes.data)) {
+        const fallbackMerged = recentRes.data.find((pr) => {
+          const headLabel = pr.head?.label || pr.head?.ref || '';
+          const isBranch =
+            headLabel === stagingBranch || headLabel.endsWith(`:${stagingBranch}`);
+          const isMerged = pr.merged === true || pr.merged_by != null;
+          if (!isBranch || !isMerged) return false;
+          if (pr.merged_at) return new Date(pr.merged_at) >= new Date(effectiveSince);
+          return false;
+        });
+        if (fallbackMerged) {
+          return {
+            success: true,
+            details: `PR #${fallbackMerged.number} merged ${stagingBranch} into master on ${repo} (confirmed via fallback scan; head-filter was unreliable after branch deletion)`,
+          };
+        }
+      }
+    } catch (_) {
+      // Non-fatal: if the fallback scan itself fails, fall through to the
+      // original failure response so the pipeline can retry.
+    }
+
     // Branch doesn't exist AND no merged PR — push likely never happened
     return {
       success: false,

--- a/src/self-diagnosis.js
+++ b/src/self-diagnosis.js
@@ -206,8 +206,18 @@ function extractDiagnosisJson(raw) {
   if (!raw || typeof raw !== 'string') {
     throw new Error('Diagnosis agent returned no text');
   }
-  const fenceMatch = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
-  const candidate = fenceMatch ? fenceMatch[1].trim() : raw.trim();
+  // Strip outermost code fence using greedy matching (first open, last close).
+  // A non-greedy regex would stop at the first ``` it encounters, truncating
+  // valid JSON when the body field contains nested markdown code fences.
+  let candidate = raw.trim();
+  const openFenceMatch = candidate.match(/^```(?:json)?\s*\n/);
+  if (openFenceMatch) {
+    const afterOpen = openFenceMatch[0].length;
+    const lastFenceIdx = candidate.lastIndexOf('\n```');
+    if (lastFenceIdx > afterOpen) {
+      candidate = candidate.slice(afterOpen, lastFenceIdx).trim();
+    }
+  }
   const parsed = tryParseDiagnosisJson(candidate);
   if (parsed === null) {
     throw new Error(`Diagnosis agent returned invalid JSON: ${candidate.slice(0, 1000)}`);


### PR DESCRIPTION
Closes #79.

## Summary

Two bugs found and fixed from the PSA 125 tqs pipeline failure:

### Bug 1 — `src/repo-verify.js`: `verifyRepoPush` false-negative after branch deletion

**Root cause:** After `door43Push` merges a PR and deletes the staging branch, Gitea silently drops the `head=` association for that PR. The subsequent `verifyRepoPush` call issues `GET /pulls?state=closed&head=unfoldingWord:AI-PSA-125` → Gitea returns `[]` → branch existence check → 404 (correctly deleted) → incorrectly concludes push never happened.

**Fix:** Added a fallback scan after the head-filtered query returns empty and the branch is absent. Queries the 20 most-recent closed PRs without a head filter and matches on branch name + `merged_at` timestamp within the verification window. A genuine push-never-happened case still returns failure (no matching PR found). A successfully merged+deleted PR is now correctly confirmed.

### Bug 2 — `src/self-diagnosis.js`: `extractDiagnosisJson` non-greedy fence regex

**Root cause:** `raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)` uses non-greedy `*?` matching, which stops at the **first** ` ``` ` it encounters. When the diagnosis agent's `body` field contains markdown code blocks (e.g. the failure signal or suggested fix code), the regex truncates the JSON at the first nested fence, producing unparseable output.

**Fix:** Replaced the non-greedy regex with `candidate.match(/^```(?:json)?\s*\n/)` to detect an opening fence and `candidate.lastIndexOf('\n```')` to find the outermost closing fence. This correctly captures the full JSON regardless of nested code fences in the body.

## Test

- Syntax: `node --check` passes on both files ✓
- Logic: standalone unit test confirms OLD regex fails on nested-fence input; NEW logic parses correctly ✓

## Notes

- Bot was NOT restarted. This is an app-side PR — merge manually; live bot will pick up changes on next Docker rebuild.