### PR TITLE
forcing AT opening caps to match ult_span

### DIFF
--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -587,6 +587,9 @@ async function runATGeneration({ notesPath, pipeDir, status }) {
   function normalizeATCapitalization(atText, exactUltSpan) {
     if (!atText || !exactUltSpan) return atText;
 
+    const trimmed = atText.trim();
+    if (!trimmed) return atText;
+
     const spanFirst = exactUltSpan.trim()[0];
     const atFirst = atText.trim()[0];
 
@@ -699,6 +702,12 @@ async function runATGeneration({ notesPath, pipeDir, status }) {
       });
       let retryAt = extractResultText(retryResult);
       retryAt = retryAt.replace(/^\[|\]$/g, '').replace(/^Alternate translation:\s*/i, '').trim();
+      
+      // Normalize capitalization to ULT span
+      retryAt = normalizeATCapitalization(
+        retryAt,
+        packet.exact_ult_span
+      );
 
       if (!retryAt) {
         // First attempt's AT survives; tag for human review. Log retry failure reason

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -583,6 +583,28 @@ async function runATGeneration({ notesPath, pipeDir, status }) {
     return '';
   }
 
+  // Cap AT if ULT span is capped
+  function normalizeATCapitalization(atText, exactUltSpan) {
+    if (!atText || !exactUltSpan) return atText;
+
+    const spanFirst = exactUltSpan.trim()[0];
+    const atFirst = atText.trim()[0];
+
+    // Only enforce capitalization if the span starts uppercase
+    if (!/[A-Z]/.test(spanFirst)) {
+      return atText;
+    }
+
+    // AT already starts uppercase
+    if (/[A-Z]/.test(atFirst)) {
+      return atText;
+    }
+
+    const trimmed = atText.trim();
+
+    return atFirst.toUpperCase() + trimmed.slice(1);
+  }
+
   // Process items with concurrency limiter
   async function generateOneAT(packet) {
     const userPrompt = [
@@ -614,6 +636,12 @@ async function runATGeneration({ notesPath, pipeDir, status }) {
       let atText = extractResultText(atResult);
       // Strip any accidental brackets or "Alternate translation:" prefix
       atText = atText.replace(/^\[|\]$/g, '').replace(/^Alternate translation:\s*/i, '').trim();
+
+      // Normalize capitalization to ULT span
+      atText = normalizeATCapitalization(
+        atText,
+        packet.exact_ult_span
+      );
 
       if (!atText) {
         return { id: packet.id, success: false, reason: classifyEmpty(atResult, 'generate') };

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -603,8 +603,6 @@ async function runATGeneration({ notesPath, pipeDir, status }) {
       return atText;
     }
 
-    const trimmed = atText.trim();
-
     return atFirst.toUpperCase() + trimmed.slice(1);
   }
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Sometimes the generated AT should be capitalized, but the generated AT is not capitalized. Adding a helper function to notes-pipeline.js that checks exact_ult_span to see if it starts with caps. If it does and AT does not, AT is capped. 

#### Please include detailed Test instructions for your pull request:
Nothing should change except capitalization. Here is an example where capitalization should change:
exact_ult_span: "And it happened in the days of Ahaz"
AT text: "when Ahaz was king"

Because exact_ult_span is capped, AT text should become "When Ahaz was king." 

However, if exact_ult_span is lowercase, the AT should never change in capitalization.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
