### PR TITLE
Stephen wunrow patch 1

### DIFF
--- a/src/workspace-tools/usfm-tools.js
+++ b/src/workspace-tools/usfm-tools.js
@@ -276,15 +276,25 @@ function createAlignedUsfm({ hebrew, mapping, source, output, chapter, verse, us
       maxBuffer: 10 * 1024 * 1024,
       timeout: 30000,
     });
-    if (output) {
-      console.log(`Aligned USFM written to ${output}`);
-      const repairResult = repairAlignmentXContent({
+
+    if (!output) {
+      return result;
+    }
+
+    console.log(`Aligned USFM written to ${output}`);
+
+    let repairResult;
+    try {
+      repairResult = repairAlignmentXContent({
         alignedUsfm: output,
         hebrewUsfm: hebrew,
       });
-      return `Aligned USFM written to ${output}.\nX-content and lemma byte repair completed:\n${repairResult}`;
+    } catch (repairErr) {
+      return `Aligned USFM written to ${output}.\nRepair step failed: ${repairErr.message}`;
     }
-    return result;
+
+    return `Aligned USFM written to ${output}.\nX-content and lemma byte repair completed:\n${repairResult}`;
+
   } catch (err) {
     const stderr = err.stderr ? err.stderr.toString() : '';
     const msg = stderr || err.message;

--- a/src/workspace-tools/usfm-tools.js
+++ b/src/workspace-tools/usfm-tools.js
@@ -277,7 +277,12 @@ function createAlignedUsfm({ hebrew, mapping, source, output, chapter, verse, us
       timeout: 30000,
     });
     if (output) {
-      return `Aligned USFM written to ${output}`;
+      console.log(`Aligned USFM written to ${output}`);
+      const repairResult = repairAlignmentXContent({
+        alignedUsfm: output,
+        hebrewUsfm: hebrew,
+      });
+      return `Aligned USFM written to ${output}.\nX-content and lemma byte repair completed:\n${repairResult}`;
     }
     return result;
   } catch (err) {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Calling repairAlignmentXContent within the createAlignedUsfm function. 

#### Please include detailed Test instructions for your pull request:
Whenever the createAlignedUsfm is called, after it has written an output usfm file, repairAlignmentXContent should check and replace all wrongly ordered unicode bytes in x-content and lemma fields. This should happen every time, and nothing should change except lemma and x-content.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
