### PR TITLE
Fix silent templates.csv fetch + add fetch-status health surface

### DIFF
--- a/src/cron-weekly-refresh.js
+++ b/src/cron-weekly-refresh.js
@@ -10,6 +10,13 @@ function startWeeklyRefresh() {
     try {
       const result = await curatePublishedData({ step: 'fetch-google', force: true });
       console.log('[weekly-refresh] Done:', result.messages.join(' | '));
+      const errors = result.fetchErrors || [];
+      if (errors.length) {
+        const summary = errors.map(e => `${e.file}: ${e.message}`).join('; ');
+        console.error(`[weekly-refresh] FAILED: ${errors.length} file(s) — ${summary}`);
+      } else {
+        console.log('[weekly-refresh] OK: all sources refreshed');
+      }
     } catch (err) {
       console.error('[weekly-refresh] Failed:', err.message);
     }

--- a/src/curate-data.js
+++ b/src/curate-data.js
@@ -16,6 +16,7 @@ const WORKSPACE = process.env.CSKILLBP_DIR || path.resolve(__dirname, '..', '..'
 const DATA_DIR = path.join(WORKSPACE, 'data');
 const CACHE_DIR = path.join(DATA_DIR, 'cache');
 const MANIFEST_PATH = path.join(CACHE_DIR, 'published_manifest.json');
+const FETCH_STATUS_PATH = path.join(DATA_DIR, '.fetch-status.json');
 
 // usfm-js is an app dependency (installed via npm, baked into Docker image)
 let usfm;
@@ -42,7 +43,7 @@ const GOOGLE = {
       biblical_phrases: 1459152614,
     },
   },
-  templates: { sheetId: '1ot6A7RxcsxM_Wv94sauoTAaRPO5Q-gynFqMHeldnM64', gid: 0 },
+  templates: { sheetId: '1ot6A7RxcsxM_Wv94sauoTAaRPO5Q-gynFqMHeldnM64', gid: 1419396008 },
   issuesResolved: { docId: '1C0C7Qsm78fM0tuLyVZEAs-IWtClNo9nqbsAZkAFeFio' },
 };
 
@@ -204,10 +205,15 @@ async function fetchDoor43Data(books, force, manifest, log) {
 
 // ── Step 4: Fetch Google Sheets/Docs ───────────────────────────────────────
 
-async function fetchGoogleData(force, log) {
+async function fetchGoogleData(force, log, fetchErrors) {
   log('Fetching Google Sheets/Docs...');
   var glossaryDir = path.join(DATA_DIR, 'glossary');
   ensureDir(glossaryDir);
+
+  function recordFailure(file, err) {
+    fetchErrors.push({ file: file, message: err.message, attemptedAt: new Date().toISOString() });
+    log('Warning: ' + file + ': ' + err.message);
+  }
 
   var tabEntries = Object.entries(GOOGLE.glossary.tabs);
   for (var gi = 0; gi < tabEntries.length; gi++) {
@@ -218,7 +224,7 @@ async function fetchGoogleData(force, log) {
       var url = 'https://docs.google.com/spreadsheets/d/' + GOOGLE.glossary.sheetId + '/export?format=csv&gid=' + gid;
       fs.writeFileSync(dest, '# Fetched: ' + today() + '\n' + stripBom(await httpFetch(url)));
       log('  ' + name + '.csv');
-    } catch (err) { log('Warning: ' + name + '.csv: ' + err.message); }
+    } catch (err) { recordFailure(name + '.csv', err); }
   }
 
   var templatesDest = path.join(DATA_DIR, 'templates.csv');
@@ -227,7 +233,7 @@ async function fetchGoogleData(force, log) {
       var tUrl = 'https://docs.google.com/spreadsheets/d/' + GOOGLE.templates.sheetId + '/export?format=csv&gid=' + GOOGLE.templates.gid;
       fs.writeFileSync(templatesDest, '# Fetched: ' + today() + '\n' + stripBom(await httpFetch(tUrl)));
       log('  templates.csv');
-    } catch (err) { log('Warning: templates.csv: ' + err.message); }
+    } catch (err) { recordFailure('templates.csv', err); }
   }
 
   var issuesDest = path.join(DATA_DIR, 'issues_resolved.txt');
@@ -236,8 +242,26 @@ async function fetchGoogleData(force, log) {
       var iUrl = 'https://docs.google.com/document/d/' + GOOGLE.issuesResolved.docId + '/export?format=txt';
       fs.writeFileSync(issuesDest, '# Fetched: ' + today() + '\n' + stripBom(await httpFetch(iUrl)));
       log('  issues_resolved.txt');
-    } catch (err) { log('Warning: issues_resolved.txt: ' + err.message); }
+    } catch (err) { recordFailure('issues_resolved.txt', err); }
   }
+}
+
+function readFetchStatus() {
+  if (!fs.existsSync(FETCH_STATUS_PATH)) return { lastRun: null, lastSuccess: null, errors: [] };
+  try { return JSON.parse(fs.readFileSync(FETCH_STATUS_PATH, 'utf-8')); }
+  catch (e) { return { lastRun: null, lastSuccess: null, errors: [] }; }
+}
+
+function writeFetchStatus(fetchErrors) {
+  ensureDir(DATA_DIR);
+  var prev = readFetchStatus();
+  var now = new Date().toISOString();
+  var status = {
+    lastRun: now,
+    lastSuccess: fetchErrors.length === 0 ? now : (prev.lastSuccess || null),
+    errors: fetchErrors,
+  };
+  fs.writeFileSync(FETCH_STATUS_PATH, JSON.stringify(status, null, 2));
 }
 
 // ── Step 5: Extract unaligned English via usfm-js ──────────────────────────
@@ -671,8 +695,10 @@ async function curatePublishedData(opts) {
     newBooks = await fetchDoor43Data(releaseInfo.books, force, manifest, log);
   }
 
+  var fetchErrors = [];
   if (runStep('fetch-google')) {
-    await fetchGoogleData(force, log);
+    await fetchGoogleData(force, log, fetchErrors);
+    writeFetchStatus(fetchErrors);
   }
 
   var ultAlignments = new Map();
@@ -697,7 +723,7 @@ async function curatePublishedData(opts) {
   });
 
   log('Done.');
-  return { success: true, messages: messages, release: releaseInfo.tag, books: releaseInfo.books, newBooks: newBooks };
+  return { success: true, messages: messages, release: releaseInfo.tag, books: releaseInfo.books, newBooks: newBooks, fetchErrors: fetchErrors };
 }
 
-module.exports = { curatePublishedData };
+module.exports = { curatePublishedData, readFetchStatus, FETCH_STATUS_PATH };

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -15,6 +15,7 @@ const { listCheckpoints } = require('./pipeline-checkpoints');
 const { handleTnQuickRequest } = require('./api/tn-quick');
 const { handleStartRequest, handleStatusRequest } = require('./api/pipeline');
 const { loadCache: loadVerseDataCache } = require('./api-runner/verse-data');
+const { readFetchStatus } = require('./curate-data');
 
 const ADMIN_PORT = Number(process.env.PORT || 8080);
 const MCP_PORT = Number(process.env.MCP_PORT || 3001);
@@ -28,6 +29,9 @@ const PROCESS_STARTED_AT_MS = Number(process.env.PROCESS_STARTED_AT_MS || Date.n
 // generation steps, which can spend more than an hour inside one model call.
 const CHECKPOINT_FRESHNESS_MINUTES = Number(process.env.PIPELINE_HEALTH_FRESHNESS_MINUTES || 12 * 60);
 const CHECKPOINT_FRESHNESS_MS = CHECKPOINT_FRESHNESS_MINUTES * 60 * 1000;
+
+// Weekly refresh runs Thursdays. 10-day staleness allows for one missed run.
+const FETCH_STALE_MS = 10 * 24 * 60 * 60 * 1000;
 
 function getActivePipelines() {
   const now = Date.now();
@@ -705,6 +709,21 @@ function createHttpServer() {
         active: pipelines.length,
         processStartedAt: new Date(PROCESS_STARTED_AT_MS).toISOString(),
         pipelines,
+      }));
+      return;
+    }
+
+    if (req.method === 'GET' && urlPath === '/health/data-freshness') {
+      const status = readFetchStatus();
+      const lastRunMs = status.lastRun ? Date.parse(status.lastRun) : NaN;
+      const stale = !Number.isFinite(lastRunMs) || (Date.now() - lastRunMs) > FETCH_STALE_MS;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        lastRun: status.lastRun,
+        lastSuccess: status.lastSuccess,
+        stale,
+        errorCount: (status.errors || []).length,
+        errors: status.errors || [],
       }));
       return;
     }


### PR DESCRIPTION
## Summary
- Fix `templates.csv` fetch — Google Sheet tab moved from `gid=0` to `gid=1419396008`, causing the weekly cron to silently fail for ~8 weeks (last good fetch 2026-03-23).
- Stop swallowing per-source Google fetch errors — structured `fetchErrors[]` written to `data/.fetch-status.json`; cron now logs a loud `[weekly-refresh] FAILED: …` / `OK: …` summary line.
- Add `GET /health/data-freshness` endpoint alongside `/health/pipelines` for external monitoring; `stale: true` when `lastRun` is older than 10 days.

## Test plan
- [x] `curl -sIL …/export?format=csv&gid=1419396008` → 200, text/csv, 51 KB
- [x] Local fetch run with `CSKILLBP_DIR=/tmp/...` → all 7 Google sources OK, `fetchErrors: []`, `.fetch-status.json` written with correct shape, `templates.csv` has fresh header + valid CSV
- [x] Negative test (gid=0 reverted, then restored): structured error captured in `fetchErrors[]` and in `.fetch-status.json`, other sources still fetched
- [x] Cron callback simulation → `[weekly-refresh] OK: all sources refreshed` line appears
- [x] Health handler smoke test: fresh shows `stale: false`; backdating `lastRun` 11 days flips it to `stale: true` with `lastSuccess` preserved
- [x] `node --check` on all 3 modified files: OK
- [ ] Post-merge: `curl https://uw-bt-bot.fly.dev/health/data-freshness` after deploy and confirm `errorCount: 0`, `stale: false` once next Thursday refresh runs (or trigger manually via admin DM `curate-data force`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)