### PR TITLE
Fixing expandquote function to include contiguous English words aligned with Hebrew throughout quote

### DIFF
--- a/src/workspace-tools/tn-tools.js
+++ b/src/workspace-tools/tn-tools.js
@@ -970,32 +970,32 @@ function expandAlignedQuoteEdges(entries, quote, normalizeHeb) {
 
     if (!matched) continue;
 
-  let end = start + normalizedQuote.length - 1;
+    let end = start + normalizedQuote.length - 1;
 
-  // Collect ALL Hebrew words represented in the matched span
-  const matchedHebs = new Set();
+    // Collect ALL Hebrew words represented in the matched span
+    const matchedHebs = new Set();
 
-  for (let i = start; i <= end; i++) {
-    matchedHebs.add(normalizeHeb(entries[i].heb));
-  }
+    for (let i = start; i <= end; i++) {
+      matchedHebs.add(normalizeHeb(entries[i].heb));
+    }
 
-  // Expand backward to include contiguous English words
-  // aligned to ANY Hebrew word in the matched span
-  while (
-    start > 0 &&
-    matchedHebs.has(normalizeHeb(entries[start - 1].heb))
-  ) {
-    start--;
-  }
+    // Expand backward to include contiguous English words
+    // aligned to ANY Hebrew word in the matched span
+    while (
+      start > 0 &&
+      matchedHebs.has(normalizeHeb(entries[start - 1].heb))
+    ) {
+      start--;
+    }
 
-  // Expand forward to include contiguous English words
-  // aligned to ANY Hebrew word in the matched span
-  while (
-    end < entries.length - 1 &&
-    matchedHebs.has(normalizeHeb(entries[end + 1].heb))
-  ) {
-    end++;
-  }
+    // Expand forward to include contiguous English words
+    // aligned to ANY Hebrew word in the matched span
+    while (
+      end < entries.length - 1 &&
+      matchedHebs.has(normalizeHeb(entries[end + 1].heb))
+    ) {
+      end++;
+    }
 
     return entries
       .slice(start, end + 1)

--- a/src/workspace-tools/tn-tools.js
+++ b/src/workspace-tools/tn-tools.js
@@ -970,29 +970,32 @@ function expandAlignedQuoteEdges(entries, quote, normalizeHeb) {
 
     if (!matched) continue;
 
-    let end = start + normalizedQuote.length - 1;
+  let end = start + normalizedQuote.length - 1;
 
-    // Get the boundary Hebrew words
-    const firstHeb = normalizeHeb(entries[start].heb);
-    const lastHeb = normalizeHeb(entries[end].heb);
+  // Collect ALL Hebrew words represented in the matched span
+  const matchedHebs = new Set();
 
-    // Expand backward to include ALL immediately preceding
-    // English words aligned to the first Hebrew word
-    while (
-      start > 0 &&
-      normalizeHeb(entries[start - 1].heb) === firstHeb
-    ) {
-      start--;
-    }
+  for (let i = start; i <= end; i++) {
+    matchedHebs.add(normalizeHeb(entries[i].heb));
+  }
 
-    // Expand forward to include ALL immediately following
-    // English words aligned to the last Hebrew word
-    while (
-      end < entries.length - 1 &&
-      normalizeHeb(entries[end + 1].heb) === lastHeb
-    ) {
-      end++;
-    }
+  // Expand backward to include contiguous English words
+  // aligned to ANY Hebrew word in the matched span
+  while (
+    start > 0 &&
+    matchedHebs.has(normalizeHeb(entries[start - 1].heb))
+  ) {
+    start--;
+  }
+
+  // Expand forward to include contiguous English words
+  // aligned to ANY Hebrew word in the matched span
+  while (
+    end < entries.length - 1 &&
+    matchedHebs.has(normalizeHeb(entries[end + 1].heb))
+  ) {
+    end++;
+  }
 
     return entries
       .slice(start, end + 1)


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Added feature to expand English quotes to include all words aligned to the Hebrew selection. That includes words like opening “and” that are aligned to a word later in the phrase. 

#### Please include detailed Test instructions for your pull request:
This is from alignment_data.json: "11:2": [ { "eng": "And", "heb": "וְ⁠נָחָ֥ה", "heb_pos": 0, "strong": "c:H5117" }, { "eng": "the", "heb": "ר֣וּחַ", "heb_pos": 0, "strong": "H7307" }, { "eng": "Spirit", "heb": "ר֣וּחַ", "heb_pos": 0, "strong": "H7307" }, { "eng": "of", "heb": "ר֣וּחַ", "heb_pos": 0, "strong": "H7307" }, { "eng": "Yahweh", "heb": "יְהוָ֑ה", "heb_pos": 0, "strong": "H3068" }, { "eng": "will", "heb": "וְ⁠נָחָ֥ה", "heb_pos": 0, "strong": "c:H5117" }, { "eng": "rest", "heb": "וְ⁠נָחָ֥ה", "heb_pos": 0, "strong": "c:H5117"}.

When the original snippet is “the Spirit of Yahweh will rest”, the code should expand the English quote to include “And,” since it is aligned to a Hebrew word in the phrase, even though that Hebrew word is not first. Nothing else should change. 

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
