### PR TITLE
Bump tn-quality-check to Opus + extended-thinking auto-defaults

### DIFF
--- a/src/claude-runner.js
+++ b/src/claude-runner.js
@@ -60,11 +60,13 @@ const THINKING_LEVELS = {
 function resolveThinkingBudget(thinking, resolvedModel) {
   if (thinking === false || thinking === 'off' || thinking === 'none') return null;
   if (typeof thinking === 'number') {
-    if (thinking >= 1024) return thinking;
-    throw new Error(`Invalid thinking budget: ${thinking} (must be >= 1024 tokens)`);
+    if (thinking < 1024 || thinking > THINKING_MAX) {
+      throw new Error(`Invalid thinking budget: ${thinking} (must be between 1024 and ${THINKING_MAX} tokens)`);
+    }
+    return thinking;
   }
   if (typeof thinking === 'string') {
-    if (THINKING_LEVELS[thinking]) return THINKING_LEVELS[thinking];
+    if (thinking in THINKING_LEVELS) return THINKING_LEVELS[thinking];
     throw new Error(`Unrecognized thinking level: '${thinking}' (expected one of: ${Object.keys(THINKING_LEVELS).join(', ')}, 'off')`);
   }
   // Auto-default (thinking == null/undefined): Opus → HIGH, Sonnet → MEDIUM, Haiku/others → none.

--- a/src/claude-runner.js
+++ b/src/claude-runner.js
@@ -59,10 +59,16 @@ const THINKING_LEVELS = {
 
 function resolveThinkingBudget(thinking, resolvedModel) {
   if (thinking === false || thinking === 'off' || thinking === 'none') return null;
-  if (typeof thinking === 'number' && thinking >= 1024) return thinking;
-  if (typeof thinking === 'string' && THINKING_LEVELS[thinking]) return THINKING_LEVELS[thinking];
-  // Auto-default: Opus → HIGH, Sonnet → MEDIUM, Haiku/others → none.
-  if (thinking == null && typeof resolvedModel === 'string') {
+  if (typeof thinking === 'number') {
+    if (thinking >= 1024) return thinking;
+    throw new Error(`Invalid thinking budget: ${thinking} (must be >= 1024 tokens)`);
+  }
+  if (typeof thinking === 'string') {
+    if (THINKING_LEVELS[thinking]) return THINKING_LEVELS[thinking];
+    throw new Error(`Unrecognized thinking level: '${thinking}' (expected one of: ${Object.keys(THINKING_LEVELS).join(', ')}, 'off')`);
+  }
+  // Auto-default (thinking == null/undefined): Opus → HIGH, Sonnet → MEDIUM, Haiku/others → none.
+  if (typeof resolvedModel === 'string') {
     if (/opus/i.test(resolvedModel)) return THINKING_HIGH;
     if (/sonnet/i.test(resolvedModel)) return THINKING_MEDIUM;
   }

--- a/src/claude-runner.js
+++ b/src/claude-runner.js
@@ -42,6 +42,33 @@ async function createFreshWorkspaceToolsServer(toolSet) {
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_MAX_TURNS = 200;
 
+// Extended-thinking budgets (token counts for Claude Agent SDK thinking option).
+// Mirrors Claude Code's keyword tiers: think / megathink / ultrathink, plus an
+// extra "high" tier we use as the default for Opus calls.
+const THINKING_LOW = 4000;
+const THINKING_MEDIUM = 10000;
+const THINKING_HIGH = 20000;
+const THINKING_MAX = 31999;
+
+const THINKING_LEVELS = {
+  low: THINKING_LOW,
+  medium: THINKING_MEDIUM,
+  high: THINKING_HIGH,
+  max: THINKING_MAX,
+};
+
+function resolveThinkingBudget(thinking, resolvedModel) {
+  if (thinking === false || thinking === 'off' || thinking === 'none') return null;
+  if (typeof thinking === 'number' && thinking >= 1024) return thinking;
+  if (typeof thinking === 'string' && THINKING_LEVELS[thinking]) return THINKING_LEVELS[thinking];
+  // Auto-default: Opus → HIGH, Sonnet → MEDIUM, Haiku/others → none.
+  if (thinking == null && typeof resolvedModel === 'string') {
+    if (/opus/i.test(resolvedModel)) return THINKING_HIGH;
+    if (/sonnet/i.test(resolvedModel)) return THINKING_MEDIUM;
+  }
+  return null;
+}
+
 const DEFAULT_ALLOWED_TOOLS = [
   'Read', 'Write', 'Edit', 'Glob', 'Grep',
   'Task', 'Skill', 'SendMessage',
@@ -86,6 +113,7 @@ function buildOptions({
   appendSystemPrompt,
   abortController,
   mcpServers,
+  thinking,
 }) {
   const options = {
     cwd: cwd || process.cwd(),
@@ -117,6 +145,10 @@ function buildOptions({
     options.resume = resume;
   }
   options.model = model || 'opus';
+  const thinkingBudget = resolveThinkingBudget(thinking, options.model);
+  if (thinkingBudget) {
+    options.thinking = { type: 'enabled', budget_tokens: thinkingBudget };
+  }
   if (betas) {
     options.betas = betas;
   }
@@ -144,6 +176,7 @@ async function runClaudeOnce({
   mcpToolSet,
   onProgress,
   guardrails,
+  thinking,
 }) {
   await ensureFreshToken();
   const query = await getQuery();
@@ -204,6 +237,7 @@ async function runClaudeOnce({
     appendSystemPrompt,
     abortController,
     mcpServers: { 'workspace-tools': wsTools },
+    thinking,
   });
 
   console.log(`[claude-runner q=${queryId}] Starting query in ${cwd}`);
@@ -524,6 +558,7 @@ async function runClaudeStream({
   maxTurns,
   timeoutMs,
   appendSystemPrompt,
+  thinking,
 }) {
   await ensureFreshToken();
   const query = await getQuery();
@@ -549,6 +584,7 @@ async function runClaudeStream({
     appendSystemPrompt,
     abortController,
     mcpServers: { 'workspace-tools': wsTools },
+    thinking,
   });
 
   console.log(`[claude-runner] Starting stream in ${cwd}${resume ? ` (resume: ${resume.slice(0, 8)}…)` : ''}`);
@@ -570,4 +606,9 @@ module.exports = {
   DEFAULT_RESTRICTED_TOOLS,
   ClaudeTransientOutageError,
   isTransientOutageError,
+  THINKING_LOW,
+  THINKING_MEDIUM,
+  THINKING_HIGH,
+  THINKING_MAX,
+  resolveThinkingBudget,
 };

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -1863,7 +1863,7 @@ async function notesPipeline(route, message) {
       mcpTools: 'quality',
       maxTurns: 100,
       ops: 1,
-      model: 'sonnet',
+      model: 'opus',
     });
 
     // --- Run skills sequentially ---

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -1852,7 +1852,8 @@ async function notesPipeline(route, message) {
       ops: 1,
     });
 
-    // tn-quality-check runs as a separate Sonnet invocation for independent review
+    // tn-quality-check runs as a separate Opus invocation for independent review
+    // (auto-defaults to THINKING_HIGH via claude-runner's thinking-budget logic)
     const qualityTag = hasVerseRange ? `${tag}-vv${verseStart}-${verseEnd}` : tag;
     const defaultNotesPath = hasVerseRange ? notesShardRel : notesChapterRel;
     skills.push({


### PR DESCRIPTION
## Summary
- tn-quality-check skill now runs on Opus 4.7 (was Sonnet 4.6) for a stronger independent reviewer pass over generated notes.
- claude-runner gains `THINKING_LOW/MEDIUM/HIGH/MAX` (4k/10k/20k/31999) and a `thinking` option plumbed through `runClaude` / `runClaudeStream`. Auto-defaults: **Opus → HIGH (20k), Sonnet → MEDIUM (10k), Haiku → off.** Callers can override per-call with a level keyword, a numeric budget, or `false` to disable.

## Test plan
- [ ] Lint / type-check pass (pre-existing eslint config gap is not new)
- [ ] Spot-check a notes pipeline run: tn-quality-check log line shows opus + thinking enabled
- [ ] Verify generate / tn-writer / interactive-DM Opus runs report thinking enabled
- [ ] Verify Sonnet pipelines (post-edit-review, self-diagnosis, tqs) report thinking enabled at 10k

🤖 Generated with [Claude Code](https://claude.com/claude-code)