### PR TITLE
updating fill_quotes.py re:exact_ult_span

### DIFF
--- a/src/fill_quotes.py
+++ b/src/fill_quotes.py
@@ -773,7 +773,7 @@ def update_json_from_tsv(json_file, origl_and_snippet):
                 item["writer_packet"]["orig_quote"] = hebrew_phrase
                 item["writer_packet"]["gl_quote"] = english_phrase
                 item["writer_packet"]["issue_span_gl_quote"] = english_phrase
-                item["exact_ult_span"] = english_phrase
+                item["writer_packet"]["exact_ult_span"] = english_phrase
         
         if hebrew_phrase == '':
             if english_phrase == '':

--- a/src/fill_quotes.py
+++ b/src/fill_quotes.py
@@ -766,12 +766,14 @@ def update_json_from_tsv(json_file, origl_and_snippet):
             item["orig_quote"] = hebrew_phrase
             item["gl_quote"] = english_phrase
             item["issue_span_gl_quote"] = english_phrase
+            item["exact_ult_span"] = english_phrase
 
             # Nested writer_packet replacements
             if "writer_packet" in item:
                 item["writer_packet"]["orig_quote"] = hebrew_phrase
                 item["writer_packet"]["gl_quote"] = english_phrase
                 item["writer_packet"]["issue_span_gl_quote"] = english_phrase
+                item["exact_ult_span"] = english_phrase
         
         if hebrew_phrase == '':
             if english_phrase == '':

--- a/src/fill_quotes.py
+++ b/src/fill_quotes.py
@@ -784,12 +784,14 @@ def update_json_from_tsv(json_file, origl_and_snippet):
                 item["orig_quote"] = english_phrase
                 item["gl_quote"] = english_phrase
                 item["issue_span_gl_quote"] = english_phrase
-
+                item["exact_ult_span"] = english_phrase
+                
                 # Nested writer_packet replacements
                 if "writer_packet" in item:
                     item["writer_packet"]["orig_quote"] = english_phrase
                     item["writer_packet"]["gl_quote"] = english_phrase
                     item["writer_packet"]["issue_span_gl_quote"] = english_phrase
+                    item["writer_packet"]["exact_ult_span"] = english_phrase
 
     def safe_write_json(json_file, data):
         # 1. Write to temp file in same directory

--- a/src/fill_quotes.py
+++ b/src/fill_quotes.py
@@ -728,6 +728,7 @@ def update_json_from_tsv(json_file, origl_and_snippet):
         - all orig_quote fields
         - all gl_quote fields
         - all issue_span_gl_quote fields
+        - all exact_ult_span fields
     """
 
     # Load JSON
@@ -785,7 +786,7 @@ def update_json_from_tsv(json_file, origl_and_snippet):
                 item["gl_quote"] = english_phrase
                 item["issue_span_gl_quote"] = english_phrase
                 item["exact_ult_span"] = english_phrase
-                
+
                 # Nested writer_packet replacements
                 if "writer_packet" in item:
                     item["writer_packet"]["orig_quote"] = english_phrase


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
fill_quotes.py has been adapted to replace exact_ult_span in prepared_notes.json. This field is fed to AT generation, so it needs to be the same as the other English quote fields. 

#### Please include detailed Test instructions for your pull request:
If fill_quotes.py successfully reads and updates prepared_notes.json, including now also exact_ult_span, the code is successful. 

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
