### PR TITLE
Increase Fly.io VM resources: 4GB memory and 2 CPUs

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -30,9 +30,9 @@ kill_timeout = 30
   processes = ["app"]
 
 [[vm]]
-  memory = "2gb"
+  memory = "4gb"
   cpu_kind = "shared"
-  cpus = 1
+  cpus = 2
 
 [[mounts]]
   source = "workspace_vol"


### PR DESCRIPTION
## Summary
Scale up the Fly.io VM resources to improve performance and reliability of the `uw-bt-bot` application.

## Changes
- **Memory**: Increased from 2GB to 4GB
- **CPU count**: Increased from 1 to 2 (shared CPU kind)

## Rationale
These resource increases provide headroom for pipeline processing and concurrent operations, reducing the risk of memory pressure or CPU throttling during heavy workloads.

https://claude.ai/code/session_01DMkLaYhfU1QdqzDnWKQdaB