### PR TITLE
Changing "explanation" for logic-result notes

### DIFF
--- a/src/workspace-tools/tn-tools.js
+++ b/src/workspace-tools/tn-tools.js
@@ -452,8 +452,14 @@ function parseExplanationDirectives(explanation) {
     remaining.push(trimmed);
   }
 
+  let cleanExplanation = normalizeWhitespace(remaining.join(' '));
+
+  if (cleanExplanation.includes('reason after result')) {
+    cleanExplanation = 'Reverse: reason after result';
+  }
+
   return {
-    clean_explanation: normalizeWhitespace(remaining.join(' ')),
+    clean_explanation: cleanExplanation,
     must_include: mustInclude,
     template_hints: templateHints,
   };


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Many logic-result notes included an explanation field that indicated that the issue was that the result came before the reason. However, these notes were then usually identified as "for" notes. Change introduced in parsing of explanation that adds the word "reverse" to explanation. Hopefully this triggers the "reverse" template.

#### Please include detailed Test instructions for your pull request:
issues.tsv will sometimes include logic-result note suggestions that include in the explanation that "reason after result" (sometimes along with something like "for means because"). In these cases, the explanation parser should replace the whole field with "Reverse: reason after result." This should trigger the "reverse" template instead of the "for" template in prepared_notes.json.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
