### PR TITLE
Fix verse-data loadCache: honor CSKILLBP_DIR

### DIFF
--- a/src/api-runner/verse-data.js
+++ b/src/api-runner/verse-data.js
@@ -4,6 +4,7 @@
 const http = require('http');
 const https = require('https');
 const fs = require('fs');
+const path = require('path');
 
 const DOOR43_BASE = 'https://git.door43.org/unfoldingWord';
 
@@ -178,18 +179,32 @@ function stripMarkup(verseUsfm) {
 function loadCache() {
   if (cache.validIssues && cache.templates) return;
 
-  // Try Docker path first, then host path
-  const paths = ['/workspace/data', '/srv/bot/workspace/data'];
-  let dataDir;
-  for (const p of paths) {
-    if (fs.existsSync(p)) { dataDir = p; break; }
-  }
-  if (!dataDir) {
-    throw new Error('Cannot find workspace/data directory for translation-issues.csv and templates.csv');
+  const workspaceDir = process.env.CSKILLBP_DIR || '';
+  const dataDirCandidates = [
+    workspaceDir ? path.join(workspaceDir, 'data') : null,
+    '/data/workspace/data',
+    '/srv/bot/workspace/data',
+    '/workspace/data',
+    '/srv/bot/app/data',
+  ].filter(Boolean);
+
+  let issuesPath = null;
+  let templatesPath = null;
+  for (const dataDir of dataDirCandidates) {
+    const ic = path.join(dataDir, 'translation-issues.csv');
+    const tc = path.join(dataDir, 'templates.csv');
+    if (fs.existsSync(ic) && fs.existsSync(tc)) {
+      issuesPath = ic;
+      templatesPath = tc;
+      break;
+    }
   }
 
-  const issuesPath = `${dataDir}/translation-issues.csv`;
-  const templatesPath = `${dataDir}/templates.csv`;
+  if (!issuesPath || !templatesPath) {
+    throw new Error(
+      `Cannot find workspace/data directory for translation-issues.csv and templates.csv. Tried: ${dataDirCandidates.join(', ')}`
+    );
+  }
 
   const issuesText = fs.readFileSync(issuesPath, 'utf8');
   const issueRows = parseCSV(issuesText);


### PR DESCRIPTION
## Summary
- Follow-up fix for #86: \`/api/tn-quick\` was returning 503 \`cache_unavailable\` in production because the legacy \`api-runner/verse-data.js\` loadCache only tried \`/workspace/data\` and \`/srv/bot/workspace/data\`.
- On Fly the data lives at \`/data/workspace/data\` (via \`CSKILLBP_DIR=/data/workspace\` in \`fly.toml\`).
- Mirrors the candidate-path logic already in \`src/mcp-server.js\`.

## Test plan
- [x] Local smoke tests still pass with and without \`CSKILLBP_DIR\` set.
- [ ] Post-deploy: curl https://uw-bt-bot.fly.dev/api/tn-quick → 200 with valid {quote, note}.

🤖 Generated with [Claude Code](https://claude.com/claude-code)