### PR TITLE
Extend /api/pipeline/start with per-pipeline option flags

### DIFF
--- a/src/api/pipeline.js
+++ b/src/api/pipeline.js
@@ -24,6 +24,28 @@ const RATE_LIMIT_WINDOW_MS = 60_000;
 
 const PIPELINE_TYPES = Object.keys(API_PIPELINE_ROUTE_NAMES);
 
+const OptionsSchema = z.object({
+  // Common — currently a no-op on the wire (model is fixed per pipeline today),
+  // but accepted for forward compatibility with the contract doc.
+  model: z.enum(['sonnet', 'opus']).optional(),
+  // Common — re-run after a previous failed/paused run, clears checkpoint & prior outputs.
+  fresh: z.boolean().optional(),
+  // generate-only:
+  // Restrict to a subset of content types. Default is both. Single-element array
+  // routes to a per-type skill (ULT-gen / UST-gen) inside the pipeline.
+  contentTypes: z.array(z.enum(['ult', 'ust'])).min(1).max(2).optional(),
+  // Skip alignment + repo-insert. Mutually exclusive with alignOnly and textOnly.
+  noAlign: z.boolean().optional(),
+  // Reuse existing generated files; only align + repo-insert. Mutually exclusive
+  // with noAlign and textOnly.
+  alignOnly: z.boolean().optional(),
+  // Push unaligned USFM files (no alignment). Mutually exclusive with noAlign and alignOnly.
+  textOnly: z.boolean().optional(),
+  // notes-only:
+  noIntro: z.boolean().optional(),
+  pauseBeforeATs: z.boolean().optional(),
+}).strict();
+
 const StartBodySchema = z.object({
   pipelineType: z.enum(PIPELINE_TYPES),
   book: z.string().regex(/^[A-Za-z0-9]{3}$/),
@@ -35,9 +57,42 @@ const StartBodySchema = z.object({
   sessionKey: z.string().min(1).max(120).regex(/^[A-Za-z0-9_\-./]+$/)
     .refine((v) => !/__/.test(v), { message: 'sessionKey must not contain "__"' })
     .refine((v) => !v.replace(/[^a-zA-Z0-9_]/g, '_').includes('__'), { message: 'sessionKey collapses to "__" after sanitization' }),
-  options: z.object({
-    model: z.enum(['sonnet', 'opus']).optional(),
-  }).optional(),
+  options: OptionsSchema.optional(),
+}).superRefine((body, ctx) => {
+  const o = body.options || {};
+  // Mutually-exclusive align mode flags.
+  const alignFlags = ['noAlign', 'alignOnly', 'textOnly'].filter((k) => o[k]);
+  if (alignFlags.length > 1) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['options'],
+      message: `options.${alignFlags.join(' / options.')} are mutually exclusive`,
+    });
+  }
+  // generate-only flags must not appear on notes/tqs.
+  if (body.pipelineType !== 'generate') {
+    for (const k of ['contentTypes', 'noAlign', 'alignOnly', 'textOnly']) {
+      if (o[k] !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['options', k],
+          message: `options.${k} only valid for pipelineType "generate"`,
+        });
+      }
+    }
+  }
+  // notes-only flags must not appear on generate/tqs.
+  if (body.pipelineType !== 'notes') {
+    for (const k of ['noIntro', 'pauseBeforeATs']) {
+      if (o[k] !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['options', k],
+          message: `options.${k} only valid for pipelineType "notes"`,
+        });
+      }
+    }
+  }
 });
 
 const rateLimits = new Map();
@@ -226,6 +281,7 @@ async function handleStartRequest(req, res) {
       verseEnd: body.verseEnd ?? null,
       username: body.username,
       apiSessionKey: body.sessionKey,
+      options: body.options || {},
     });
 
     const lat = Date.now() - startedAt;

--- a/src/router.js
+++ b/src/router.js
@@ -1364,12 +1364,33 @@ function buildApiSyntheticRoute(pipelineType, scope) {
   };
 }
 
-function buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username }) {
+function buildApiContentFlags(pipelineType, options) {
+  const o = options || {};
+  const flags = [];
+  if (pipelineType === 'generate') {
+    if (Array.isArray(o.contentTypes) && o.contentTypes.length === 1) {
+      flags.push(o.contentTypes[0].toUpperCase()); // 'ULT' | 'UST' restricts to one
+    }
+    if (o.noAlign) flags.push('--no-align');
+    if (o.alignOnly) flags.push('--align-only');
+    if (o.textOnly) flags.push('--text-only');
+  }
+  if (pipelineType === 'notes') {
+    if (o.noIntro) flags.push('--no-intro');
+    if (o.pauseBeforeATs) flags.push('--pause-before-ats');
+  }
+  if (o.fresh) flags.push('--fresh');
+  return flags;
+}
+
+function buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username, options }) {
   const { book, startChapter, endChapter } = scope;
   const chapterPart = startChapter === endChapter ? String(startChapter) : `${startChapter}-${endChapter}`;
   const commandWord = pipelineType === 'generate' ? 'generate'
     : pipelineType === 'notes' ? 'write notes'
     : 'write tqs';
+  const flags = buildApiContentFlags(pipelineType, options);
+  const content = [commandWord, book, chapterPart, ...flags].join(' ');
   return {
     id: -1,
     type: 'stream',
@@ -1378,7 +1399,7 @@ function buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username
     sender_id: -1,
     sender_full_name: username,
     sender_email: `${username}@api.bp-assistant`,
-    content: `${commandWord} ${book} ${chapterPart}`,
+    content,
     _apiOrigin: true,
   };
 }
@@ -1400,6 +1421,7 @@ function buildApiJobId({ apiSessionKey, pipelineType, scope }) {
  * @param {number|null} [input.verseEnd]
  * @param {string} input.username - DCS handle for commit attribution
  * @param {string} input.apiSessionKey - caller-supplied; idempotency + scoping
+ * @param {object} [input.options] - per-pipeline flag toggles (contentTypes, noAlign, alignOnly, textOnly, fresh, noIntro, pauseBeforeATs)
  * @returns {{ status: 'running'|'already_running'|'conflict'|'invalid', jobId?, scope?, conflictingJobId?, message? }}
  */
 function triggerPipelineFromApi(input) {
@@ -1412,6 +1434,7 @@ function triggerPipelineFromApi(input) {
     verseEnd = null,
     username,
     apiSessionKey,
+    options = {},
   } = input;
 
   const scope = { book, startChapter, endChapter, verseStart, verseEnd };
@@ -1419,7 +1442,7 @@ function triggerPipelineFromApi(input) {
   if (!route) {
     return { status: 'invalid', message: `Unknown pipelineType: ${pipelineType}` };
   }
-  const message = buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username });
+  const message = buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username, options });
   const derivedSessionKey = `stream-${getApiStream()}-${apiSessionKey}`;
   const jobId = buildCheckpointKey({ sessionKey: derivedSessionKey, pipelineType, scope });
 
@@ -1478,5 +1501,6 @@ module.exports = {
   parseIntentScope,
   triggerPipelineFromApi,
   buildApiJobId,
+  buildApiContentFlags,
   API_PIPELINE_ROUTE_NAMES,
 };

--- a/test/pipeline-api.test.js
+++ b/test/pipeline-api.test.js
@@ -188,3 +188,117 @@ test('PIPELINE_OUTPUT_TYPES — all referenced types exist in REPO_MAP', () => {
     }
   }
 });
+
+// ---------------------------------------------------------------------------
+// Options → synthetic content flags
+// ---------------------------------------------------------------------------
+
+const { buildApiContentFlags } = require('../src/router');
+
+test('buildApiContentFlags — generate, no options → no flags', () => {
+  assert.deepEqual(buildApiContentFlags('generate', {}), []);
+  assert.deepEqual(buildApiContentFlags('generate', undefined), []);
+});
+
+test('buildApiContentFlags — generate, ULT-only contentTypes → "ULT" flag', () => {
+  assert.deepEqual(buildApiContentFlags('generate', { contentTypes: ['ult'] }), ['ULT']);
+  assert.deepEqual(buildApiContentFlags('generate', { contentTypes: ['ust'] }), ['UST']);
+});
+
+test('buildApiContentFlags — generate, both contentTypes → no restriction flag', () => {
+  assert.deepEqual(buildApiContentFlags('generate', { contentTypes: ['ult', 'ust'] }), []);
+});
+
+test('buildApiContentFlags — generate, noAlign → --no-align', () => {
+  assert.deepEqual(buildApiContentFlags('generate', { noAlign: true }), ['--no-align']);
+});
+
+test('buildApiContentFlags — generate, alignOnly → --align-only', () => {
+  assert.deepEqual(buildApiContentFlags('generate', { alignOnly: true }), ['--align-only']);
+});
+
+test('buildApiContentFlags — generate, textOnly → --text-only', () => {
+  assert.deepEqual(buildApiContentFlags('generate', { textOnly: true }), ['--text-only']);
+});
+
+test('buildApiContentFlags — generate, combined ULT + no-align + fresh', () => {
+  const f = buildApiContentFlags('generate', { contentTypes: ['ult'], noAlign: true, fresh: true });
+  assert.deepEqual(f, ['ULT', '--no-align', '--fresh']);
+});
+
+test('buildApiContentFlags — notes, noIntro + pauseBeforeATs', () => {
+  assert.deepEqual(
+    buildApiContentFlags('notes', { noIntro: true, pauseBeforeATs: true }),
+    ['--no-intro', '--pause-before-ats'],
+  );
+});
+
+test('buildApiContentFlags — notes ignores generate-only flags', () => {
+  // Schema-level validation rejects these for notes, but the builder must also
+  // be tolerant: silently drop generate-only flags rather than emit them.
+  assert.deepEqual(buildApiContentFlags('notes', { contentTypes: ['ult'], noAlign: true }), []);
+});
+
+test('buildApiContentFlags — tqs, fresh', () => {
+  assert.deepEqual(buildApiContentFlags('tqs', { fresh: true }), ['--fresh']);
+});
+
+// ---------------------------------------------------------------------------
+// StartBodySchema — option validation
+// ---------------------------------------------------------------------------
+
+test('StartBodySchema — accepts options.contentTypes for generate', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'generate', book: 'PSA', startChapter: 1,
+    username: 'u', sessionKey: 'k',
+    options: { contentTypes: ['ult'] },
+  });
+  assert.equal(r.success, true);
+});
+
+test('StartBodySchema — rejects generate-only options on notes', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'PSA', startChapter: 1,
+    username: 'u', sessionKey: 'k',
+    options: { contentTypes: ['ult'] },
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — rejects notes-only options on generate', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'generate', book: 'PSA', startChapter: 1,
+    username: 'u', sessionKey: 'k',
+    options: { noIntro: true },
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — rejects mutually-exclusive align flags', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'generate', book: 'PSA', startChapter: 1,
+    username: 'u', sessionKey: 'k',
+    options: { noAlign: true, alignOnly: true },
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — rejects unknown options keys (strict)', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'generate', book: 'PSA', startChapter: 1,
+    username: 'u', sessionKey: 'k',
+    options: { mysteryFlag: true },
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — accepts fresh on any pipeline type', () => {
+  for (const pt of ['generate', 'notes', 'tqs']) {
+    const r = StartBodySchema.safeParse({
+      pipelineType: pt, book: 'PSA', startChapter: 1,
+      username: 'u', sessionKey: 'k',
+      options: { fresh: true },
+    });
+    assert.equal(r.success, true, `${pt} should accept fresh`);
+  }
+});


### PR DESCRIPTION
## Summary
- Adds `options.*` fields to `POST /api/pipeline/start`: `fresh`, `contentTypes`, `noAlign`, `alignOnly`, `textOnly`, `noIntro`, `pauseBeforeATs`. Maps them to the existing Zulip-command flags via a synthetic content-string builder — pipeline code is unchanged.
- Schema validation rejects unknown keys (`.strict()`), pipelineType-incompatible flags, and mutually-exclusive align modes.
- Contract doc (`~/bp-bot/pipeline-api-contract.md`) updated with the new schema and an 8-row "UI intent → request body" mapping table.

## Constraint flagged
The pipeline does NOT support asymmetric alignment (ULT aligned + UST unaligned, or vice versa). bible-editor's 4-checkbox UI must collapse to one of the 8 supported combinations before sending; the doc spells them out.

## Test plan
- [x] `node --test test/pipeline-api.test.js` — 33/33 pass (16 new for option mapping + schema validation)
- [x] `npm test` — 233/235 pass; the 2 fails are the pre-existing `fillOrigQuotes` cases in `tn-tools.test.js`, present on `main` before this PR
- [ ] Smoke test after merge:
   - `curl -X POST .../api/pipeline/start ... -d '{\"pipelineType\":\"generate\",\"book\":\"PSA\",\"startChapter\":1,\"username\":\"benjamin-test\",\"sessionKey\":\"opt-smoke-1\",\"options\":{\"contentTypes\":[\"ult\"],\"noAlign\":true}}'`
   - Bot logs should show synthetic content `generate PSA 1 ULT --no-align`

🤖 Generated with [Claude Code](https://claude.com/claude-code)