### PR TITLE
Add /api/tn-quick public endpoint for translation-note editor UI

### DIFF
--- a/src/api-runner/verse-data.js
+++ b/src/api-runner/verse-data.js
@@ -368,4 +368,10 @@ module.exports = {
   VERSE_DATA_TOOL_SCHEMAS,
   executeVerseDataTool,
   isVerseDataTool,
+  getTemplate,
+  getVerseData,
+  getExistingNotes,
+  loadCache,
+  cache,
+  BOOK_NUMBERS,
 };

--- a/src/api/tn-quick.js
+++ b/src/api/tn-quick.js
@@ -1,0 +1,385 @@
+// tn-quick.js — public HTTPS endpoint that wraps the tn-quick skill.
+// See: /home/ubuntu/bp-bot/tn-quick-api-contract.md for the client-facing
+// contract this implements.
+
+const path = require('path');
+const crypto = require('crypto');
+const Anthropic = require('@anthropic-ai/sdk');
+const { z } = require('zod');
+const { readSecret } = require('../secrets');
+const { getAnthropicApiKey } = require('../anthropic-env');
+const { resolveProviderModel } = require('../api-runner/provider-config');
+const {
+  getTemplate,
+  loadCache,
+  BOOK_NUMBERS,
+} = require('../api-runner/verse-data');
+const {
+  parseHebrewVerseWords,
+  normalizeHebrewQuote,
+} = require('../workspace-tools/quality-tools');
+
+const HEBREW_DIR_REL = 'data/hebrew_bible';
+const MAX_BODY_BYTES = 32 * 1024;
+const RATE_LIMIT_RPM = 60;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+// Canonical source of these style rules: bp-assistant-skills/.claude/skills/tn-quick/SKILL.md
+// Keep in sync when style guidance there changes.
+const TN_QUICK_STYLE = `You draft a single English translation note for an English support phrase highlighted in the ULT.
+
+Output: call the submit_note tool exactly once with the final note text. No preamble outside the tool call.
+
+## Style Rules
+
+### Templates
+- Use the template from the templates field as closely as possible.
+- Replace ALL CAPS placeholders with context from the verse.
+- Resolve slashes by picking the appropriate word.
+- Do not rephrase or condense template wording.
+
+### Alternate Translations
+- Enclose in square brackets: \`Alternate translation: [text here]\`.
+- Must fit seamlessly: removing the quoted phrase from the ULT and inserting the AT should read as natural English.
+- Must differ from UST phrasing for the same verse.
+- Minimal change to ULT wording — only change what the issue requires.
+- No punctuation at start/end of brackets unless the note is about punctuation.
+- Match capitalization to sentence position of the quoted phrase.
+
+### Bold and Quoting
+- Bold words/phrases quoted from the verse: \`**quoted words**\`.
+- Only bold the first occurrence.
+- Match capitalization and grammatical forms exactly from the ULT.
+
+### Quotation Marks
+- Use Unicode curly quotes in note body text: “ ” (U+201C/U+201D) and ‘ ’ (U+2018/U+2019).
+- Never use straight quotes (" or ') in prose — curly quotes only.
+- Alternate translation brackets [] are unaffected.
+
+### Author References
+- Always use the author's name, never "the author." Replace SPEAKER placeholders in templates with the name (e.g., Habakkuk, Isaiah, Moses).
+- For Psalms, check the superscription: use David, Asaph, etc. if named; use "the psalmist" if anonymous.
+
+### "Here" Rule
+- Only start with "Here, " if immediately followed by a bolded lowercase quote: \`Here, **admonish** means...\`.
+- Never: \`Here the author is speaking...\` or \`Here Habakkuk is saying...\`.
+
+### Restrictions
+- No source language names (Hebrew, Greek, Aramaic) in note text.
+- No linguistic jargon not present in the template (no "cognate accusative," "genitive," etc.).
+- No "could mean" (reserved for TCM multi-interpretation notes).
+- No extra explanation beyond what the template models.
+- Do not define words for figs-abstractnouns — just resolve the abstract noun.
+- For figs-activepassive, the AT must use an active verb, not passive with agent added.
+
+### Figure of Speech Verbiage
+| Figure | Standard Verbiage |
+|---|---|
+| Metaphor | speaking of X as if it were Y |
+| Hyperbole | generalization, extreme statement |
+| Idiom | was a common expression meaning |
+| Merism | referring to all of X by naming two extremes |
+| Metonymy | X represents Y |
+| Parallelism | These two phrases mean basically the same thing |
+| Personification | speaks of X as if it were a person who could... |
+| Synecdoche | using one kind to mean the general category |
+| Hendiadys | The phrase X and Y expresses a single idea |
+| Reduplication | repeating forms of the word X to intensify |
+`;
+
+const ContextSchema = z.object({
+  prev5: z.array(z.string().max(3000)).max(5).default([]),
+  next5: z.array(z.string().max(3000)).max(5).default([]),
+}).default({ prev5: [], next5: [] });
+
+const TextSideSchema = z.object({
+  selection: z.string().min(1).max(500),
+  verse: z.string().min(1).max(3000),
+  context: ContextSchema,
+});
+
+const BodySchema = z.object({
+  ref: z.object({
+    book: z.string().regex(/^[A-Za-z0-9]{3}$/),
+    chapter: z.number().int().min(1).max(150),
+    verse: z.number().int().min(1).max(200),
+  }),
+  issueType: z.string().min(2).max(80),
+  ult: TextSideSchema,
+  ust: TextSideSchema,
+  hebrewGuess: z.string().min(1).max(500),
+  model: z.enum(['sonnet', 'opus']).default('sonnet'),
+});
+
+const rateLimits = new Map();
+
+function checkRateLimit(token) {
+  const key = crypto.createHash('sha256').update(token).digest('hex');
+  const now = Date.now();
+  const cur = rateLimits.get(key);
+  if (!cur || now - cur.windowStartMs >= RATE_LIMIT_WINDOW_MS) {
+    rateLimits.set(key, { count: 1, windowStartMs: now });
+    return true;
+  }
+  cur.count++;
+  return cur.count <= RATE_LIMIT_RPM;
+}
+
+function readBody(req, maxBytes) {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    let exceeded = false;
+    const chunks = [];
+    req.on('data', (c) => {
+      if (exceeded) return;
+      size += c.length;
+      if (size > maxBytes) {
+        exceeded = true;
+        const err = new Error('body too large');
+        err.code = 'BODY_TOO_LARGE';
+        reject(err);
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on('end', () => {
+      if (!exceeded) resolve(Buffer.concat(chunks).toString('utf8'));
+    });
+    req.on('error', (e) => { if (!exceeded) reject(e); });
+  });
+}
+
+function reply(res, status, body, extraHeaders) {
+  const headers = { 'Content-Type': 'application/json', ...(extraHeaders || {}) };
+  res.writeHead(status, headers);
+  res.end(JSON.stringify(body));
+}
+
+function applyCors(req, res) {
+  const raw = process.env.TN_QUICK_CORS_ORIGINS || '';
+  const allowed = raw.split(',').map((s) => s.trim()).filter(Boolean);
+  if (!allowed.length) return;
+  const origin = req.headers.origin || '';
+  if (allowed.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+  } else {
+    res.removeHeader('Access-Control-Allow-Origin');
+  }
+}
+
+function getVerseWords(book, chapter, verse) {
+  const num = BOOK_NUMBERS[book.toUpperCase()];
+  if (!num) return null;
+  const hebrewPath = path.posix.join(HEBREW_DIR_REL, `${num}-${book.toUpperCase()}.usfm`);
+  const verseMap = parseHebrewVerseWords(hebrewPath);
+  if (!verseMap || Object.keys(verseMap).length === 0) return null;
+  return verseMap[`${chapter}:${verse}`] || [];
+}
+
+function formatContextLines(label, verseText, prev5, next5, refVerse) {
+  const lines = [];
+  for (let i = 0; i < prev5.length; i++) {
+    const v = refVerse - (prev5.length - i);
+    if (v >= 1) lines.push(`${label} ${v}: ${prev5[i]}`);
+  }
+  lines.push(`${label} ${refVerse} [TARGET VERSE]: ${verseText}`);
+  for (let i = 0; i < next5.length; i++) {
+    lines.push(`${label} ${refVerse + i + 1}: ${next5[i]}`);
+  }
+  return lines.join('\n');
+}
+
+function buildUserMessage({ body, templateInfo, hebrewQuote }) {
+  const { ref, issueType, ult, ust } = body;
+  const ultCtx = formatContextLines('ULT v.', ult.verse, ult.context.prev5, ult.context.next5, ref.verse);
+  const ustCtx = formatContextLines('UST v.', ust.verse, ust.context.prev5, ust.context.next5, ref.verse);
+
+  return [
+    `Reference: ${ref.book.toUpperCase()} ${ref.chapter}:${ref.verse}`,
+    `Issue type: ${issueType}`,
+    '',
+    `ULT support phrase: "${ult.selection}"`,
+    `UST parallel phrase: "${ust.selection}"`,
+    `Hebrew quote (validated): ${hebrewQuote}`,
+    '',
+    'Templates for this issue type:',
+    JSON.stringify(templateInfo.templates, null, 2),
+    '',
+    'ULT context (±5 verses):',
+    ultCtx,
+    '',
+    'UST context (±5 verses):',
+    ustCtx,
+    '',
+    'Draft ONE translation note for the ULT support phrase above. Call submit_note exactly once with the final note text.',
+  ].join('\n');
+}
+
+async function callModel({ system, userMessage, modelTier, apiKey }) {
+  const AnthropicCtor = Anthropic.default || Anthropic.Anthropic || Anthropic;
+  const client = new AnthropicCtor({ apiKey });
+  const modelId = resolveProviderModel('claude', modelTier);
+
+  const response = await client.messages.create({
+    model: modelId,
+    max_tokens: 800,
+    system,
+    messages: [{ role: 'user', content: userMessage }],
+    tools: [{
+      name: 'submit_note',
+      description: 'Submit the final drafted translation note.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          note: { type: 'string', description: 'The drafted note text.' },
+        },
+        required: ['note'],
+      },
+    }],
+    tool_choice: { type: 'tool', name: 'submit_note' },
+  });
+
+  const toolUse = (response.content || []).find((b) => b.type === 'tool_use');
+  if (!toolUse || !toolUse.input || typeof toolUse.input.note !== 'string') {
+    throw new Error('model did not return submit_note tool call');
+  }
+  return toolUse.input.note;
+}
+
+async function handleTnQuickRequest(req, res) {
+  const startedAt = Date.now();
+  let logLine = '[tn-quick] ';
+  try {
+    applyCors(req, res);
+
+    const token = readSecret('bt_api_token', 'BT_API_TOKEN');
+    if (!token) {
+      reply(res, 503, {
+        error: 'tn_quick_disabled',
+        message: 'BT_API_TOKEN not configured on server',
+      });
+      return;
+    }
+
+    const auth = req.headers.authorization || '';
+    if (auth !== `Bearer ${token}`) {
+      reply(res, 401, { error: 'unauthorized' });
+      return;
+    }
+
+    if (!checkRateLimit(token)) {
+      reply(res, 429, { error: 'rate_limited' }, { 'Retry-After': '30' });
+      return;
+    }
+
+    let raw;
+    try {
+      raw = await readBody(req, MAX_BODY_BYTES);
+    } catch (err) {
+      if (err.code === 'BODY_TOO_LARGE') {
+        reply(res, 413, { error: 'body_too_large', maxBytes: MAX_BODY_BYTES });
+        return;
+      }
+      throw err;
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      reply(res, 400, { error: 'invalid_json' });
+      return;
+    }
+
+    const result = BodySchema.safeParse(parsed);
+    if (!result.success) {
+      reply(res, 400, { error: 'validation_failed', issues: result.error.issues });
+      return;
+    }
+    const body = result.data;
+
+    const bookUpper = body.ref.book.toUpperCase();
+    if (!BOOK_NUMBERS[bookUpper]) {
+      reply(res, 400, { error: 'unknown_book', book: body.ref.book });
+      return;
+    }
+
+    try {
+      loadCache();
+    } catch (err) {
+      reply(res, 503, { error: 'cache_unavailable', message: err.message });
+      return;
+    }
+
+    const templateInfo = getTemplate({ issue_type: body.issueType });
+    if (templateInfo.error) {
+      reply(res, 400, { error: 'unknown_issue_type', issueType: body.issueType });
+      return;
+    }
+
+    const verseWords = getVerseWords(bookUpper, body.ref.chapter, body.ref.verse);
+    if (!verseWords || verseWords.length === 0) {
+      reply(res, 503, { error: 'uhb_missing_for_verse', ref: body.ref });
+      return;
+    }
+
+    const heb = normalizeHebrewQuote(body.hebrewGuess, verseWords);
+    if (heb.status === 'no_rtl') {
+      reply(res, 422, {
+        error: 'no_rtl',
+        message: 'hebrewGuess contains no Hebrew characters',
+      });
+      return;
+    }
+    if (heb.status === 'no_words_match') {
+      reply(res, 422, {
+        error: 'hebrew_words_not_in_verse',
+        detail: heb.warnings,
+      });
+      return;
+    }
+    const warnings = heb.warnings.map((w) => `${w.code}: ${w.detail}`);
+
+    const apiKey = getAnthropicApiKey();
+    if (!apiKey) {
+      reply(res, 503, { error: 'anthropic_api_key_missing' });
+      return;
+    }
+
+    const system = TN_QUICK_STYLE;
+    const userMessage = buildUserMessage({
+      body,
+      templateInfo,
+      hebrewQuote: heb.quote,
+    });
+
+    let noteText;
+    try {
+      noteText = await callModel({
+        system,
+        userMessage,
+        modelTier: body.model,
+        apiKey,
+      });
+    } catch (err) {
+      console.error(`[tn-quick] model error: ${err.message}`);
+      reply(res, 502, { error: 'model_call_failed', message: err.message });
+      return;
+    }
+
+    reply(res, 200, { quote: heb.quote, note: noteText, warnings });
+    const lat = Date.now() - startedAt;
+    logLine += `book=${bookUpper} ${body.ref.chapter}:${body.ref.verse} `
+      + `issue=${body.issueType} lat=${lat}ms model=${body.model} `
+      + `status=200 warnings=${warnings.length}`;
+    console.log(logLine);
+  } catch (err) {
+    console.error(`[tn-quick] unhandled: ${err.stack || err.message}`);
+    if (!res.headersSent) {
+      reply(res, 500, { error: 'internal_error' });
+    }
+  }
+}
+
+module.exports = { handleTnQuickRequest };

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -12,6 +12,8 @@ const { z } = require('zod');
 const { readSecret } = require('./secrets');
 const { readAdminStatus } = require('./admin-status');
 const { listCheckpoints } = require('./pipeline-checkpoints');
+const { handleTnQuickRequest } = require('./api/tn-quick');
+const { loadCache: loadVerseDataCache } = require('./api-runner/verse-data');
 
 const ADMIN_PORT = Number(process.env.PORT || 8080);
 const MCP_PORT = Number(process.env.MCP_PORT || 3001);
@@ -706,6 +708,11 @@ function createHttpServer() {
       return;
     }
 
+    if (req.method === 'POST' && urlPath === '/api/tn-quick') {
+      await handleTnQuickRequest(req, res);
+      return;
+    }
+
     if (urlPath === '/admin' || urlPath === '/admin/status') {
       if (!requireAdminAuth(req, res, adminPassword)) return;
       const filters = {
@@ -787,6 +794,11 @@ function startAdminServer() {
   httpServer.listen(ADMIN_PORT, '0.0.0.0', () => {
     console.log(`[admin] Admin server listening on port ${ADMIN_PORT}`);
   });
+  try {
+    loadVerseDataCache();
+  } catch (err) {
+    console.warn(`[admin] verse-data cache preload failed (will retry on first /api/tn-quick request): ${err.message}`);
+  }
 }
 
 function startMcpServer() {

--- a/src/workspace-tools/quality-tools.js
+++ b/src/workspace-tools/quality-tools.js
@@ -241,6 +241,83 @@ function parseHebrewVerseWords(hebrewUsfmPath) {
   return verseWords;
 }
 
+const HEBREW_RTL_RE = /[֐-׿؀-ۿיִ-﷿ﹰ-﻿]/;
+const HEBREW_CANT_RE = /[֑-֯⁠־]/g;
+
+/**
+ * Normalize a candidate Hebrew quote against the canonical verse word list
+ * loaded from the UHB. Inserts ` & ` joiners at discontinuity gaps so the
+ * returned string matches translation-note conventions.
+ *
+ * Returns { quote, status, warnings } where:
+ *   quote    — normalized Hebrew (NFC, with ` & ` joiners where needed)
+ *   status   — 'ok' | 'no_rtl' | 'no_words_match' | 'partial_match'
+ *   warnings — [{ code, detail }] zero or more soft issues
+ *
+ * Matching is cantillation/taamim-insensitive. First occurrence wins when
+ * a verse repeats a word (refinement candidate if mis-matches show up).
+ */
+function normalizeHebrewQuote(rawQuote, verseWords) {
+  const warnings = [];
+  if (!rawQuote || typeof rawQuote !== 'string') {
+    return { quote: '', status: 'no_rtl', warnings };
+  }
+  if (!HEBREW_RTL_RE.test(rawQuote)) {
+    return { quote: rawQuote, status: 'no_rtl', warnings };
+  }
+
+  const tokens = rawQuote
+    .split(/\s+&\s+|\s+/)
+    .map(s => s.trim())
+    .filter(Boolean);
+  if (tokens.length === 0) {
+    return { quote: rawQuote, status: 'no_words_match', warnings };
+  }
+
+  const matched = [];
+  let matchCount = 0;
+  for (const tok of tokens) {
+    const tokStripped = tok.replace(HEBREW_CANT_RE, '');
+    let pos = -1;
+    for (let i = 0; i < verseWords.length; i++) {
+      const w = verseWords[i];
+      if (w === tok || w.replace(HEBREW_CANT_RE, '') === tokStripped) {
+        pos = i;
+        break;
+      }
+    }
+    if (pos < 0) {
+      warnings.push({ code: 'hebrew_word_not_in_verse', detail: tok });
+    } else {
+      matchCount++;
+    }
+    matched.push({ token: tok, position: pos });
+  }
+
+  if (matchCount === 0) {
+    return { quote: rawQuote, status: 'no_words_match', warnings };
+  }
+
+  const parts = [];
+  for (let i = 0; i < matched.length; i++) {
+    const cur = matched[i];
+    if (i === 0) {
+      parts.push(cur.token);
+      continue;
+    }
+    const prev = matched[i - 1];
+    const gap = (prev.position >= 0 && cur.position >= 0)
+      ? (cur.position - prev.position)
+      : 1;
+    parts.push(gap > 1 ? ' & ' : ' ');
+    parts.push(cur.token);
+  }
+
+  const normalized = parts.join('').normalize('NFC');
+  const status = matchCount < tokens.length ? 'partial_match' : 'ok';
+  return { quote: normalized, status, warnings };
+}
+
 /**
  * Fetch upstream TN IDs for a given book from Door43.
  * Returns a Set of IDs on success, or null on failure.
@@ -870,4 +947,9 @@ async function checkTnQuality({ tsvPath, preparedJson, ultUsfm, ustUsfm, book, h
   return `Quality check: ${summary.total_notes} notes, ${summary.errors} errors, ${summary.warnings} warnings, ${summary.clean} clean\n${outPath}`;
 }
 
-module.exports = { validateTnTsv, checkTnQuality };
+module.exports = {
+  validateTnTsv,
+  checkTnQuality,
+  parseHebrewVerseWords,
+  normalizeHebrewQuote,
+};


### PR DESCRIPTION
## Summary
- New public HTTPS endpoint `POST /api/tn-quick` on `uw-bt-bot` (port 8080) that wraps the `tn-quick` skill as a JSON API for an external translation-note editor UI.
- UI sends ULT/UST selections + issue type + best-guess Hebrew; server validates Hebrew against the canonical UHB (inserts ` & ` joiners for discontinuous quotes), picks the template by issue type, and drafts a note via Sonnet 4.6 with forced `submit_note` tool-use for JSON output.
- Bearer auth via new `BT_API_TOKEN` secret (distinct from `BT_MCP_API_TOKEN`); 60 RPM per-token rate-limit; 32 KB body cap. MCP server on `:3001` stays loopback-only — only the one new route is exposed.
- No `fly.toml` changes.

Client-side contract for the UI lives at `~/bp-bot/tn-quick-api-contract.md` (not committed — it's docs for the external repo).

## Test plan
- [x] Local smoke tests: 401 no-auth / bad-auth, 400 invalid-json / unknown-book / unknown-issue, 413 oversized body, 422 no_rtl / hebrew_words_not_in_verse, 429 rate-limit at request #61. All pass (no model spend).
- [x] `normalizeHebrewQuote` unit checks: contiguous match, discontinuous gets ` & ` inserted, partial match emits warning, zero-match returns `no_words_match`.
- [x] `node --check` on all modified files; `require()` of `./src/mcp-server` succeeds.
- [ ] After merge + deploy: set `BT_API_TOKEN` Fly secret, curl `https://uw-bt-bot.fly.dev/api/tn-quick` with a real ZEC 1:14 / `figs-abstractnouns` payload; confirm 200 with valid `{quote, note}`.
- [ ] Confirm `flyctl logs -a uw-bt-bot` shows `[tn-quick]` lines and MCP server still binds `127.0.0.1:3001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)