### PR TITLE
Saving original GLquotes for testing with ATs

### DIFF
--- a/src/workspace-tools/tn-tools.js
+++ b/src/workspace-tools/tn-tools.js
@@ -1816,6 +1816,65 @@ function verifyBoldMatches({ tsvFile, ultUsfm, preparedJson, output }) {
   return result.join('\n');
 }
 
+
+/**
+ * Save original GLquotes for the checking against later ATs
+ * Writes a file to data/workspace/output/notes
+ * File includes ID and original GL quote (before any normalization or scope extraction)
+ */
+function writeGlquoteFiles({ items, bookCode }) {
+  const fs = require('fs');
+  const path = require('path');
+
+  const book3 = bookCode.toLowerCase();
+
+  const baseOut = path.resolve(
+    CSKILLBP_DIR,
+    'data/workspace/output/notes',
+    book3
+  );
+
+  fs.mkdirSync(baseOut, { recursive: true });
+
+  const chapterBuckets = {};
+
+  for (const item of items || []) {
+    const ref = item.reference || '';
+    const chapterMatch = ref.match(/:(\d+)/);
+    const chapter = chapterMatch ? chapterMatch[1] : 'unknown';
+
+    const quote = item.orig_quote || item.gl_quote || item.issue_span_gl_quote || '';
+
+    if (!chapterBuckets[chapter]) {
+      chapterBuckets[chapter] = [];
+    }
+
+    chapterBuckets[chapter].push({
+      id: item.id,
+      quote
+    });
+  }
+
+  for (const [chapter, rows] of Object.entries(chapterBuckets)) {
+    const filePath = path.join(
+      baseOut,
+      `glquote_${book3}-${chapter}.tsv`
+    );
+
+    const tsv = rows
+      .map(r => `${r.id}\t${r.quote}`)
+      .join('\n');
+
+    fs.writeFileSync(filePath, tsv, 'utf8');
+  }
+
+  return {
+    chaptersWritten: Object.keys(chapterBuckets).length,
+    totalRows: items.length
+  };
+}
+
+
 /**
  * Fill empty orig_quote fields in prepared_notes.json using alignment data.
  * Deterministically matches English gl_quote words to Hebrew via alignment,
@@ -2340,6 +2399,10 @@ function fillOrigQuotes({ preparedJson, alignmentJson, hebrewUsfm, masterUltUsfm
   }
 
   fs.writeFileSync(prepPath, JSON.stringify(data, null, 2));
+  writeGlquoteFiles({
+    items: data.items,
+    bookCode
+  });
 
   const hintNote = resolvedViaHint ? `, ${resolvedViaHint} via Hebrew hint` : '';
   const masterNote = resolvedViaMaster ? `, ${resolvedViaMaster} via master ULT` : '';


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
I need to save the original GL quotes from the notes before origL is filled. I'm writing them to a tsv file at data/workspace/output/notes/{book_code}

#### Please include detailed Test instructions for your pull request:
Pipeline should run as it did before. The only change should be that a tsv file is saved data/workspace/output/notes/{book_code}. The file should include the ID the GL quote.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
