### PR TITLE
Add /api/pipeline endpoints for chapter-scale pipeline triggering

### DIFF
--- a/src/api/pipeline-output.js
+++ b/src/api/pipeline-output.js
@@ -1,0 +1,145 @@
+// pipeline-output.js — deterministic Door43 output ref derivation for the
+// public pipeline API. Source of truth for "where does <pipelineType> for
+// <book> <chapter> land on Door43?".
+//
+// Keep in sync with:
+//   - REPO_MAP in src/door43-push.js (resource → repo name)
+//   - getRepoFilename in src/door43-push.js (resource → in-repo file path)
+//   - branch naming in pipeline-utils.js (`AI-{BOOK}-{CHAPTER}`)
+
+const https = require('https');
+const { buildBranchName } = require('../pipeline-utils');
+
+const ORG = 'unfoldingWord';
+const GITEA_HOST = 'git.door43.org';
+const GITEA_API_PREFIX = '/api/v1';
+
+const REPO_MAP = { tn: 'en_tn', tq: 'en_tq', ult: 'en_ult', ust: 'en_ust' };
+
+const BOOK_NUMBERS = {
+  GEN: '01', EXO: '02', LEV: '03', NUM: '04', DEU: '05',
+  JOS: '06', JDG: '07', RUT: '08', '1SA': '09', '2SA': '10',
+  '1KI': '11', '2KI': '12', '1CH': '13', '2CH': '14', EZR: '15',
+  NEH: '16', EST: '17', JOB: '18', PSA: '19', PRO: '20',
+  ECC: '21', SNG: '22', ISA: '23', JER: '24', LAM: '25',
+  EZK: '26', DAN: '27', HOS: '28', JOL: '29', AMO: '30',
+  OBA: '31', JON: '32', MIC: '33', NAM: '34', HAB: '35',
+  ZEP: '36', HAG: '37', ZEC: '38', MAL: '39',
+  MAT: '41', MRK: '42', LUK: '43', JHN: '44', ACT: '45',
+  ROM: '46', '1CO': '47', '2CO': '48', GAL: '49', EPH: '50',
+  PHP: '51', COL: '52', '1TH': '53', '2TH': '54', '1TI': '55',
+  '2TI': '56', TIT: '57', PHM: '58', HEB: '59', JAS: '60',
+  '1PE': '61', '2PE': '62', '1JN': '63', '2JN': '64', '3JN': '65',
+  JUD: '66', REV: '67',
+};
+
+const PIPELINE_OUTPUT_TYPES = {
+  generate: ['ult', 'ust'],
+  notes: ['tn'],
+  tqs: ['tq'],
+};
+
+function rawUrl(repo, file) {
+  return `https://${GITEA_HOST}/${ORG}/${repo}/raw/branch/master/${file}`;
+}
+
+function fileFor(type, book) {
+  const upper = book.toUpperCase();
+  if (type === 'tn') return `tn_${upper}.tsv`;
+  if (type === 'tq') return `tq_${upper}.tsv`;
+  if (type === 'ult' || type === 'ust') {
+    const num = BOOK_NUMBERS[upper];
+    if (!num) throw new Error(`Unknown book code: ${book}`);
+    return `${num}-${upper}.usfm`;
+  }
+  throw new Error(`Unknown resource type: ${type}`);
+}
+
+function getExpectedOutputs(pipelineType, book) {
+  const types = PIPELINE_OUTPUT_TYPES[pipelineType];
+  if (!types) throw new Error(`Unknown pipelineType: ${pipelineType}`);
+  return types.map((type) => {
+    const repo = REPO_MAP[type];
+    const file = fileFor(type, book);
+    return {
+      type,
+      repo: `${ORG}/${repo}`,
+      branch: 'master',
+      path: file,
+      rawUrl: rawUrl(repo, file),
+    };
+  });
+}
+
+function buildStagingBranch(book, startChapter, endChapter) {
+  return buildBranchName(book, startChapter, endChapter);
+}
+
+function giteaGet(pathSuffix, token) {
+  return new Promise((resolve, reject) => {
+    const req = https.request({
+      hostname: GITEA_HOST,
+      path: `${GITEA_API_PREFIX}${pathSuffix}`,
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        ...(token ? { Authorization: `token ${token}` } : {}),
+        'User-Agent': 'bp-assistant',
+      },
+      timeout: 10_000,
+    }, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf8');
+        let data = body;
+        try { data = JSON.parse(body); } catch { /* leave as string */ }
+        resolve({ status: res.statusCode, data });
+      });
+    });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(new Error('gitea request timed out')); });
+    req.end();
+  });
+}
+
+async function findMergedPr({ repo, branch, token }) {
+  const res = await giteaGet(
+    `/repos/${ORG}/${repo}/pulls?state=closed&head=${encodeURIComponent(`${ORG}:${branch}`)}&limit=5`,
+    token,
+  );
+  if (res.status !== 200 || !Array.isArray(res.data)) return null;
+  for (const pr of res.data) {
+    if (pr.merged === true && pr.merged_at && pr.merge_commit_sha) {
+      return {
+        prNumber: pr.number,
+        mergedAt: pr.merged_at,
+        commitSha: pr.merge_commit_sha,
+      };
+    }
+  }
+  return null;
+}
+
+async function detectLandedOutputs({ pipelineType, book, startChapter, endChapter, token }) {
+  const branch = buildStagingBranch(book, startChapter, endChapter);
+  const expected = getExpectedOutputs(pipelineType, book);
+  const results = await Promise.all(expected.map(async (e) => {
+    const repoShortName = e.repo.split('/').pop();
+    const pr = await findMergedPr({ repo: repoShortName, branch, token });
+    if (!pr) return null;
+    return { ...e, prNumber: pr.prNumber, mergedAt: pr.mergedAt, commitSha: pr.commitSha };
+  }));
+  const landed = results.filter(Boolean);
+  if (landed.length === 0) return null;
+  return landed;
+}
+
+module.exports = {
+  REPO_MAP,
+  PIPELINE_OUTPUT_TYPES,
+  getExpectedOutputs,
+  buildStagingBranch,
+  detectLandedOutputs,
+  fileFor,
+};

--- a/src/api/pipeline.js
+++ b/src/api/pipeline.js
@@ -1,0 +1,330 @@
+// pipeline.js — public HTTP endpoints that drive the chapter-scale Zulip
+// pipelines (`generate`, `write notes`, `write tqs`) from outside the bot.
+// See: /home/ubuntu/bp-bot/pipeline-api-contract.md for the client-facing
+// contract this implements.
+//
+// Pattern mirrors src/api/tn-quick.js: same bearer auth, same body cap +
+// rate limit + CORS strategy. Pipelines themselves run unchanged via the
+// existing firePipeline → runPipeline path.
+
+const crypto = require('crypto');
+const { z } = require('zod');
+const { readSecret } = require('../secrets');
+const { getCheckpoint } = require('../pipeline-checkpoints');
+const { triggerPipelineFromApi, buildApiJobId, API_PIPELINE_ROUTE_NAMES } = require('../router');
+const { BOOK_NUMBERS } = require('../api-runner/verse-data');
+const {
+  getExpectedOutputs,
+  detectLandedOutputs,
+} = require('./pipeline-output');
+
+const MAX_BODY_BYTES = 4 * 1024;          // start payloads are tiny
+const RATE_LIMIT_RPM = 60;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+const PIPELINE_TYPES = Object.keys(API_PIPELINE_ROUTE_NAMES);
+
+const StartBodySchema = z.object({
+  pipelineType: z.enum(PIPELINE_TYPES),
+  book: z.string().regex(/^[A-Za-z0-9]{3}$/),
+  startChapter: z.number().int().min(1).max(150),
+  endChapter: z.number().int().min(1).max(150).optional(),
+  verseStart: z.number().int().min(1).max(200).nullable().optional(),
+  verseEnd: z.number().int().min(1).max(200).nullable().optional(),
+  username: z.string().min(1).max(80).regex(/^[A-Za-z0-9._-]+$/),
+  sessionKey: z.string().min(1).max(120).regex(/^[A-Za-z0-9_\-./]+$/)
+    .refine((v) => !/__/.test(v), { message: 'sessionKey must not contain "__"' })
+    .refine((v) => !v.replace(/[^a-zA-Z0-9_]/g, '_').includes('__'), { message: 'sessionKey collapses to "__" after sanitization' }),
+  options: z.object({
+    model: z.enum(['sonnet', 'opus']).optional(),
+  }).optional(),
+});
+
+const rateLimits = new Map();
+
+function checkRateLimit(token) {
+  const key = crypto.createHash('sha256').update(token).digest('hex');
+  const now = Date.now();
+  const cur = rateLimits.get(key);
+  if (!cur || now - cur.windowStartMs >= RATE_LIMIT_WINDOW_MS) {
+    rateLimits.set(key, { count: 1, windowStartMs: now });
+    return true;
+  }
+  cur.count++;
+  return cur.count <= RATE_LIMIT_RPM;
+}
+
+function readBody(req, maxBytes) {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    let exceeded = false;
+    const chunks = [];
+    req.on('data', (c) => {
+      if (exceeded) return;
+      size += c.length;
+      if (size > maxBytes) {
+        exceeded = true;
+        const err = new Error('body too large');
+        err.code = 'BODY_TOO_LARGE';
+        reject(err);
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on('end', () => {
+      if (!exceeded) resolve(Buffer.concat(chunks).toString('utf8'));
+    });
+    req.on('error', (e) => { if (!exceeded) reject(e); });
+  });
+}
+
+function reply(res, status, body, extraHeaders) {
+  const headers = { 'Content-Type': 'application/json', ...(extraHeaders || {}) };
+  res.writeHead(status, headers);
+  res.end(JSON.stringify(body));
+}
+
+function applyCors(req, res) {
+  const raw = process.env.BT_API_CORS_ORIGINS || process.env.TN_QUICK_CORS_ORIGINS || '';
+  const allowed = raw.split(',').map((s) => s.trim()).filter(Boolean);
+  if (!allowed.length) return;
+  const origin = req.headers.origin || '';
+  if (allowed.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+  } else {
+    res.removeHeader('Access-Control-Allow-Origin');
+  }
+}
+
+function checkAuth(req, res) {
+  const token = readSecret('bt_api_token', 'BT_API_TOKEN');
+  if (!token) {
+    reply(res, 503, { error: 'pipeline_api_disabled', message: 'BT_API_TOKEN not configured on server' });
+    return null;
+  }
+  const auth = req.headers.authorization || '';
+  if (auth !== `Bearer ${token}`) {
+    reply(res, 401, { error: 'unauthorized' });
+    return null;
+  }
+  if (!checkRateLimit(token)) {
+    reply(res, 429, { error: 'rate_limited' }, { 'Retry-After': '30' });
+    return null;
+  }
+  return token;
+}
+
+// jobId format: `${safe(sessionKey)}__${safe(pipelineType)}__${BOOK_S_E_VS_VE}`
+// where safe() replaces non-[A-Za-z0-9_] with _. Reversible because we
+// validate user-supplied sessionKey to never collapse to `__`.
+function parseJobId(jobId) {
+  if (typeof jobId !== 'string') return null;
+  const parts = jobId.split('__');
+  if (parts.length !== 3) return null;
+  const [sessionKey, pipelineType, scopeId] = parts;
+  if (!PIPELINE_TYPES.includes(pipelineType)) return null;
+  const scopeParts = scopeId.split('_');
+  if (scopeParts.length !== 5) return null;
+  const [book, startStr, endStr, vsStr, veStr] = scopeParts;
+  const startChapter = Number(startStr);
+  const endChapter = Number(endStr);
+  if (!Number.isInteger(startChapter) || !Number.isInteger(endChapter)) return null;
+  const verseStart = vsStr === 'na' ? null : Number(vsStr);
+  const verseEnd = veStr === 'na' ? null : Number(veStr);
+  return {
+    sessionKey,
+    pipelineType,
+    scope: { book, startChapter, endChapter, verseStart, verseEnd },
+  };
+}
+
+function serializeCheckpoint(jobId, cp) {
+  const out = {
+    jobId,
+    pipelineType: cp.pipelineType,
+    scope: cp.scope,
+    state: cp.state,
+    updatedAt: cp.updatedAt,
+    createdAt: cp.createdAt,
+    interrupted: false,
+  };
+  if (cp.current) {
+    out.current = {
+      chapter: cp.current.chapter,
+      skill: cp.current.skill,
+      status: cp.current.status,
+      ...(cp.current.startedAt ? { startedAt: cp.current.startedAt } : {}),
+      ...(cp.current.errorKind ? { errorKind: cp.current.errorKind } : {}),
+      ...(cp.current.error ? { error: cp.current.error } : {}),
+    };
+  }
+  const updatedMs = Date.parse(cp.updatedAt || '');
+  if (Number.isFinite(updatedMs) && cp.state === 'running') {
+    // Mirror /health/pipelines' heuristic: a 'running' checkpoint untouched
+    // for more than 12h is almost certainly orphaned by a bot restart.
+    out.interrupted = (Date.now() - updatedMs) > (12 * 60 * 60 * 1000);
+  }
+  return out;
+}
+
+async function handleStartRequest(req, res) {
+  const startedAt = Date.now();
+  try {
+    applyCors(req, res);
+
+    if (!checkAuth(req, res)) return;
+
+    let raw;
+    try {
+      raw = await readBody(req, MAX_BODY_BYTES);
+    } catch (err) {
+      if (err.code === 'BODY_TOO_LARGE') {
+        reply(res, 413, { error: 'body_too_large', maxBytes: MAX_BODY_BYTES });
+        return;
+      }
+      throw err;
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      reply(res, 400, { error: 'invalid_json' });
+      return;
+    }
+
+    const result = StartBodySchema.safeParse(parsed);
+    if (!result.success) {
+      reply(res, 400, { error: 'validation_failed', issues: result.error.issues });
+      return;
+    }
+    const body = result.data;
+    const book = body.book.toUpperCase();
+    if (!BOOK_NUMBERS[book]) {
+      reply(res, 400, { error: 'unknown_book', book: body.book });
+      return;
+    }
+
+    const startChapter = body.startChapter;
+    const endChapter = body.endChapter ?? body.startChapter;
+    if (endChapter < startChapter) {
+      reply(res, 400, { error: 'validation_failed', message: 'endChapter < startChapter' });
+      return;
+    }
+    if (body.verseStart != null && body.verseEnd != null && body.verseEnd < body.verseStart) {
+      reply(res, 400, { error: 'validation_failed', message: 'verseEnd < verseStart' });
+      return;
+    }
+
+    const trigger = triggerPipelineFromApi({
+      pipelineType: body.pipelineType,
+      book,
+      startChapter,
+      endChapter,
+      verseStart: body.verseStart ?? null,
+      verseEnd: body.verseEnd ?? null,
+      username: body.username,
+      apiSessionKey: body.sessionKey,
+    });
+
+    const lat = Date.now() - startedAt;
+    if (trigger.status === 'conflict') {
+      reply(res, 409, {
+        error: 'conflict',
+        jobId: trigger.jobId,
+        message: trigger.message || 'another run owns this scope',
+      });
+      console.log(`[pipeline-api] start ${body.pipelineType} ${book} ${startChapter}-${endChapter} → 409 conflict lat=${lat}ms`);
+      return;
+    }
+    if (trigger.status === 'invalid') {
+      reply(res, 400, { error: 'validation_failed', message: trigger.message });
+      return;
+    }
+
+    reply(res, trigger.status === 'already_running' ? 200 : 202, {
+      jobId: trigger.jobId,
+      scope: trigger.scope,
+      status: trigger.status,
+    });
+    console.log(`[pipeline-api] start ${body.pipelineType} ${book} ${startChapter}-${endChapter} → ${trigger.status} jobId=${trigger.jobId} user=${body.username} lat=${lat}ms`);
+  } catch (err) {
+    console.error(`[pipeline-api] start unhandled: ${err.stack || err.message}`);
+    if (!res.headersSent) {
+      reply(res, 500, { error: 'internal_error' });
+    }
+  }
+}
+
+async function handleStatusRequest(req, res, jobId) {
+  try {
+    applyCors(req, res);
+
+    if (!checkAuth(req, res)) return;
+
+    const parsed = parseJobId(jobId);
+    if (!parsed) {
+      reply(res, 400, { error: 'malformed_job_id', jobId });
+      return;
+    }
+
+    const cp = getCheckpoint({
+      sessionKey: parsed.sessionKey,
+      pipelineType: parsed.pipelineType,
+      scope: parsed.scope,
+    });
+
+    if (cp) {
+      reply(res, 200, serializeCheckpoint(jobId, cp));
+      return;
+    }
+
+    // No checkpoint → either never started, or completed and self-cleared.
+    // Probe Door43 for the expected output(s).
+    let landed = null;
+    try {
+      const token = readSecret('door43_token', 'DOOR43_TOKEN') || readSecret('gitea_token', 'GITEA_TOKEN');
+      landed = await detectLandedOutputs({
+        pipelineType: parsed.pipelineType,
+        book: parsed.scope.book,
+        startChapter: parsed.scope.startChapter,
+        endChapter: parsed.scope.endChapter,
+        token,
+      });
+    } catch (err) {
+      console.warn(`[pipeline-api] door43 probe failed: ${err.message}`);
+    }
+
+    if (landed && landed.length > 0) {
+      const expected = getExpectedOutputs(parsed.pipelineType, parsed.scope.book);
+      reply(res, 200, {
+        jobId,
+        pipelineType: parsed.pipelineType,
+        scope: parsed.scope,
+        state: 'done',
+        interrupted: false,
+        output: landed,
+        // Expected count vs found count helps callers spot partial-merge edge cases (e.g. ULT merged, UST still open).
+        expectedOutputCount: expected.length,
+      });
+      return;
+    }
+
+    reply(res, 404, { error: 'not_found', jobId });
+  } catch (err) {
+    console.error(`[pipeline-api] status unhandled: ${err.stack || err.message}`);
+    if (!res.headersSent) {
+      reply(res, 500, { error: 'internal_error' });
+    }
+  }
+}
+
+module.exports = {
+  handleStartRequest,
+  handleStatusRequest,
+  // exposed for testing
+  parseJobId,
+  StartBodySchema,
+  buildApiJobId,
+};

--- a/src/door43-push.js
+++ b/src/door43-push.js
@@ -876,7 +876,8 @@ async function door43Push(opts) {
     }
 
     // Step 4: Commit and push
-    const commitMsg = `${type.toUpperCase()}: ${book} ${chapter} [${username}]`;
+    const pipelineForTrailer = type === 'tn' ? 'notes' : type === 'tq' ? 'tqs' : 'generate';
+    const commitMsg = `${type.toUpperCase()}: ${book} ${chapter} [${username}]\n\nX-AI-Pipeline: bp-assistant/${pipelineForTrailer}`;
     const pushResult = await commitAndPush(repoDir, branch, repoFilename, commitMsg, { force: !!branchOnly });
 
     if (pushResult.noChanges) {

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -13,6 +13,7 @@ const { readSecret } = require('./secrets');
 const { readAdminStatus } = require('./admin-status');
 const { listCheckpoints } = require('./pipeline-checkpoints');
 const { handleTnQuickRequest } = require('./api/tn-quick');
+const { handleStartRequest, handleStatusRequest } = require('./api/pipeline');
 const { loadCache: loadVerseDataCache } = require('./api-runner/verse-data');
 
 const ADMIN_PORT = Number(process.env.PORT || 8080);
@@ -710,6 +711,22 @@ function createHttpServer() {
 
     if (req.method === 'POST' && urlPath === '/api/tn-quick') {
       await handleTnQuickRequest(req, res);
+      return;
+    }
+
+    if (req.method === 'POST' && urlPath === '/api/pipeline/start') {
+      await handleStartRequest(req, res);
+      return;
+    }
+
+    if (req.method === 'GET' && urlPath.startsWith('/api/pipeline/')) {
+      const jobId = decodeURIComponent(urlPath.slice('/api/pipeline/'.length));
+      if (!jobId) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'missing_job_id' }));
+        return;
+      }
+      await handleStatusRequest(req, res, jobId);
       return;
     }
 

--- a/src/router.js
+++ b/src/router.js
@@ -6,7 +6,7 @@ const { getTotalVerses, getChapterCount } = require('./verse-counts');
 const { classifyIntent } = require('./intent-classifier');
 const { preflightCheck, estimateTokens } = require('./usage-tracker');
 const { getPendingMerge, clearPendingMerge, getAllPendingMerges } = require('./pending-merges');
-const { getCheckpoint, setCheckpoint, clearCheckpoint } = require('./pipeline-checkpoints');
+const { getCheckpoint, setCheckpoint, clearCheckpoint, buildCheckpointKey } = require('./pipeline-checkpoints');
 const { listCheckpoints } = require('./pipeline-checkpoints');
 const { resumeInsertion } = require('./insertion-resume');
 const { normalizeBookName, isValidBook } = require('./pipeline-utils');
@@ -1318,6 +1318,154 @@ function hasActiveSession(channel, topic, senderId) {
   return hasActiveStreamSession(channel, topic, senderId);
 }
 
+// ---------------------------------------------------------------------------
+// triggerPipelineFromApi — HTTP-initiated pipeline launch
+//
+// Mirrors firePipeline's responsibilities (dedup, activePipelines bookkeeping,
+// fire-and-forget runPipeline) but takes structured input and returns a
+// structured result instead of sending Zulip messages on conflict. Used by
+// the public `/api/pipeline/start` endpoint.
+// ---------------------------------------------------------------------------
+
+const API_PIPELINE_ROUTE_NAMES = {
+  generate: 'generate-content',
+  notes: 'write-notes',
+  tqs: 'write-tqs',
+};
+
+function getApiStream() {
+  return process.env.BT_API_ZULIP_STREAM || 'bp-api';
+}
+
+function buildApiSyntheticRoute(pipelineType, scope) {
+  const routeName = API_PIPELINE_ROUTE_NAMES[pipelineType];
+  if (!routeName) return null;
+  const baseRoute = config.routes.find((r) => r.name === routeName);
+  if (!baseRoute) return null;
+
+  const { book, startChapter, endChapter, verseStart, verseEnd } = scope;
+  const rangeLabel = verseStart != null && verseEnd != null && startChapter === endChapter
+    ? `${book} ${startChapter}:${verseStart}-${verseEnd}`
+    : startChapter === endChapter
+      ? `${book} ${startChapter}`
+      : `${book} ${startChapter}-${endChapter}`;
+
+  return {
+    ...baseRoute,
+    _synthetic: true,
+    _book: book,
+    _startChapter: startChapter,
+    _endChapter: endChapter,
+    _verseStart: verseStart ?? null,
+    _verseEnd: verseEnd ?? null,
+    _scopeText: rangeLabel.replace(/^\S+\s+/, ''),
+    _apiOrigin: true,
+    confirmMessage: null,
+  };
+}
+
+function buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username }) {
+  const { book, startChapter, endChapter } = scope;
+  const chapterPart = startChapter === endChapter ? String(startChapter) : `${startChapter}-${endChapter}`;
+  const commandWord = pipelineType === 'generate' ? 'generate'
+    : pipelineType === 'notes' ? 'write notes'
+    : 'write tqs';
+  return {
+    type: 'stream',
+    display_recipient: getApiStream(),
+    subject: apiSessionKey,
+    sender_id: -1,
+    sender_full_name: username,
+    sender_email: `${username}@api.bp-assistant`,
+    content: `${commandWord} ${book} ${chapterPart}`,
+    _apiOrigin: true,
+  };
+}
+
+function buildApiJobId({ apiSessionKey, pipelineType, scope }) {
+  const derivedSessionKey = `stream-${getApiStream()}-${apiSessionKey}`;
+  return buildCheckpointKey({ sessionKey: derivedSessionKey, pipelineType, scope });
+}
+
+/**
+ * Launch a pipeline from an HTTP/API caller.
+ *
+ * @param {object} input
+ * @param {'generate'|'notes'|'tqs'} input.pipelineType
+ * @param {string} input.book - 3-letter USFM code (already uppercased)
+ * @param {number} input.startChapter
+ * @param {number} input.endChapter
+ * @param {number|null} [input.verseStart]
+ * @param {number|null} [input.verseEnd]
+ * @param {string} input.username - DCS handle for commit attribution
+ * @param {string} input.apiSessionKey - caller-supplied; idempotency + scoping
+ * @returns {{ status: 'running'|'already_running'|'conflict'|'invalid', jobId?, scope?, conflictingJobId?, message? }}
+ */
+function triggerPipelineFromApi(input) {
+  const {
+    pipelineType,
+    book,
+    startChapter,
+    endChapter,
+    verseStart = null,
+    verseEnd = null,
+    username,
+    apiSessionKey,
+  } = input;
+
+  const scope = { book, startChapter, endChapter, verseStart, verseEnd };
+  const route = buildApiSyntheticRoute(pipelineType, scope);
+  if (!route) {
+    return { status: 'invalid', message: `Unknown pipelineType: ${pipelineType}` };
+  }
+  const message = buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username });
+  const derivedSessionKey = `stream-${getApiStream()}-${apiSessionKey}`;
+  const jobId = buildCheckpointKey({ sessionKey: derivedSessionKey, pipelineType, scope });
+
+  // Conflict check 1: same (sessionKey, pipelineType, scope) already running?
+  const activeCp = getActiveCheckpoint(route, derivedSessionKey, []);
+  if (activeCp && !isStaleRunningCheckpoint(activeCp) && activeCp.state === 'running') {
+    return { status: 'already_running', jobId, scope };
+  }
+  // Stale running → flip to failed so it becomes resumable (mirrors firePipeline).
+  if (isStaleRunningCheckpoint(activeCp)) {
+    setCheckpoint({
+      sessionKey: activeCp.sessionKey,
+      pipelineType: activeCp.pipelineType,
+      scope: activeCp.scope,
+    }, { state: 'failed', current: { ...activeCp.current, status: 'failed', errorKind: 'interrupted' } });
+  }
+
+  // Conflict check 2: another caller is running the same (book, chapter) under a different sessionKey?
+  const keys = getPipelineKeys(route, message);
+  if (keys) {
+    const conflicts = keys.filter((k) => activePipelines.has(k));
+    if (conflicts.length > 0) {
+      return {
+        status: 'conflict',
+        jobId,
+        scope,
+        message: `Another run holds ${conflicts[0]}`,
+      };
+    }
+    for (const k of keys) activePipelines.add(k);
+  }
+
+  // Fire and forget.
+  runPipeline(route, message)
+    .catch(async (err) => {
+      console.error(`[router/api] Pipeline "${route.name}" failed: ${err.message}`);
+      await publishRouterFailure(route, message, err);
+    })
+    .finally(() => {
+      if (keys) {
+        for (const k of keys) activePipelines.delete(k);
+      }
+    });
+
+  return { status: 'running', jobId, scope };
+}
+
 module.exports = {
   routeMessage,
   hasPendingAction,
@@ -1327,4 +1475,7 @@ module.exports = {
   buildWriteTqsConfirmText,
   buildSyntheticRoute,
   parseIntentScope,
+  triggerPipelineFromApi,
+  buildApiJobId,
+  API_PIPELINE_ROUTE_NAMES,
 };

--- a/src/router.js
+++ b/src/router.js
@@ -1371,6 +1371,7 @@ function buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username
     : pipelineType === 'notes' ? 'write notes'
     : 'write tqs';
   return {
+    id: -1,
     type: 'stream',
     display_recipient: getApiStream(),
     subject: apiSessionKey,

--- a/src/zulip-client.js
+++ b/src/zulip-client.js
@@ -22,7 +22,24 @@ async function getClient() {
   return client;
 }
 
+// Stream name used by triggerPipelineFromApi as a synthetic display_recipient.
+// Pipelines for API-triggered runs surface their status via publishAdminStatus
+// to the existing /admin page; we suppress duplicate Zulip writes here so the
+// bot doesn't spam errors trying to post to a stream that doesn't exist.
+// Override via BT_API_SUPPRESS_STREAM (set to '' to disable suppression and
+// route API-run status to a real Zulip stream named in BT_API_ZULIP_STREAM).
+const API_SUPPRESS_STREAM = process.env.BT_API_SUPPRESS_STREAM ?? 'bp-api';
+
+function isApiSuppressedSender(userId) {
+  // Synthetic API messages set sender_id to -1; DMs back to that id would be no-ops.
+  return userId === -1 || userId === '-1';
+}
+
 async function sendMessage(stream, topic, content) {
+  if (API_SUPPRESS_STREAM && stream === API_SUPPRESS_STREAM) {
+    console.log(`[zulip-api-suppress] ${stream}/${topic}: ${String(content).slice(0, 200)}`);
+    return { result: 'success', id: -1, suppressed: true };
+  }
   const z = await getClient();
   return z.messages.send({
     type: 'stream',
@@ -33,6 +50,10 @@ async function sendMessage(stream, topic, content) {
 }
 
 async function sendDM(userId, content) {
+  if (isApiSuppressedSender(userId)) {
+    console.log(`[zulip-api-suppress] DM to ${userId}: ${String(content).slice(0, 200)}`);
+    return { result: 'success', id: -1, suppressed: true };
+  }
   const z = await getClient();
   return z.messages.send({
     type: 'direct',
@@ -48,6 +69,9 @@ async function getStreamId(streamName) {
 }
 
 async function addReaction(messageId, emojiName) {
+  if (messageId === -1 || messageId === '-1' || messageId == null) {
+    return { result: 'success', suppressed: true };
+  }
   const z = await getClient();
   return z.callEndpoint(`/messages/${messageId}/reactions`, 'POST', {
     emoji_name: emojiName,
@@ -55,6 +79,9 @@ async function addReaction(messageId, emojiName) {
 }
 
 async function removeReaction(messageId, emojiName) {
+  if (messageId === -1 || messageId === '-1' || messageId == null) {
+    return { result: 'success', suppressed: true };
+  }
   const z = await getClient();
   return z.callEndpoint(`/messages/${messageId}/reactions`, 'DELETE', {
     emoji_name: emojiName,

--- a/test/pipeline-api.test.js
+++ b/test/pipeline-api.test.js
@@ -1,0 +1,190 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  parseJobId,
+  StartBodySchema,
+  buildApiJobId,
+} = require('../src/api/pipeline');
+const {
+  getExpectedOutputs,
+  buildStagingBranch,
+  PIPELINE_OUTPUT_TYPES,
+  REPO_MAP,
+} = require('../src/api/pipeline-output');
+
+// ---------------------------------------------------------------------------
+// jobId round-trip
+// ---------------------------------------------------------------------------
+
+test('buildApiJobId / parseJobId — round-trip for single chapter', () => {
+  const apiSessionKey = 'bible-editor-123-abc';
+  const scope = { book: 'PSA', startChapter: 1, endChapter: 1, verseStart: null, verseEnd: null };
+  const jobId = buildApiJobId({ apiSessionKey, pipelineType: 'notes', scope });
+
+  const parsed = parseJobId(jobId);
+  assert.ok(parsed, 'parseJobId returned null');
+  assert.equal(parsed.pipelineType, 'notes');
+  assert.deepEqual(parsed.scope, scope);
+  // sessionKey is the derived "stream-bp-api-<key>" form, sanitized.
+  assert.match(parsed.sessionKey, /bp_api/);
+});
+
+test('parseJobId — round-trip with chapter range', () => {
+  const apiSessionKey = 'editor-uuid-deadbeef';
+  const scope = { book: 'GEN', startChapter: 1, endChapter: 5, verseStart: null, verseEnd: null };
+  const jobId = buildApiJobId({ apiSessionKey, pipelineType: 'generate', scope });
+  const parsed = parseJobId(jobId);
+  assert.deepEqual(parsed.scope, scope);
+  assert.equal(parsed.pipelineType, 'generate');
+});
+
+test('parseJobId — round-trip with verse range', () => {
+  const apiSessionKey = 'verse-range-test';
+  const scope = { book: 'PSA', startChapter: 23, endChapter: 23, verseStart: 1, verseEnd: 6 };
+  const jobId = buildApiJobId({ apiSessionKey, pipelineType: 'tqs', scope });
+  const parsed = parseJobId(jobId);
+  assert.deepEqual(parsed.scope, scope);
+  assert.equal(parsed.pipelineType, 'tqs');
+});
+
+test('parseJobId — rejects malformed inputs', () => {
+  assert.equal(parseJobId(''), null);
+  assert.equal(parseJobId('not-a-job-id'), null);
+  assert.equal(parseJobId('only__two'), null);
+  assert.equal(parseJobId('a__b__c__d'), null);
+  assert.equal(parseJobId('foo__notes__PSA_1_1_na'), null);              // scope only 4 parts
+  assert.equal(parseJobId('foo__unknown_type__PSA_1_1_na_na'), null);   // bad pipelineType
+  assert.equal(parseJobId('foo__notes__PSA_x_1_na_na'), null);          // non-numeric chapter
+  assert.equal(parseJobId(null), null);
+  assert.equal(parseJobId(undefined), null);
+});
+
+// ---------------------------------------------------------------------------
+// StartBodySchema
+// ---------------------------------------------------------------------------
+
+test('StartBodySchema — accepts a minimal valid payload', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes',
+    book: 'PSA',
+    startChapter: 1,
+    username: 'stephen-wunrow',
+    sessionKey: 'bible-editor/abc/123',
+  });
+  assert.equal(r.success, true);
+});
+
+test('StartBodySchema — rejects sessionKey containing "__"', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes',
+    book: 'PSA',
+    startChapter: 1,
+    username: 'stephen-wunrow',
+    sessionKey: 'evil__separator',
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — rejects sessionKey that collapses to "__" via sanitization', () => {
+  // Two consecutive non-alphanumeric chars (e.g. `//`) sanitize to `__`,
+  // which would corrupt jobId parsing. Must reject.
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes',
+    book: 'PSA',
+    startChapter: 1,
+    username: 'stephen-wunrow',
+    sessionKey: 'a//b',
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — rejects bad book code, bad pipelineType, missing username', () => {
+  const r1 = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'PSALM', startChapter: 1, username: 'u', sessionKey: 'k',
+  });
+  assert.equal(r1.success, false);
+  const r2 = StartBodySchema.safeParse({
+    pipelineType: 'unknown', book: 'PSA', startChapter: 1, username: 'u', sessionKey: 'k',
+  });
+  assert.equal(r2.success, false);
+  const r3 = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'PSA', startChapter: 1, sessionKey: 'k',
+  });
+  assert.equal(r3.success, false);
+});
+
+test('StartBodySchema — accepts options.model', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'generate', book: 'PSA', startChapter: 1, endChapter: 2,
+    username: 'u', sessionKey: 'k', options: { model: 'opus' },
+  });
+  assert.equal(r.success, true);
+});
+
+// ---------------------------------------------------------------------------
+// getExpectedOutputs
+// ---------------------------------------------------------------------------
+
+test('getExpectedOutputs — generate produces ULT + UST refs', () => {
+  const out = getExpectedOutputs('generate', 'PSA');
+  assert.equal(out.length, 2);
+  const types = out.map((o) => o.type).sort();
+  assert.deepEqual(types, ['ult', 'ust']);
+  const ult = out.find((o) => o.type === 'ult');
+  assert.equal(ult.repo, 'unfoldingWord/en_ult');
+  assert.equal(ult.branch, 'master');
+  assert.equal(ult.path, '19-PSA.usfm');
+  assert.equal(ult.rawUrl, 'https://git.door43.org/unfoldingWord/en_ult/raw/branch/master/19-PSA.usfm');
+});
+
+test('getExpectedOutputs — notes produces one tn ref with whole-book TSV', () => {
+  const out = getExpectedOutputs('notes', 'GEN');
+  assert.equal(out.length, 1);
+  assert.equal(out[0].type, 'tn');
+  assert.equal(out[0].repo, 'unfoldingWord/en_tn');
+  assert.equal(out[0].path, 'tn_GEN.tsv');
+  assert.equal(out[0].rawUrl, 'https://git.door43.org/unfoldingWord/en_tn/raw/branch/master/tn_GEN.tsv');
+});
+
+test('getExpectedOutputs — tqs produces one tq ref', () => {
+  const out = getExpectedOutputs('tqs', 'HAB');
+  assert.equal(out.length, 1);
+  assert.equal(out[0].path, 'tq_HAB.tsv');
+});
+
+test('getExpectedOutputs — rejects unknown pipelineType', () => {
+  assert.throws(() => getExpectedOutputs('mystery', 'PSA'));
+});
+
+test('getExpectedOutputs — rejects unknown book in generate (book number lookup)', () => {
+  assert.throws(() => getExpectedOutputs('generate', 'XYZ'));
+});
+
+// ---------------------------------------------------------------------------
+// buildStagingBranch — must match pipeline-utils' buildBranchName
+// ---------------------------------------------------------------------------
+
+test('buildStagingBranch — PSA uses 3-digit padding', () => {
+  assert.equal(buildStagingBranch('PSA', 30, 30), 'AI-PSA-030');
+  assert.equal(buildStagingBranch('PSA', 1, 1), 'AI-PSA-001');
+  assert.equal(buildStagingBranch('PSA', 1, 5), 'AI-PSA-001-005');
+});
+
+test('buildStagingBranch — non-PSA books use 2-digit padding', () => {
+  assert.equal(buildStagingBranch('GEN', 1, 1), 'AI-GEN-01');
+  assert.equal(buildStagingBranch('ISA', 33, 33), 'AI-ISA-33');
+  assert.equal(buildStagingBranch('ISA', 33, 34), 'AI-ISA-33-34');
+});
+
+// ---------------------------------------------------------------------------
+// Sanity — constants line up
+// ---------------------------------------------------------------------------
+
+test('PIPELINE_OUTPUT_TYPES — all referenced types exist in REPO_MAP', () => {
+  for (const [, types] of Object.entries(PIPELINE_OUTPUT_TYPES)) {
+    for (const t of types) {
+      assert.ok(REPO_MAP[t], `REPO_MAP missing entry for ${t}`);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Adds `POST /api/pipeline/start` and `GET /api/pipeline/{jobId}` on the admin server (`:8080`) for the bible-editor integration. v1 scope per agreement: trigger + poll + status surface only.
- Reuses the existing `BT_API_TOKEN` and the tn-quick HTTP scaffolding pattern; pipelines run unchanged via the existing `firePipeline → runPipeline` path.
- Adds an `X-AI-Pipeline: bp-assistant/<type>` commit trailer in `door43-push.js` for stronger provenance on AI commits.

## Test plan
- [x] `node --test test/pipeline-api.test.js` — 17/17 pass (jobId round-trip, zod validation, output URL derivation, staging-branch parity)
- [x] Full suite (`npm test`) — 217/219 pass; the 2 failures are pre-existing on `main` (`fillOrigQuotes` in `tn-tools.test.js`), unrelated to this PR
- [ ] Smoke test in production after merge:
  - `curl -X POST https://uw-bt-bot.fly.dev/api/pipeline/start -H "Authorization: Bearer $BT_API_TOKEN" -d '{"pipelineType":"tqs","book":"PSA","startChapter":1,"endChapter":1,"username":"benjamin-test","sessionKey":"smoke-test-1"}'`
  - Poll `GET /api/pipeline/<jobId>` until `state: done`
  - Verify the `output[].rawUrl` points to the merged TSV on Door43

## Notes for the bot maintainer
- No new secrets required. Auth reuses `BT_API_TOKEN`.
- To suppress Zulip noise from API-triggered runs, optionally create a Zulip stream named `bp-api` (or set `BT_API_ZULIP_STREAM` to an existing stream). Pipelines run regardless.
- Client contract: `~/bp-bot/pipeline-api-contract.md` (in the workspace, not in this repo).

Generated with [Claude Code](https://claude.com/claude-code)