### PR TITLE
Tag claude-runner logs with per-job label (book/chapter/step)

### DIFF
--- a/src/claude-runner.js
+++ b/src/claude-runner.js
@@ -168,6 +168,7 @@ function buildOptions({
 
 async function runClaudeOnce({
   prompt,
+  label,
   cwd,
   resume,
   model,
@@ -199,6 +200,13 @@ async function runClaudeOnce({
   const queryStart = Date.now();
   const queryDeadline = queryStart + timeout;
   const queryId = Math.random().toString(36).slice(2, 8);
+  // Human-readable job tag for the logs (e.g. "NUM 23 UST-gen", "HOS 6 tn-writer").
+  // Threaded onto every line this query emits so concurrent pipeline runs stay
+  // attributable in the interleaved fly.io log stream. Falls back to just the
+  // query id when no label is supplied.
+  const idTag = label ? `${label} q=${queryId}` : `q=${queryId}`;
+  const runnerPrefix = `[claude-runner ${idTag}]`;
+  const claudePrefix = `[claude ${idTag}]`;
   let localTimeoutFired = false;
   const toolErrorSigs = new Map();
   let consecutiveToolErrors = 0;
@@ -210,7 +218,7 @@ async function runClaudeOnce({
     // Positive = event loop was busy and couldn't service the timer on schedule.
     const driftMs = elapsedMs - timeout;
     console.warn(
-      `[claude-runner q=${queryId}] Timeout fired — ` +
+      `${runnerPrefix} Timeout fired — ` +
       `configured=${timeout}ms elapsed=${elapsedMs}ms drift=${driftMs}ms ` +
       `turns=${turnCount} lastTool=${lastTool || 'none'} — aborting query`
     );
@@ -248,9 +256,9 @@ async function runClaudeOnce({
     thinking,
   });
 
-  console.log(`[claude-runner q=${queryId}] Starting query in ${cwd}`);
-  console.log(`[claude-runner q=${queryId}] Prompt: ${fullPrompt.slice(0, 200)}`);
-  console.log(`[claude-runner q=${queryId}] maxTurns: ${options.maxTurns}, timeout: ${timeout / 1000}s, deadline: ${new Date(queryDeadline).toISOString()}`);
+  console.log(`${runnerPrefix} Starting query in ${cwd}`);
+  console.log(`${runnerPrefix} Prompt: ${fullPrompt.slice(0, 200)}`);
+  console.log(`${runnerPrefix} maxTurns: ${options.maxTurns}, timeout: ${timeout / 1000}s, deadline: ${new Date(queryDeadline).toISOString()}`);
 
   const conversation = query({ prompt: fullPrompt, options });
 
@@ -261,11 +269,11 @@ async function runClaudeOnce({
       if (message.type === 'assistant' && message.message?.content) {
         for (const block of message.message.content) {
           if ('text' in block) {
-            console.log(`[claude] ${block.text.slice(0, 200)}`);
+            console.log(`${claudePrefix} ${block.text.slice(0, 200)}`);
           } else if ('name' in block) {
             turnCount++;
             lastTool = block.name;
-            console.log(`[claude] Tool: ${block.name}(${JSON.stringify(block.input || {}).slice(0, 150)})`);
+            console.log(`${claudePrefix} Tool: ${block.name}(${JSON.stringify(block.input || {}).slice(0, 150)})`);
           }
         }
       } else if (message.type === 'result') {
@@ -304,17 +312,17 @@ async function runClaudeOnce({
           consecutiveToolErrors = 0;
         }
         if (text.includes('command-stderr') || text.includes('Error')) {
-          console.error(`[claude-runner] SDK user message (error): ${text.slice(0, 500)}`);
+          console.error(`${runnerPrefix} SDK user message (error): ${text.slice(0, 500)}`);
         } else {
-          console.log(`[claude-runner] SDK user message: ${text.slice(0, 300)}`);
+          console.log(`${runnerPrefix} SDK user message: ${text.slice(0, 300)}`);
         }
       } else if (message.type === 'system') {
-        console.log(`[claude-runner] SDK system: ${message.subtype || 'unknown'} ${JSON.stringify(message).slice(0, 200)}`);
+        console.log(`${runnerPrefix} SDK system: ${message.subtype || 'unknown'} ${JSON.stringify(message).slice(0, 200)}`);
         if (message.subtype === 'init' && Array.isArray(message.tools)) {
-          console.log(`[claude-runner] SDK init tools: ${message.tools.join(', ')}`);
+          console.log(`${runnerPrefix} SDK init tools: ${message.tools.join(', ')}`);
         }
       } else {
-        console.log(`[claude-runner] SDK event: ${message.type}${message.subtype ? '/' + message.subtype : ''}`);
+        console.log(`${runnerPrefix} SDK event: ${message.type}${message.subtype ? '/' + message.subtype : ''}`);
       }
       if (guardrails && Number(guardrails.maxToolCalls || 0) > 0 && turnCount >= Number(guardrails.maxToolCalls)) {
         throw new Error(`Guardrail stop: max tool calls exceeded (${turnCount}/${guardrails.maxToolCalls})`);
@@ -325,7 +333,7 @@ async function runClaudeOnce({
       const elapsedMs = Date.now() - queryStart;
       const driftMs = elapsedMs - timeout;
       console.warn(
-        `[claude-runner q=${queryId}] Query aborted — ` +
+        `${runnerPrefix} Query aborted — ` +
         `elapsed=${elapsedMs}ms${localTimeoutFired ? ` drift=${driftMs}ms` : ''} ` +
         `turns=${turnCount} lastTool=${lastTool || 'none'} ` +
         `reason=${localTimeoutFired ? 'timeout_local_abort' : 'external_abort'}`
@@ -335,7 +343,7 @@ async function runClaudeOnce({
       const msg = (err.message || '').toLowerCase();
       const isRateLimit = msg.includes('rate limit') || msg.includes('429') || msg.includes('too many requests');
       if (isRateLimit) {
-        console.warn(`[claude-runner] Rate limit detected -- calibrating window budget`);
+        console.warn(`${runnerPrefix} Rate limit detected -- calibrating window budget`);
         try {
           const room = await getHeadroom();
           recordRateLimit({ windowUsed: room.used, source: 'claude-runner-error' });
@@ -350,15 +358,15 @@ async function runClaudeOnce({
   }
 
   if (result) {
-    console.log(`[claude-runner q=${queryId}] Finished — subtype: ${result.subtype}, turns: ${result.num_turns}, cost: $${result.total_cost_usd?.toFixed(4) || '?'}, duration: ${(result.duration_ms / 1000).toFixed(1)}s`);
+    console.log(`${runnerPrefix} Finished — subtype: ${result.subtype}, turns: ${result.num_turns}, cost: $${result.total_cost_usd?.toFixed(4) || '?'}, duration: ${(result.duration_ms / 1000).toFixed(1)}s`);
     if (result.subtype !== 'success' && result.result) {
-      console.error(`[claude-runner q=${queryId}] Result text: ${result.result.slice(0, 500)}`);
+      console.error(`${runnerPrefix} Result text: ${result.result.slice(0, 500)}`);
     }
     // Detect rate limit in result subtype or error message
     const resultMsg = (result.subtype || '') + ' ' + (result.error || '');
     const isRateLimit = /rate.?limit|429|too.many.requests/i.test(resultMsg);
     if (isRateLimit) {
-      console.warn(`[claude-runner q=${queryId}] Rate limit in result subtype -- calibrating window budget`);
+      console.warn(`${runnerPrefix} Rate limit in result subtype -- calibrating window budget`);
       try {
         const room = await getHeadroom();
         recordRateLimit({ windowUsed: room.used, source: 'claude-runner-result' });
@@ -374,7 +382,7 @@ async function runClaudeOnce({
   if (localTimeoutFired || abortController.signal.aborted) {
     const driftMs = elapsedMs - timeout;
     console.warn(
-      `[claude-runner q=${queryId}] Returning timeout outcome — ` +
+      `${runnerPrefix} Returning timeout outcome — ` +
       `reason=timeout_local_abort elapsed=${elapsedMs}ms configured=${timeout}ms drift=${driftMs}ms`
     );
     return {
@@ -389,7 +397,7 @@ async function runClaudeOnce({
       lastTool,
     };
   }
-  console.warn(`[claude-runner q=${queryId}] Query ended without a result message (elapsed=${elapsedMs}ms) — reason=no_result_message`);
+  console.warn(`${runnerPrefix} Query ended without a result message (elapsed=${elapsedMs}ms) — reason=no_result_message`);
   return {
     subtype: 'no_result',
     reason: 'no_result_message',
@@ -463,6 +471,9 @@ async function runClaude(args) {
   let attempt = 0;
   let lastTransientMessage = '';
   let firstDowntimeNoticeSent = false;
+  // Job tag for the wrapper's own retry/backoff lines. Each runClaudeOnce()
+  // attempt mints its own q= id, so the wrapper carries only the label.
+  const labelPrefix = args?.label ? `[claude-runner ${args.label}]` : '[claude-runner]';
 
   while (true) {
     attempt++;
@@ -496,7 +507,7 @@ async function runClaude(args) {
           );
         }
         const delay = backoffDelayMs(attempt);
-        console.warn(`[claude-runner] Transient non-success result, retrying in ${Math.round(delay / 1000)}s (attempt ${attempt})`);
+        console.warn(`${labelPrefix} Transient non-success result, retrying in ${Math.round(delay / 1000)}s (attempt ${attempt})`);
         await sleep(delay);
         continue;
       }
@@ -525,7 +536,7 @@ async function runClaude(args) {
           );
         }
         const delay = backoffDelayMs(attempt);
-        console.warn(`[claude-runner] Transient SDK error, retrying in ${Math.round(delay / 1000)}s (attempt ${attempt}): ${msg.slice(0, 200)}`);
+        console.warn(`${labelPrefix} Transient SDK error, retrying in ${Math.round(delay / 1000)}s (attempt ${attempt}): ${msg.slice(0, 200)}`);
         await sleep(delay);
         continue;
       }
@@ -554,6 +565,7 @@ async function runClaude(args) {
  */
 async function runClaudeStream({
   prompt,
+  label,
   cwd,
   resume,
   model,
@@ -573,8 +585,9 @@ async function runClaudeStream({
   const wsTools = await createFreshWorkspaceToolsServer();
   const abortController = new AbortController();
   const timeout = timeoutMs || DEFAULT_TIMEOUT_MS;
+  const streamPrefix = label ? `[claude-runner ${label}]` : '[claude-runner]';
   const timer = setTimeout(() => {
-    console.warn(`[claude-runner] Timeout reached (${timeout / 1000}s) — aborting stream`);
+    console.warn(`${streamPrefix} Timeout reached (${timeout / 1000}s) — aborting stream`);
     abortController.abort();
   }, timeout);
 
@@ -595,7 +608,7 @@ async function runClaudeStream({
     thinking,
   });
 
-  console.log(`[claude-runner] Starting stream in ${cwd}${resume ? ` (resume: ${resume.slice(0, 8)}…)` : ''}`);
+  console.log(`${streamPrefix} Starting stream in ${cwd}${resume ? ` (resume: ${resume.slice(0, 8)}…)` : ''}`);
   const conversation = query({ prompt, options });
 
   function cleanup() {

--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -610,6 +610,7 @@ async function generatePipeline(route, message) {
         } else if (runInitialSkill) {
           claudeResult = await runClaude({
             prompt: initialPrompt,
+            label: `${skillRef} ${skill}`,
             cwd: CSKILLBP_DIR,
             model,
             betas,
@@ -780,6 +781,7 @@ async function generatePipeline(route, message) {
                 missing: initialPipelineStatus.missing,
                 observed: observedArtifacts,
               }),
+              label: `${book} ${ch} ${skill} (cont)`,
               cwd: CSKILLBP_DIR,
               model,
               betas,
@@ -1061,6 +1063,7 @@ async function generatePipeline(route, message) {
       const alignTypeFlags = [contentTypes.includes('ult') && '--ult', contentTypes.includes('ust') && '--ust'].filter(Boolean).join(' ');
       const alignResult = await runClaude({
         prompt: `${alignRef} ${alignTypeFlags}${genCtxFlag}`,
+        label: `${alignRef} align-all-parallel`,
         cwd: CSKILLBP_DIR,
         model: model || 'sonnet',  // mechanical alignment — Sonnet suffices at lower cost
         betas,
@@ -1180,6 +1183,7 @@ async function generatePipeline(route, message) {
         await status(`Retrying **align-all-parallel** for ${book} ${ch} after degraded alignment check...`);
         const retryResult = await runClaude({
           prompt: `${alignRef} ${alignTypeFlags}${genCtxFlag}`,
+          label: `${alignRef} align-all-parallel (retry)`,
           cwd: CSKILLBP_DIR,
           model: model || 'sonnet',
           betas,

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -470,6 +470,7 @@ async function runPerNoteGeneration({ pipeDir, outputPath, status, book }) {
     try {
       const result = await runClaude({
         prompt,
+        label: `${item.reference || book} note`,
         cwd: CSKILLBP_DIR,
         model: 'sonnet',
         maxTurns: 2,
@@ -679,6 +680,7 @@ async function runATGeneration({ notesPath, pipeDir, status }) {
       // Step 1: Generate AT with Sonnet via SDK
       const atResult = await runClaude({
         prompt: userPrompt,
+        label: `${packet.reference || 'AT'} AT-gen`,
         cwd: CSKILLBP_DIR,
         model: 'sonnet',
         maxTurns: 2,
@@ -716,6 +718,7 @@ async function runATGeneration({ notesPath, pipeDir, status }) {
 
       const valResult = await runClaude({
         prompt: validatorPrompt,
+        label: `${packet.reference || 'AT'} AT-val`,
         cwd: CSKILLBP_DIR,
         model: 'haiku',
         maxTurns: 2,
@@ -743,6 +746,7 @@ async function runATGeneration({ notesPath, pipeDir, status }) {
 
       const retryResult = await runClaude({
         prompt: retryPrompt,
+        label: `${packet.reference || 'AT'} AT-retry`,
         cwd: CSKILLBP_DIR,
         model: 'sonnet',
         maxTurns: 2,
@@ -1518,6 +1522,7 @@ async function runParallelTnWriter({
       const toolConfig = getSkillToolConfig('tn-writer');
       return runClaude({
         prompt,
+        label: `${book} ${ch} tn-writer shard ${i}${vRange ? ` v${vRange}` : ''}`,
         cwd: CSKILLBP_DIR,
         model: model || undefined,
         skill: 'tn-writer',
@@ -2329,6 +2334,7 @@ async function notesPipeline(route, message) {
           console.log(`[notes] Starting skill ${skill.name} for ${ref}`);
           result = await runClaude({
             prompt: skill.prompt,
+            label: `${ref} ${skill.name}`,
             cwd: CSKILLBP_DIR,
             model: model || skill.model, // TEST_FAST haiku overrides per-skill model
             skill: skill.name,
@@ -2678,6 +2684,7 @@ async function notesPipeline(route, message) {
             `Do not create scratch scripts and do not perform open-ended manual JSON surgery loops.`;
           await runClaude({
             prompt: rescuePrompt,
+            label: `${ref} tn-quality-check (rescue)`,
             cwd: CSKILLBP_DIR,
             model: model || 'sonnet',
             skill: 'tn-quality-check',

--- a/src/self-diagnosis.js
+++ b/src/self-diagnosis.js
@@ -257,6 +257,7 @@ async function runDiagnosisAgent({ contextSummary, runClaudeImpl }) {
   const runner = runClaudeImpl || runClaude;
   const result = await runner({
     prompt: contextSummary,
+    label: 'self-diagnosis',
     cwd: process.cwd(),
     model: 'sonnet',
     allowedTools: ['Read', 'Grep'],

--- a/src/test-skill.js
+++ b/src/test-skill.js
@@ -65,6 +65,7 @@ async function runSDK(opts) {
 
   const options = {
     prompt: opts.prompt,
+    label: `test ${opts.skill}`,
     cwd: CSKILLBP_DIR,
     model: opts.model,
     skill: opts.skill,

--- a/src/tqs-pipeline.js
+++ b/src/tqs-pipeline.js
@@ -259,6 +259,7 @@ async function tqsPipeline(route, message) {
     try {
       result = await runClaude({
         skill: 'tq-writer',
+        label: `${ref} tq-writer`,
         model: 'sonnet',
         cwd: CSKILLBP_DIR,
         prompt: `Write translation questions for ${book} chapter ${chapter}.`,


### PR DESCRIPTION
## What

Adds a human-readable **job label** to the `claude-runner` log lines so a human scanning the fly.io log can immediately tell which job a burst of output belongs to — e.g. `NUM 23 UST-gen`, `HOS 6 tn-writer`, `GEN 5 tq-writer`.

## Why

Pipelines run **2–5 at a time** (fire-and-forget, per-scope dedup only), so their log lines interleave in the single fly.io stream. Today a line like `[claude] riches` or `[claude] Tool: Grep(...)` is unattributable — there's no way to tell which book/chapter/step produced it.

## How

`runClaudeOnce` now accepts an optional `label` and builds a single tag that prefixes **every line the query emits** — assistant text (`[claude …]`), tool calls, SDK events, and all `[claude-runner …]` lifecycle/timeout lines — alongside the existing `q=<id>`:

```
[claude HOS 6 notes q=0p4xu8] riches
[claude HOS 6 notes q=0p4xu8] Tool: Grep({"pattern":"wholly burned"...})
[claude-runner HOS 6 notes q=0p4xu8] Finished — subtype: success, turns: 1
[claude-runner NUM 23 UST-gen q=3jqf3e] Starting query in /data/workspace
```

The retry wrapper and `runClaudeStream` carry the label too. When no label is passed the format is unchanged (`q=<id>` only), so it's **backward-compatible** — nothing that greps the `[claude-runner` prefix (deploy health-check notes, self-diagnosis boundary detection) breaks.

All **14 call sites** pass a label built from in-scope `book`/`chapter`/step:

| Pipeline | Example label |
|---|---|
| generate (initial / continuation) | `NUM 23 initial-pipeline`, `NUM 23 UST-gen`, `… (cont)` |
| generate (alignment) | `NUM 23 align-all-parallel`, `… (retry)` |
| notes (chapter skill) | `HOS 6 tn-writer`, `HOS 6 tn-quality-check` |
| notes (parallel shards) | `HOS 6 tn-writer shard 2 v19-36` |
| notes (per-note / per-AT sub-agents) | `HOS 6:4 note`, `HOS 6:4 AT-gen` / `AT-val` / `AT-retry` |
| tqs | `GEN 5 tq-writer` |
| self-diagnosis / test-skill | `self-diagnosis`, `test post-edit-review` |

Real skill names are used (e.g. `initial-pipeline`, which produces both ULT and UST) rather than invented descriptions.

## Testing

- `node --check` passes on all 6 edited files.
- Full suite: **254 pass, 3 fail, 2 skipped**. The 3 failures (`check_tn_quality`, two `fillOrigQuotes`) are in `tn-tools`/`quality-tools` — files this PR does not touch — and fail identically on a clean `main`. This change adds **zero** regressions.

## Notes for reviewer

- No log-parsing code depends on the exact prefix format; the change preserves the `[claude-runner`/`[claude` substrings that human/grep checks rely on.
- Spotted (out of scope, not addressed here): `notes-pipeline.js` has 5 leftover debug `fetch` blocks POSTing pipeline internals to a hardcoded `localhost:7282` on every run — worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)