### PR TITLE
Accept options.hints on /api/pipeline/start; expand via tn-writer

### DIFF
--- a/src/api/pipeline.js
+++ b/src/api/pipeline.js
@@ -24,6 +24,28 @@ const RATE_LIMIT_WINDOW_MS = 60_000;
 
 const PIPELINE_TYPES = Object.keys(API_PIPELINE_ROUTE_NAMES);
 
+const OptionsSchema = z.object({
+  // Common — currently a no-op on the wire (model is fixed per pipeline today),
+  // but accepted for forward compatibility with the contract doc.
+  model: z.enum(['sonnet', 'opus']).optional(),
+  // Common — re-run after a previous failed/paused run, clears checkpoint & prior outputs.
+  fresh: z.boolean().optional(),
+  // generate-only:
+  // Restrict to a subset of content types. Default is both. Single-element array
+  // routes to a per-type skill (ULT-gen / UST-gen) inside the pipeline.
+  contentTypes: z.array(z.enum(['ult', 'ust'])).min(1).max(2).optional(),
+  // Skip alignment + repo-insert. Mutually exclusive with alignOnly and textOnly.
+  noAlign: z.boolean().optional(),
+  // Reuse existing generated files; only align + repo-insert. Mutually exclusive
+  // with noAlign and textOnly.
+  alignOnly: z.boolean().optional(),
+  // Push unaligned USFM files (no alignment). Mutually exclusive with noAlign and alignOnly.
+  textOnly: z.boolean().optional(),
+  // notes-only:
+  noIntro: z.boolean().optional(),
+  pauseBeforeATs: z.boolean().optional(),
+}).strict();
+
 const StartBodySchema = z.object({
   pipelineType: z.enum(PIPELINE_TYPES),
   book: z.string().regex(/^[A-Za-z0-9]{3}$/),
@@ -35,9 +57,42 @@ const StartBodySchema = z.object({
   sessionKey: z.string().min(1).max(120).regex(/^[A-Za-z0-9_\-./]+$/)
     .refine((v) => !/__/.test(v), { message: 'sessionKey must not contain "__"' })
     .refine((v) => !v.replace(/[^a-zA-Z0-9_]/g, '_').includes('__'), { message: 'sessionKey collapses to "__" after sanitization' }),
-  options: z.object({
-    model: z.enum(['sonnet', 'opus']).optional(),
-  }).optional(),
+  options: OptionsSchema.optional(),
+}).superRefine((body, ctx) => {
+  const o = body.options || {};
+  // Mutually-exclusive align mode flags.
+  const alignFlags = ['noAlign', 'alignOnly', 'textOnly'].filter((k) => o[k]);
+  if (alignFlags.length > 1) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['options'],
+      message: `options.${alignFlags.join(' / options.')} are mutually exclusive`,
+    });
+  }
+  // generate-only flags must not appear on notes/tqs.
+  if (body.pipelineType !== 'generate') {
+    for (const k of ['contentTypes', 'noAlign', 'alignOnly', 'textOnly']) {
+      if (o[k] !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['options', k],
+          message: `options.${k} only valid for pipelineType "generate"`,
+        });
+      }
+    }
+  }
+  // notes-only flags must not appear on generate/tqs.
+  if (body.pipelineType !== 'notes') {
+    for (const k of ['noIntro', 'pauseBeforeATs']) {
+      if (o[k] !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['options', k],
+          message: `options.${k} only valid for pipelineType "notes"`,
+        });
+      }
+    }
+  }
 });
 
 const rateLimits = new Map();
@@ -226,6 +281,7 @@ async function handleStartRequest(req, res) {
       verseEnd: body.verseEnd ?? null,
       username: body.username,
       apiSessionKey: body.sessionKey,
+      options: body.options || {},
     });
 
     const lat = Date.now() - startedAt;

--- a/src/api/pipeline.js
+++ b/src/api/pipeline.js
@@ -18,11 +18,26 @@ const {
   detectLandedOutputs,
 } = require('./pipeline-output');
 
-const MAX_BODY_BYTES = 4 * 1024;          // start payloads are tiny
+// Bumped from 4KB to fit up to 50 hints with full prose seeds. The
+// per-field caps on HintSchema below bound the worst case well under this.
+const MAX_BODY_BYTES = 32 * 1024;
 const RATE_LIMIT_RPM = 60;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 
 const PIPELINE_TYPES = Object.keys(API_PIPELINE_ROUTE_NAMES);
+
+// Canonical TN row-id format: lowercase letter + 3 alphanumerics. Same shape
+// as INTRO_ID_RE in src/lib/insert-tn-rows.js — hint rowIds are preserved
+// verbatim as TSV column-1 IDs, so they must conform to the TSV ID grammar.
+const HINT_ROW_ID_RE = /^[a-z][a-z0-9]{3}$/;
+
+const HintSchema = z.object({
+  rowId: z.string().regex(HINT_ROW_ID_RE),
+  verse: z.number().int().min(1).max(200),
+  quote: z.string().max(500),                   // source-language; may be ''
+  supportReference: z.string().max(200).nullable(),
+  seed: z.string().max(4000).nullable(),
+}).strict();
 
 const OptionsSchema = z.object({
   // Common — currently a no-op on the wire (model is fixed per pipeline today),
@@ -44,6 +59,12 @@ const OptionsSchema = z.object({
   // notes-only:
   noIntro: z.boolean().optional(),
   pauseBeforeATs: z.boolean().optional(),
+  // Editor-marked TN row "hints" — each entry seeds one specific note the
+  // pipeline must produce, and suppresses competing notes for the same
+  // (verse, supportReference, fuzzy-quote). hint.rowId is preserved as the
+  // TSV ID column for the expanded row, so bible-editor can UPDATE the
+  // existing stub row in place by ID.
+  hints: z.array(HintSchema).max(50).optional(),
 }).strict();
 
 const StartBodySchema = z.object({
@@ -83,7 +104,7 @@ const StartBodySchema = z.object({
   }
   // notes-only flags must not appear on generate/tqs.
   if (body.pipelineType !== 'notes') {
-    for (const k of ['noIntro', 'pauseBeforeATs']) {
+    for (const k of ['noIntro', 'pauseBeforeATs', 'hints']) {
       if (o[k] !== undefined) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
@@ -91,6 +112,37 @@ const StartBodySchema = z.object({
           message: `options.${k} only valid for pipelineType "notes"`,
         });
       }
+    }
+  }
+  // hints — reject duplicate rowIds within a single request. The rowId is
+  // the stable TN row identifier and gets preserved as the TSV ID column;
+  // duplicates would produce ambiguous matches on bible-editor's apply side.
+  if (Array.isArray(o.hints) && o.hints.length > 1) {
+    const seen = new Set();
+    for (let i = 0; i < o.hints.length; i++) {
+      const id = o.hints[i] && o.hints[i].rowId;
+      if (id && seen.has(id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['options', 'hints', i, 'rowId'],
+          message: `duplicate hint rowId "${id}"`,
+        });
+      }
+      if (id) seen.add(id);
+    }
+  }
+  // hints carry verse but not chapter, so multi-chapter scopes would
+  // produce ambiguous routing (verse 7 could mean ch.7v7 or ch.8v7 …).
+  // Until bible-editor's wire-shape includes chapter-per-hint, require a
+  // single-chapter scope when hints are present.
+  if (Array.isArray(o.hints) && o.hints.length > 0) {
+    const endCh = body.endChapter ?? body.startChapter;
+    if (endCh !== body.startChapter) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['options', 'hints'],
+        message: 'options.hints requires a single-chapter scope (startChapter must equal endChapter)',
+      });
     }
   }
 });
@@ -382,5 +434,7 @@ module.exports = {
   // exposed for testing
   parseJobId,
   StartBodySchema,
+  HintSchema,
+  HINT_ROW_ID_RE,
   buildApiJobId,
 };

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -14,7 +14,7 @@ const { sendMessage, sendDM, addReaction, removeReaction } = require('./zulip-cl
 const { runClaude, DEFAULT_RESTRICTED_TOOLS, isTransientOutageError } = require('./claude-runner');
 const { getDoor43Username, emailToFallbackUsername, buildBranchName, resolveOutputFile, discoverFreshOutput, checkPrerequisites, calcSkillTimeout, normalizeBookName, resolveConflictMention, parsePartialTsv, truncatePartialTsv, parseChunkRange, CSKILLBP_DIR } = require('./pipeline-utils');
 const { splitTsv, fixTrailingNewlines } = require('./workspace-tools/tsv-tools');
-const { fillTsvIds, generateIds, prepareNotes, fillOrigQuotes, resolveGlQuotes, flagNarrowQuotes, extractAlignmentData, prepareATContext, substituteAT, fixUnicodeQuotes, verifyBoldMatches, syncCanonicalHebrewQuotes, _stripAlternateTranslation: stripAlternateTranslation } = require('./workspace-tools/tn-tools');
+const { fillTsvIds, generateIds, prepareNotes, fillOrigQuotes, resolveGlQuotes, flagNarrowQuotes, extractAlignmentData, prepareATContext, substituteAT, fixUnicodeQuotes, verifyBoldMatches, syncCanonicalHebrewQuotes, applyHintsToPreparedNotes, _stripAlternateTranslation: stripAlternateTranslation } = require('./workspace-tools/tn-tools');
 const { checkTnQuality } = require('./workspace-tools/quality-tools');
 const { normalizeIssuesFile, buildParallelismIntroHintArgs } = require('./issue-normalizer');
 const { curlyQuotes } = require('./workspace-tools/usfm-tools');
@@ -244,6 +244,9 @@ function runSeeHowDetection({ pipeDir }) {
   const bySref = {};
   for (const item of items) {
     if (!item.sref) continue;
+    // Hint-driven items carry their own framing (seed prose); skip see-how
+    // detection so we don't overwrite the seed with a programmatic back-ref.
+    if (item.fromHint) continue;
     if (!bySref[item.sref]) bySref[item.sref] = [];
     bySref[item.sref].push(item);
   }
@@ -1107,6 +1110,10 @@ function buildParsedNotesRequest(route, content) {
       withIntro: !hasNoIntroFlag(content) || hasWithIntroFlag(content),
       fresh: hasFreshFlag(content),
       pauseBeforeATs: hasPauseBeforeATsFlag(content),
+      // Editor-marked hints; only present on API-origin synthetic routes.
+      // Zulip-triggered runs fall through to parseWriteNotesCommand and
+      // never carry hints.
+      hints: Array.isArray(route._hints) && route._hints.length > 0 ? route._hints : null,
     };
   }
   return parseWriteNotesCommand(content);
@@ -1569,6 +1576,8 @@ async function notesPipeline(route, message) {
   }
 
   const { book, startChapter, endChapter, verseStart, verseEnd, withIntro, fresh, pauseBeforeATs } = parsed;
+  // Editor-marked TN hints (API-origin only; null on Zulip path).
+  const hints = parsed.hints || null;
   const sessionKey = stream ? `stream-${stream}-${topic}` : `dm-${message.sender_id}`;
   const debugRunId = `notes-${message.id || Date.now()}`;
   const checkpointRef = {
@@ -1975,6 +1984,35 @@ async function notesPipeline(route, message) {
             }
           } catch (seeHowErr) {
             console.warn(`[notes] See-how detection failed (non-fatal): ${seeHowErr.message}`);
+          }
+
+          // Apply editor-marked TN hints (API-origin only). Suppresses
+          // prepared items that match a hint on (verse, supportRef,
+          // fuzzy-quote) and injects each hint as a synthetic prepared
+          // item carrying its seed prose. hint.rowId is preserved as the
+          // item's id → TSV column-1 ID → bible-editor's UPDATE key.
+          if (Array.isArray(hints) && hints.length > 0) {
+            try {
+              const ctx = readContext(pipeDir);
+              const hintResult = applyHintsToPreparedNotes({
+                preparedJson: ctx.runtime.preparedNotes,
+                hints,
+                chapter: ch,
+              });
+              await status(
+                `**${ref}**: hints — ${hintResult.hintsApplied} applied, ` +
+                `${hintResult.itemsSuppressed} items suppressed, ` +
+                `${hintResult.hintsDropped} dropped`,
+              );
+              console.log(
+                `[notes] Hints ${ref}: applied=${hintResult.hintsApplied}, ` +
+                `suppressed=${hintResult.itemsSuppressed}, dropped=${hintResult.hintsDropped}` +
+                (hintResult.droppedReasons.length ? ` (${hintResult.droppedReasons.join('; ')})` : ''),
+              );
+            } catch (hintErr) {
+              console.error(`[notes] applyHintsToPreparedNotes failed (non-fatal): ${hintErr.message}`);
+              await status(`**${ref}**: hint application failed — ${hintErr.message}. Continuing without hints.`);
+            }
           }
         } catch (err) {
           console.error(`[notes] Mechanical prep failed for ${ref}: ${err.message}`);

--- a/src/router.js
+++ b/src/router.js
@@ -1337,7 +1337,7 @@ function getApiStream() {
   return process.env.BT_API_ZULIP_STREAM || 'bp-api';
 }
 
-function buildApiSyntheticRoute(pipelineType, scope) {
+function buildApiSyntheticRoute(pipelineType, scope, options) {
   const routeName = API_PIPELINE_ROUTE_NAMES[pipelineType];
   if (!routeName) return null;
   const baseRoute = config.routes.find((r) => r.name === routeName);
@@ -1350,6 +1350,14 @@ function buildApiSyntheticRoute(pipelineType, scope) {
       ? `${book} ${startChapter}`
       : `${book} ${startChapter}-${endChapter}`;
 
+  // hints can't ride the message.content flag string (it's a stringly-typed
+  // CLI grammar; an array of objects doesn't fit). Attach them structurally
+  // to the route — buildParsedNotesRequest will pick them up for synthetic
+  // (API-origin) routes. Zulip-triggered runs never go through here.
+  const hints = options && Array.isArray(options.hints) && options.hints.length > 0
+    ? options.hints
+    : null;
+
   return {
     ...baseRoute,
     _synthetic: true,
@@ -1358,6 +1366,7 @@ function buildApiSyntheticRoute(pipelineType, scope) {
     _endChapter: endChapter,
     _verseStart: verseStart ?? null,
     _verseEnd: verseEnd ?? null,
+    _hints: hints,
     _scopeText: rangeLabel.replace(/^\S+\s+/, ''),
     _apiOrigin: true,
     confirmMessage: null,
@@ -1438,7 +1447,7 @@ function triggerPipelineFromApi(input) {
   } = input;
 
   const scope = { book, startChapter, endChapter, verseStart, verseEnd };
-  const route = buildApiSyntheticRoute(pipelineType, scope);
+  const route = buildApiSyntheticRoute(pipelineType, scope, options);
   if (!route) {
     return { status: 'invalid', message: `Unknown pipelineType: ${pipelineType}` };
   }

--- a/src/router.js
+++ b/src/router.js
@@ -1364,12 +1364,33 @@ function buildApiSyntheticRoute(pipelineType, scope) {
   };
 }
 
-function buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username }) {
+function buildApiContentFlags(pipelineType, options) {
+  const o = options || {};
+  const flags = [];
+  if (pipelineType === 'generate') {
+    if (Array.isArray(o.contentTypes) && o.contentTypes.length === 1) {
+      flags.push(o.contentTypes[0].toUpperCase()); // 'ULT' | 'UST' restricts to one
+    }
+    if (o.noAlign) flags.push('--no-align');
+    if (o.alignOnly) flags.push('--align-only');
+    if (o.textOnly) flags.push('--text-only');
+  }
+  if (pipelineType === 'notes') {
+    if (o.noIntro) flags.push('--no-intro');
+    if (o.pauseBeforeATs) flags.push('--pause-before-ats');
+  }
+  if (o.fresh) flags.push('--fresh');
+  return flags;
+}
+
+function buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username, options }) {
   const { book, startChapter, endChapter } = scope;
   const chapterPart = startChapter === endChapter ? String(startChapter) : `${startChapter}-${endChapter}`;
   const commandWord = pipelineType === 'generate' ? 'generate'
     : pipelineType === 'notes' ? 'write notes'
     : 'write tqs';
+  const flags = buildApiContentFlags(pipelineType, options);
+  const content = [commandWord, book, chapterPart, ...flags].join(' ');
   return {
     id: -1,
     type: 'stream',
@@ -1378,7 +1399,7 @@ function buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username
     sender_id: -1,
     sender_full_name: username,
     sender_email: `${username}@api.bp-assistant`,
-    content: `${commandWord} ${book} ${chapterPart}`,
+    content,
     _apiOrigin: true,
   };
 }
@@ -1400,6 +1421,7 @@ function buildApiJobId({ apiSessionKey, pipelineType, scope }) {
  * @param {number|null} [input.verseEnd]
  * @param {string} input.username - DCS handle for commit attribution
  * @param {string} input.apiSessionKey - caller-supplied; idempotency + scoping
+ * @param {object} [input.options] - per-pipeline flag toggles (contentTypes, noAlign, alignOnly, textOnly, fresh, noIntro, pauseBeforeATs)
  * @returns {{ status: 'running'|'already_running'|'conflict'|'invalid', jobId?, scope?, conflictingJobId?, message? }}
  */
 function triggerPipelineFromApi(input) {
@@ -1412,6 +1434,7 @@ function triggerPipelineFromApi(input) {
     verseEnd = null,
     username,
     apiSessionKey,
+    options = {},
   } = input;
 
   const scope = { book, startChapter, endChapter, verseStart, verseEnd };
@@ -1419,7 +1442,7 @@ function triggerPipelineFromApi(input) {
   if (!route) {
     return { status: 'invalid', message: `Unknown pipelineType: ${pipelineType}` };
   }
-  const message = buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username });
+  const message = buildApiSyntheticMessage({ pipelineType, scope, apiSessionKey, username, options });
   const derivedSessionKey = `stream-${getApiStream()}-${apiSessionKey}`;
   const jobId = buildCheckpointKey({ sessionKey: derivedSessionKey, pipelineType, scope });
 
@@ -1478,5 +1501,6 @@ module.exports = {
   parseIntentScope,
   triggerPipelineFromApi,
   buildApiJobId,
+  buildApiContentFlags,
   API_PIPELINE_ROUTE_NAMES,
 };

--- a/src/workspace-tools/tn-tools.js
+++ b/src/workspace-tools/tn-tools.js
@@ -1254,6 +1254,239 @@ function stripHebrewQuoteMarks(value) {
   return String(value || '').replace(HEBREW_QUOTE_STRIP_RE, '');
 }
 
+// -- Hint helpers --------------------------------------------------------
+//
+// Used by applyHintsToPreparedNotes (and exposed for tests) to compare
+// human-supplied hint metadata against AI-prepared note items so we can
+// suppress duplicate notes and inject the hint as a synthetic prepared item.
+
+const SUPPORT_REF_RC_PREFIX_RE = /^rc:\/\/[^/]+\/ta\/man\/translate\//;
+// Word-joiner (U+2060), soft hyphen (U+00AD), Hebrew maqaf-like word
+// dividers (U+05BE) and the existing cantillation set above are stripped
+// from quotes so fuzzy match isn't confused by invisible joiners that the
+// human and AI tooling handle differently.
+const QUOTE_INVISIBLE_RE = /[\u2060\u00AD]/g;
+
+function normalizeSupportReference(s) {
+  return String(s || '').trim().replace(SUPPORT_REF_RC_PREFIX_RE, '');
+}
+
+function normalizeQuote(s) {
+  return stripHebrewQuoteMarks(String(s || ''))
+    .normalize('NFC')
+    .replace(QUOTE_INVISIBLE_RE, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function quoteFuzzyMatch(a, b) {
+  const na = normalizeQuote(a);
+  const nb = normalizeQuote(b);
+  if (!na && !nb) return true;
+  if (!na || !nb) return false;
+  if (na === nb) return true;
+  if (na.includes(nb) || nb.includes(na)) return true;
+  const ta = new Set(na.split(' ').filter(Boolean));
+  const tb = new Set(nb.split(' ').filter(Boolean));
+  if (!ta.size || !tb.size) return false;
+  let inter = 0;
+  for (const t of ta) if (tb.has(t)) inter++;
+  const union = ta.size + tb.size - inter;
+  return union > 0 && (inter / union) >= 0.6;
+}
+
+function verseFromReference(ref) {
+  if (!ref) return null;
+  const m = String(ref).match(/^(\d+):(\d+)/);
+  return m ? parseInt(m[2], 10) : null;
+}
+
+function rerollId(takenIds) {
+  const letters = 'abcdefghijklmnopqrstuvwxyz';
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  for (let attempt = 0; attempt < 100; attempt++) {
+    let id = letters[Math.floor(Math.random() * 26)];
+    for (let j = 0; j < 3; j++) id += chars[Math.floor(Math.random() * 36)];
+    if (!takenIds.has(id)) return id;
+  }
+  // Deterministic fallback; extremely unlikely to be reached.
+  return 'x' + crypto.createHash('md5').update(`${Date.now()}-${takenIds.size}`).digest('hex').slice(0, 3);
+}
+
+/**
+ * Apply editor-marked TN row hints to a prepared-notes JSON file.
+ *
+ * For each hint:
+ *   1. Suppress prepared items that target the same (verse, supportReference,
+ *      fuzzy-quote) \u2014 the translator has already chosen the issue framing,
+ *      so a competing AI note would conflict.
+ *   2. Inject the hint as a new prepared item carrying:
+ *        - id = hint.rowId (preserved across the pipeline \u2192 TSV ID column,
+ *          so bible-editor can UPDATE its stub row by ID match).
+ *        - seed = hint.seed (skill expands into a complete note when present).
+ *        - fromHint = true (marker so see-how detection and other passes
+ *          can opt out of mutating hint-driven items).
+ *
+ * Re-rolls IDs on any non-suppressed prepared item that happens to share an
+ * id with a hint's rowId \u2014 the hint id is authoritative.
+ *
+ * Skips hints whose verse is outside the chapter's existing item range and
+ * doesn't appear in the chapter's ult verses (defensive: a stray verse
+ * number shouldn't produce an orphan row).
+ *
+ * @param {object} args
+ * @param {string} args.preparedJson - workspace-relative path to prepared_notes.json
+ * @param {Array}  args.hints        - validated hint objects from options.hints
+ * @param {number} args.chapter      - chapter number (used to build references)
+ * @returns {{ hintsApplied: number, itemsSuppressed: number, hintsDropped: number,
+ *             droppedReasons: string[] }}
+ */
+function applyHintsToPreparedNotes({ preparedJson, hints, chapter }) {
+  if (!Array.isArray(hints) || hints.length === 0) {
+    return { hintsApplied: 0, itemsSuppressed: 0, hintsDropped: 0, droppedReasons: [] };
+  }
+  const absPath = path.resolve(CSKILLBP_DIR, preparedJson);
+  const data = JSON.parse(fs.readFileSync(absPath, 'utf8'));
+  const items = Array.isArray(data.items) ? data.items : [];
+  const ch = Number(chapter);
+
+  // Collect existing verses with prepared items \u2014 used to drop hints
+  // pointing at verses that aren't part of this chapter's scope.
+  const versesInChapter = new Set();
+  for (const item of items) {
+    const v = verseFromReference(item.reference);
+    if (v != null) versesInChapter.add(v);
+  }
+
+  let suppressed = 0;
+  let applied = 0;
+  let dropped = 0;
+  const droppedReasons = [];
+
+  // Process hints in input order so a deterministic suppression log results.
+  for (const hint of hints) {
+    const verse = Number(hint.verse);
+    if (!Number.isFinite(verse)) {
+      dropped++;
+      droppedReasons.push(`${hint.rowId}: non-numeric verse`);
+      continue;
+    }
+    // Drop hints outside the chapter unless the verse is plausibly inside
+    // (i.e., another item already targets the same verse). The chapter
+    // scope isn't fully known here \u2014 versesInChapter is the best proxy.
+    // Tolerate verses with no existing items only if there are NO items
+    // (empty issues TSV \u2014 the hint becomes the sole note).
+    if (versesInChapter.size > 0 && !versesInChapter.has(verse)) {
+      dropped++;
+      droppedReasons.push(`${hint.rowId}: verse ${verse} outside chapter scope`);
+      continue;
+    }
+
+    const hintSref = normalizeSupportReference(hint.supportReference);
+
+    // Suppression pass: drop any prepared item whose (verse, supportRef,
+    // fuzzy-quote) matches the hint. Skip items already marked fromHint
+    // (defensive: shouldn't happen on a single applyHints call, but a
+    // future re-entrancy bug shouldn't silently delete hint rows).
+    for (let i = items.length - 1; i >= 0; i--) {
+      const item = items[i];
+      if (item && item.fromHint) continue;
+      if (verseFromReference(item.reference) !== verse) continue;
+      if (normalizeSupportReference(item.sref) !== hintSref) continue;
+      const hintQuote = String(hint.quote || '');
+      const itemQuote = String(item.orig_quote || '');
+      // Empty hint quote \u2192 match on (verse, sref) only.
+      const quoteMatches = hintQuote ? quoteFuzzyMatch(itemQuote, hintQuote) : true;
+      if (!quoteMatches) continue;
+      items.splice(i, 1);
+      suppressed++;
+    }
+
+    // ID-collision check: a non-suppressed item happens to share the
+    // hint's rowId. The hint is authoritative \u2014 re-roll the other item's id.
+    const takenIds = new Set(items.map((it) => it.id).filter(Boolean));
+    if (takenIds.has(hint.rowId)) {
+      // Pretend this id is already taken when re-rolling, plus reserve all
+      // remaining hint rowIds so we don't burn one of those on a re-roll.
+      const reservedForLaterHints = new Set(
+        hints.slice(hints.indexOf(hint) + 1).map((h) => h.rowId),
+      );
+      const reroll = new Set([...takenIds, ...reservedForLaterHints, hint.rowId]);
+      const conflictIdx = items.findIndex((it) => it.id === hint.rowId);
+      if (conflictIdx >= 0) {
+        items[conflictIdx].id = rerollId(reroll);
+      }
+    }
+
+    // Inject a synthetic prepared item carrying the hint. It's intentionally
+    // sparse: tn-writer reads `seed` (added below) and uses the hint's
+    // orig_quote / sref directly; the heavyweight selector/template fields
+    // that prepareNotes computes for issue-driven items aren't applicable
+    // here because the human has already chosen the framing.
+    const refStr = `${ch}:${verse}`;
+    const ultVerseText = (() => {
+      const sib = items.find((it) => verseFromReference(it.reference) === verse && it.ult_verse);
+      return sib ? sib.ult_verse : '';
+    })();
+    const ustVerseText = (() => {
+      const sib = items.find((it) => verseFromReference(it.reference) === verse && it.ust_verse);
+      return sib ? sib.ust_verse : '';
+    })();
+    items.push({
+      index: items.length,
+      reference: refStr,
+      sref: hintSref,
+      gl_quote: '',
+      issue_span_gl_quote: '',
+      scope_mode: 'focused_span',
+      needs_at: false,
+      at_provided: '',
+      explanation: hint.seed || '',
+      id: hint.rowId,
+      orig_quote: String(hint.quote || ''),
+      ult_verse: ultVerseText,
+      ust_verse: ustVerseText,
+      book: data.book || '',
+      note_type: 'hint',
+      hebrew_front_words: [],
+      tcm_mode: false,
+      chosen_template_id: '',
+      chosen_template_has_at_slot: false,
+      template_text: '',
+      template_type: 'generic',
+      template_locked: false,
+      must_include: [],
+      clean_explanation: hint.seed || '',
+      at_policy: 'not_needed',
+      at_required: false,
+      at_decision_reason: 'hint',
+      template_selector_status: 'fallback_deterministic',
+      template_selector_fallback_reason: 'hint',
+      quote_scope_selector_status: 'fallback_deterministic',
+      quote_scope_selector_fallback_reason: 'hint',
+      selector_status: 'fallback_deterministic',
+      selector_fallback_reason: 'hint',
+      style_rules: [],
+      rule_overrides: [],
+      writer_packet: null,
+      prompt: '',
+      system_prompt_key: 'given_at_agent',
+      programmatic_note: '',
+      candidate_templates: [],
+      // Hint-specific fields:
+      seed: hint.seed || null,
+      hintRowId: hint.rowId,
+      fromHint: true,
+    });
+    applied++;
+  }
+
+  data.items = items;
+  fs.writeFileSync(absPath, JSON.stringify(data, null, 2));
+  return { hintsApplied: applied, itemsSuppressed: suppressed, hintsDropped: dropped, droppedReasons };
+}
+
 function buildStrippedHebrewText(raw) {
   const stripped = [];
   const offsetMap = [];
@@ -2688,6 +2921,11 @@ module.exports = {
   readPreparedNotes,
   substituteAT,
   resolveAtRequirement,
+  // Hint expansion (used by notes-pipeline mechanical prep + tests):
+  applyHintsToPreparedNotes,
+  normalizeQuote,
+  normalizeSupportReference,
+  quoteFuzzyMatch,
   _parseExplanationDirectives: parseExplanationDirectives,
   _resolveTemplateSelection: resolveTemplateSelection,
   _deriveStyleProfile: deriveStyleProfile,

--- a/test/pipeline-api.test.js
+++ b/test/pipeline-api.test.js
@@ -188,3 +188,117 @@ test('PIPELINE_OUTPUT_TYPES — all referenced types exist in REPO_MAP', () => {
     }
   }
 });
+
+// ---------------------------------------------------------------------------
+// Options → synthetic content flags
+// ---------------------------------------------------------------------------
+
+const { buildApiContentFlags } = require('../src/router');
+
+test('buildApiContentFlags — generate, no options → no flags', () => {
+  assert.deepEqual(buildApiContentFlags('generate', {}), []);
+  assert.deepEqual(buildApiContentFlags('generate', undefined), []);
+});
+
+test('buildApiContentFlags — generate, ULT-only contentTypes → "ULT" flag', () => {
+  assert.deepEqual(buildApiContentFlags('generate', { contentTypes: ['ult'] }), ['ULT']);
+  assert.deepEqual(buildApiContentFlags('generate', { contentTypes: ['ust'] }), ['UST']);
+});
+
+test('buildApiContentFlags — generate, both contentTypes → no restriction flag', () => {
+  assert.deepEqual(buildApiContentFlags('generate', { contentTypes: ['ult', 'ust'] }), []);
+});
+
+test('buildApiContentFlags — generate, noAlign → --no-align', () => {
+  assert.deepEqual(buildApiContentFlags('generate', { noAlign: true }), ['--no-align']);
+});
+
+test('buildApiContentFlags — generate, alignOnly → --align-only', () => {
+  assert.deepEqual(buildApiContentFlags('generate', { alignOnly: true }), ['--align-only']);
+});
+
+test('buildApiContentFlags — generate, textOnly → --text-only', () => {
+  assert.deepEqual(buildApiContentFlags('generate', { textOnly: true }), ['--text-only']);
+});
+
+test('buildApiContentFlags — generate, combined ULT + no-align + fresh', () => {
+  const f = buildApiContentFlags('generate', { contentTypes: ['ult'], noAlign: true, fresh: true });
+  assert.deepEqual(f, ['ULT', '--no-align', '--fresh']);
+});
+
+test('buildApiContentFlags — notes, noIntro + pauseBeforeATs', () => {
+  assert.deepEqual(
+    buildApiContentFlags('notes', { noIntro: true, pauseBeforeATs: true }),
+    ['--no-intro', '--pause-before-ats'],
+  );
+});
+
+test('buildApiContentFlags — notes ignores generate-only flags', () => {
+  // Schema-level validation rejects these for notes, but the builder must also
+  // be tolerant: silently drop generate-only flags rather than emit them.
+  assert.deepEqual(buildApiContentFlags('notes', { contentTypes: ['ult'], noAlign: true }), []);
+});
+
+test('buildApiContentFlags — tqs, fresh', () => {
+  assert.deepEqual(buildApiContentFlags('tqs', { fresh: true }), ['--fresh']);
+});
+
+// ---------------------------------------------------------------------------
+// StartBodySchema — option validation
+// ---------------------------------------------------------------------------
+
+test('StartBodySchema — accepts options.contentTypes for generate', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'generate', book: 'PSA', startChapter: 1,
+    username: 'u', sessionKey: 'k',
+    options: { contentTypes: ['ult'] },
+  });
+  assert.equal(r.success, true);
+});
+
+test('StartBodySchema — rejects generate-only options on notes', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'PSA', startChapter: 1,
+    username: 'u', sessionKey: 'k',
+    options: { contentTypes: ['ult'] },
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — rejects notes-only options on generate', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'generate', book: 'PSA', startChapter: 1,
+    username: 'u', sessionKey: 'k',
+    options: { noIntro: true },
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — rejects mutually-exclusive align flags', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'generate', book: 'PSA', startChapter: 1,
+    username: 'u', sessionKey: 'k',
+    options: { noAlign: true, alignOnly: true },
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — rejects unknown options keys (strict)', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'generate', book: 'PSA', startChapter: 1,
+    username: 'u', sessionKey: 'k',
+    options: { mysteryFlag: true },
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — accepts fresh on any pipeline type', () => {
+  for (const pt of ['generate', 'notes', 'tqs']) {
+    const r = StartBodySchema.safeParse({
+      pipelineType: pt, book: 'PSA', startChapter: 1,
+      username: 'u', sessionKey: 'k',
+      options: { fresh: true },
+    });
+    assert.equal(r.success, true, `${pt} should accept fresh`);
+  }
+});

--- a/test/pipeline-api.test.js
+++ b/test/pipeline-api.test.js
@@ -302,3 +302,113 @@ test('StartBodySchema — accepts fresh on any pipeline type', () => {
     assert.equal(r.success, true, `${pt} should accept fresh`);
   }
 });
+
+// ---------------------------------------------------------------------------
+// StartBodySchema — hints
+// ---------------------------------------------------------------------------
+
+const VALID_HINT = {
+  rowId: 'ab12',
+  verse: 7,
+  quote: 'מֵרֵעֵהוּ',
+  supportReference: 'rc://*/ta/man/translate/figs-metaphor',
+  seed: 'Could be either view.',
+};
+
+test('StartBodySchema — accepts options.hints on notes pipeline', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'ZEC', startChapter: 7,
+    username: 'u', sessionKey: 'k',
+    options: { hints: [VALID_HINT] },
+  });
+  assert.equal(r.success, true);
+});
+
+test('StartBodySchema — accepts hints with null seed and null supportReference', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'ZEC', startChapter: 7,
+    username: 'u', sessionKey: 'k',
+    options: { hints: [{ ...VALID_HINT, seed: null, supportReference: null }] },
+  });
+  assert.equal(r.success, true);
+});
+
+test('StartBodySchema — accepts empty hint.quote', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'ZEC', startChapter: 7,
+    username: 'u', sessionKey: 'k',
+    options: { hints: [{ ...VALID_HINT, quote: '' }] },
+  });
+  assert.equal(r.success, true);
+});
+
+test('StartBodySchema — rejects hints on generate and tqs pipelines', () => {
+  for (const pt of ['generate', 'tqs']) {
+    const r = StartBodySchema.safeParse({
+      pipelineType: pt, book: 'ZEC', startChapter: 7,
+      username: 'u', sessionKey: 'k',
+      options: { hints: [VALID_HINT] },
+    });
+    assert.equal(r.success, false, `${pt} should reject hints`);
+  }
+});
+
+test('StartBodySchema — rejects malformed rowId', () => {
+  for (const bad of ['AB12', '12ab', 'abcde', 'ab1', '', 'ab-1']) {
+    const r = StartBodySchema.safeParse({
+      pipelineType: 'notes', book: 'ZEC', startChapter: 7,
+      username: 'u', sessionKey: 'k',
+      options: { hints: [{ ...VALID_HINT, rowId: bad }] },
+    });
+    assert.equal(r.success, false, `rowId="${bad}" should fail`);
+  }
+});
+
+test('StartBodySchema — rejects duplicate rowIds within a single request', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'ZEC', startChapter: 7,
+    username: 'u', sessionKey: 'k',
+    options: { hints: [VALID_HINT, { ...VALID_HINT, verse: 9 }] },
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — rejects hints on multi-chapter scope', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'ZEC', startChapter: 7, endChapter: 9,
+    username: 'u', sessionKey: 'k',
+    options: { hints: [VALID_HINT] },
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — accepts hints when endChapter omitted (defaults to startChapter)', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'ZEC', startChapter: 7,
+    username: 'u', sessionKey: 'k',
+    options: { hints: [VALID_HINT] },
+  });
+  assert.equal(r.success, true);
+});
+
+test('StartBodySchema — rejects more than 50 hints', () => {
+  const many = Array.from({ length: 51 }, (_, i) => ({
+    ...VALID_HINT,
+    rowId: 'a' + String(i).padStart(3, '0'),
+  }));
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'ZEC', startChapter: 7,
+    username: 'u', sessionKey: 'k',
+    options: { hints: many },
+  });
+  assert.equal(r.success, false);
+});
+
+test('StartBodySchema — rejects unknown keys on hint object (strict)', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'ZEC', startChapter: 7,
+    username: 'u', sessionKey: 'k',
+    options: { hints: [{ ...VALID_HINT, mysteryField: 'oops' }] },
+  });
+  assert.equal(r.success, false);
+});

--- a/test/tn-tools.test.js
+++ b/test/tn-tools.test.js
@@ -19,6 +19,10 @@ const {
   _maybeBuildProgrammaticNote,
   _normalizeAssembledNoteText,
   substituteAT,
+  applyHintsToPreparedNotes,
+  normalizeQuote,
+  normalizeSupportReference,
+  quoteFuzzyMatch,
 } = require('../src/workspace-tools/tn-tools');
 
 test('parseExplanationDirectives separates t: and i: instructions deterministically', () => {
@@ -1282,4 +1286,220 @@ test('verifyBoldMatches does not scan beyond the opening to add bold', () => {
 
   assert.match(summary, /restored 0 missing bold/);
   assert.doesNotMatch(content, /\*\*stood on his right\*\*/);
+});
+
+// ---------------------------------------------------------------------------
+// Hint helpers: normalizeQuote / normalizeSupportReference / quoteFuzzyMatch
+// ---------------------------------------------------------------------------
+
+test('normalizeSupportReference — strips RC prefix and trims', () => {
+  assert.equal(normalizeSupportReference('rc://*/ta/man/translate/figs-metaphor'), 'figs-metaphor');
+  assert.equal(normalizeSupportReference('  rc://en/ta/man/translate/figs-idiom  '), 'figs-idiom');
+  assert.equal(normalizeSupportReference('figs-explicit'), 'figs-explicit');
+  assert.equal(normalizeSupportReference(''), '');
+  assert.equal(normalizeSupportReference(null), '');
+});
+
+test('normalizeQuote — strips cantillation, word-joiner, collapses whitespace', () => {
+  // Cantillation marks dropped (Hebrew accents in the 0591–05AF range).
+  const withMarks = 'מֵרֵעֵ֑הוּ';
+  const stripped = 'מֵרֵעֵהוּ';
+  assert.equal(normalizeQuote(withMarks), normalizeQuote(stripped));
+  // Word-joiner (U+2060) dropped.
+  assert.equal(normalizeQuote('a⁠b'), 'ab');
+  // Whitespace collapsed and case-folded.
+  assert.equal(normalizeQuote('  Hello   World  '), 'hello world');
+  assert.equal(normalizeQuote(''), '');
+  assert.equal(normalizeQuote(null), '');
+});
+
+test('quoteFuzzyMatch — exact match after normalization', () => {
+  assert.equal(quoteFuzzyMatch('מֵרֵעֵ֑הוּ', 'מֵרֵעֵהוּ'), true);
+  assert.equal(quoteFuzzyMatch('Hello', 'hello'), true);
+});
+
+test('quoteFuzzyMatch — substring containment matches', () => {
+  assert.equal(quoteFuzzyMatch('hello world', 'hello'), true);
+  assert.equal(quoteFuzzyMatch('hello', 'hello world'), true);
+});
+
+test('quoteFuzzyMatch — token overlap at/above 0.6 threshold matches; below does not', () => {
+  // 3/5 = 0.6 (boundary, inclusive) → match.
+  assert.equal(quoteFuzzyMatch('the quick brown fox', 'quick brown the dog'), true);
+  // All 4 tokens shared, just reordered (4/4 = 1.0) → match.
+  assert.equal(quoteFuzzyMatch('a b c d', 'd c b a'), true);
+  // Only 1 of 7 tokens shared (1/7 ≈ 0.14) → no match.
+  assert.equal(quoteFuzzyMatch('alpha beta gamma delta', 'gamma epsilon zeta'), false);
+});
+
+test('quoteFuzzyMatch — unrelated quotes do not match', () => {
+  assert.equal(quoteFuzzyMatch('hello world', 'goodbye moon'), false);
+  assert.equal(quoteFuzzyMatch('מֵרֵעֵהוּ', 'וְ⁠נִכְרַ֖תָּ'), false);
+});
+
+test('quoteFuzzyMatch — empty both sides matches; empty one side does not', () => {
+  assert.equal(quoteFuzzyMatch('', ''), true);
+  assert.equal(quoteFuzzyMatch('a', ''), false);
+  assert.equal(quoteFuzzyMatch('', 'a'), false);
+});
+
+// ---------------------------------------------------------------------------
+// applyHintsToPreparedNotes
+// ---------------------------------------------------------------------------
+
+function writePrepared(workspaceRel, prepared) {
+  const abs = path.join('/srv/bot/workspace', workspaceRel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, JSON.stringify(prepared, null, 2));
+}
+
+function readPrepared(workspaceRel) {
+  return JSON.parse(fs.readFileSync(path.join('/srv/bot/workspace', workspaceRel), 'utf8'));
+}
+
+function tempPreparedPath() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tn-hints-'));
+  return path.join('tmp', path.basename(tempDir), 'prepared_notes.json');
+}
+
+test('applyHintsToPreparedNotes — no hints → no-op', () => {
+  const prepRel = tempPreparedPath();
+  writePrepared(prepRel, { book: 'ZEC', chapter: '7', items: [
+    { id: 'aaaa', reference: '7:1', sref: 'figs-metaphor', orig_quote: 'foo' },
+  ]});
+  const r = applyHintsToPreparedNotes({ preparedJson: prepRel, hints: [], chapter: 7 });
+  assert.equal(r.hintsApplied, 0);
+  assert.equal(r.itemsSuppressed, 0);
+  assert.equal(r.hintsDropped, 0);
+  const data = readPrepared(prepRel);
+  assert.equal(data.items.length, 1);
+});
+
+test('applyHintsToPreparedNotes — injects hint as new item with id=rowId, fromHint=true', () => {
+  const prepRel = tempPreparedPath();
+  writePrepared(prepRel, { book: 'ZEC', chapter: '7', items: [
+    { id: 'aaaa', reference: '7:1', sref: 'figs-other', orig_quote: 'unrelated', ult_verse: 'Verse 1 text' },
+  ]});
+  const r = applyHintsToPreparedNotes({
+    preparedJson: prepRel,
+    hints: [{
+      rowId: 'ab12', verse: 1,
+      quote: 'מֵרֵעֵהוּ',
+      supportReference: 'rc://*/ta/man/translate/figs-metaphor',
+      seed: 'expand me',
+    }],
+    chapter: 7,
+  });
+  assert.equal(r.hintsApplied, 1);
+  assert.equal(r.itemsSuppressed, 0);
+  const data = readPrepared(prepRel);
+  assert.equal(data.items.length, 2);
+  const injected = data.items.find((it) => it.id === 'ab12');
+  assert.ok(injected, 'hint item missing');
+  assert.equal(injected.fromHint, true);
+  assert.equal(injected.seed, 'expand me');
+  assert.equal(injected.hintRowId, 'ab12');
+  assert.equal(injected.note_type, 'hint');
+  assert.equal(injected.sref, 'figs-metaphor');  // RC prefix stripped
+  assert.equal(injected.reference, '7:1');
+  assert.equal(injected.orig_quote, 'מֵרֵעֵהוּ');
+});
+
+test('applyHintsToPreparedNotes — suppresses matching item on (verse, sref, fuzzy-quote)', () => {
+  const prepRel = tempPreparedPath();
+  writePrepared(prepRel, { book: 'ZEC', chapter: '7', items: [
+    { id: 'aaaa', reference: '7:7', sref: 'figs-metaphor', orig_quote: 'מֵרֵעֵ֑הוּ' },
+    { id: 'bbbb', reference: '7:7', sref: 'figs-idiom',    orig_quote: 'מֵרֵעֵהוּ' },
+    { id: 'cccc', reference: '7:8', sref: 'figs-metaphor', orig_quote: 'מֵרֵעֵהוּ' },
+  ]});
+  const r = applyHintsToPreparedNotes({
+    preparedJson: prepRel,
+    hints: [{
+      rowId: 'ab12', verse: 7,
+      quote: 'מֵרֵעֵהוּ',  // matches aaaa after cantillation strip
+      supportReference: 'figs-metaphor',
+      seed: null,
+    }],
+    chapter: 7,
+  });
+  assert.equal(r.hintsApplied, 1);
+  assert.equal(r.itemsSuppressed, 1);
+  const data = readPrepared(prepRel);
+  // aaaa suppressed, bbbb (different sref) kept, cccc (different verse) kept, hint injected
+  const ids = data.items.map((it) => it.id).sort();
+  assert.deepEqual(ids, ['ab12', 'bbbb', 'cccc']);
+});
+
+test('applyHintsToPreparedNotes — empty hint.quote suppresses on (verse, sref) only', () => {
+  const prepRel = tempPreparedPath();
+  writePrepared(prepRel, { book: 'ZEC', chapter: '7', items: [
+    { id: 'aaaa', reference: '7:7', sref: 'figs-metaphor', orig_quote: 'whatever' },
+    { id: 'bbbb', reference: '7:8', sref: 'figs-metaphor', orig_quote: 'whatever' },
+  ]});
+  const r = applyHintsToPreparedNotes({
+    preparedJson: prepRel,
+    hints: [{ rowId: 'ab12', verse: 7, quote: '', supportReference: 'figs-metaphor', seed: null }],
+    chapter: 7,
+  });
+  assert.equal(r.itemsSuppressed, 1);
+  const data = readPrepared(prepRel);
+  assert.ok(!data.items.find((it) => it.id === 'aaaa'), 'aaaa should be suppressed');
+  assert.ok(data.items.find((it) => it.id === 'bbbb'), 'bbbb should survive');
+});
+
+test('applyHintsToPreparedNotes — drops hint whose verse is outside chapter scope', () => {
+  const prepRel = tempPreparedPath();
+  writePrepared(prepRel, { book: 'ZEC', chapter: '7', items: [
+    { id: 'aaaa', reference: '7:1', sref: 'figs-other', orig_quote: 'a' },
+    { id: 'bbbb', reference: '7:2', sref: 'figs-other', orig_quote: 'b' },
+  ]});
+  const r = applyHintsToPreparedNotes({
+    preparedJson: prepRel,
+    hints: [{ rowId: 'ab12', verse: 99, quote: 'x', supportReference: 'figs-metaphor', seed: null }],
+    chapter: 7,
+  });
+  assert.equal(r.hintsApplied, 0);
+  assert.equal(r.hintsDropped, 1);
+  assert.match(r.droppedReasons[0], /verse 99 outside/);
+});
+
+test('applyHintsToPreparedNotes — re-rolls non-hint item id on rowId collision', () => {
+  const prepRel = tempPreparedPath();
+  writePrepared(prepRel, { book: 'ZEC', chapter: '7', items: [
+    { id: 'ab12', reference: '7:1', sref: 'figs-other', orig_quote: 'unrelated' },
+  ]});
+  const r = applyHintsToPreparedNotes({
+    preparedJson: prepRel,
+    hints: [{ rowId: 'ab12', verse: 1, quote: 'newquote', supportReference: 'figs-metaphor', seed: null }],
+    chapter: 7,
+  });
+  assert.equal(r.hintsApplied, 1);
+  const data = readPrepared(prepRel);
+  // Hint owns 'ab12'; old item's id was re-rolled to something else.
+  const hint = data.items.find((it) => it.fromHint);
+  const other = data.items.find((it) => !it.fromHint);
+  assert.equal(hint.id, 'ab12');
+  assert.notEqual(other.id, 'ab12');
+  assert.match(other.id, /^[a-z][a-z0-9]{3}$/);
+});
+
+test('applyHintsToPreparedNotes — multiple hints all applied', () => {
+  const prepRel = tempPreparedPath();
+  writePrepared(prepRel, { book: 'ZEC', chapter: '7', items: [
+    { id: 'aaaa', reference: '7:7', sref: 'figs-metaphor', orig_quote: 'q1' },
+    { id: 'bbbb', reference: '7:9', sref: 'figs-idiom',    orig_quote: 'q2' },
+  ]});
+  const r = applyHintsToPreparedNotes({
+    preparedJson: prepRel,
+    hints: [
+      { rowId: 'ab12', verse: 7, quote: 'q1', supportReference: 'figs-metaphor', seed: 's1' },
+      { rowId: 'cd34', verse: 9, quote: 'q2', supportReference: 'figs-idiom',    seed: null },
+    ],
+    chapter: 7,
+  });
+  assert.equal(r.hintsApplied, 2);
+  assert.equal(r.itemsSuppressed, 2);
+  const data = readPrepared(prepRel);
+  const ids = data.items.map((it) => it.id).sort();
+  assert.deepEqual(ids, ['ab12', 'cd34']);
 });


### PR DESCRIPTION
## Summary

- Adds `options.hints` to `/api/pipeline/start` so bible-editor can pre-seed specific TN rows the AI must produce, and suppress competing AI-derived notes for the same `(verse, supportReference, fuzzy-quote)`.
- Preserves `hint.rowId` as the TSV `ID` column for the expanded row — bible-editor matches its D1 stub to the AI output by ID, no separate sidecar or column.
- TSV schema pushed to DCS is unchanged (still 7-col). Zulip-triggered runs are untouched.

## Design vs. the original contract

bible-editor's draft contract proposed an 8th `HintRowID` TSV column (or a sidecar JSON). We rejected both — the notes TSV is pushed to DCS and is parsed positionally by downstream consumers, so polluting its schema is off the table; and a sidecar plus status-endpoint extension introduces an atomicity problem. Re-using the existing TSV `ID` column avoids both issues. Coordination points back to bible-editor are documented in the plan file the work was scoped against.

## Notes

- New helpers in `tn-tools.js`: `normalizeQuote` (strips Hebrew cantillation + word-joiner, NFC, lowercase), `normalizeSupportReference` (strips RC prefix), `quoteFuzzyMatch` (exact / substring / token-set ≥ 0.6), `applyHintsToPreparedNotes`.
- `applyHintsToPreparedNotes` runs after `runMechanicalPrep` and after see-how detection (which is also taught to skip `fromHint` items, defensively).
- Validation guards: hints rejected on `generate`/`tqs`, duplicate `rowId` rejected, multi-chapter scope + hints rejected (hint carries verse but no chapter), 50-hint cap, body size cap 4KB → 32KB.
- Companion change to `bp-assistant-skills` (`SKILL.md`) teaches tn-writer to expand `seed` prose into a complete note rather than echo it. PR there opening alongside.

## Test plan

- [x] `node --test test/pipeline-api.test.js` — 43 pass (11 new for hint schema).
- [x] `node --test test/tn-tools.test.js` — 42 pass (9 new for hint helpers). Two pre-existing `fillOrigQuotes` failures unchanged.
- [x] Full suite `npm test` — 254 pass, 3 pre-existing failures, no new regressions.
- [ ] After merge: end-to-end smoke against staging using the curl in the plan file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)