### PR TITLE
Graceful degradation on tn-quality-check guardrail stop + structured edit tools

### DIFF
--- a/config.json
+++ b/config.json
@@ -127,6 +127,8 @@
     "tnWriterParallelMinVerses": 35,
     "tnWriterMaxTurns": 400,
     "tnWriterMaxToolCalls": 400,
-    "rescueMaxPasses": 1
+    "rescueMaxPasses": 1,
+    "qualityCheckMaxConsecutiveToolErrors": 6,
+    "qualityCheckMaxRepeatedToolErrorSignature": 5
   }
 }

--- a/src/claude-runner.js
+++ b/src/claude-runner.js
@@ -443,6 +443,14 @@ function isTransientOutageError(err) {
   return false;
 }
 
+// True for any guardrail-stop the runner throws/returns (repeated tool errors,
+// max tool calls, or token budget). Callers use this to distinguish a "ran out
+// of budget / looping" stop from a genuine crash or transient outage.
+function isGuardrailStop(err) {
+  const msg = typeof err === 'string' ? err : (err && err.message) || String(err || '');
+  return /Guardrail stop:/i.test(msg);
+}
+
 function backoffDelayMs(attempt) {
   const exp = Math.min(RETRY_MAX_DELAY_MS, RETRY_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1)));
   const jitter = Math.floor(Math.random() * 2000);
@@ -627,6 +635,7 @@ module.exports = {
   DEFAULT_RESTRICTED_TOOLS,
   ClaudeTransientOutageError,
   isTransientOutageError,
+  isGuardrailStop,
   THINKING_LOW,
   THINKING_MEDIUM,
   THINKING_HIGH,

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -12,7 +12,7 @@ const path = require('path');
 const config = require('./config');
 const { spawn } = require("child_process");
 const { sendMessage, sendDM, addReaction, removeReaction } = require('./zulip-client');
-const { runClaude, DEFAULT_RESTRICTED_TOOLS, isTransientOutageError } = require('./claude-runner');
+const { runClaude, DEFAULT_RESTRICTED_TOOLS, isTransientOutageError, isGuardrailStop } = require('./claude-runner');
 const { getDoor43Username, emailToFallbackUsername, buildBranchName, resolveOutputFile, discoverFreshOutput, checkPrerequisites, calcSkillTimeout, normalizeBookName, resolveConflictMention, parsePartialTsv, truncatePartialTsv, parseChunkRange, CSKILLBP_DIR } = require('./pipeline-utils');
 const { splitTsv, fixTrailingNewlines } = require('./workspace-tools/tsv-tools');
 const { fillTsvIds, generateIds, prepareNotes, fillOrigQuotes, resolveGlQuotes, flagNarrowQuotes, extractAlignmentData, prepareATContext, substituteAT, fixUnicodeQuotes, verifyBoldMatches, syncCanonicalHebrewQuotes, applyHintsToPreparedNotes, _stripAlternateTranslation: stripAlternateTranslation } = require('./workspace-tools/tn-tools');
@@ -49,7 +49,12 @@ const TN_QUALITY_CHECK_HINT =
   'Do not guess alternate file paths or probe missing runtime files outside context.json. ' +
   'Do the full semantic review (Steps 3a-3j), fix issues found, then re-run check_tn_quality ' +
   'at most once to verify fixes. If issues still persist after that one re-check, report them ' +
-  'as unresolved and stop. Do not loop further.';
+  'as unresolved and stop. Do not loop further. ' +
+  'To apply fixes, use the structured tools update_note_text / update_prepared_quote / remove_note ' +
+  '(they locate items by id) — never hand-Edit generated_notes.json or prepared_notes.json. ' +
+  'If any Edit returns "string to replace not found", do NOT retry that edit: re-Read the file once ' +
+  'or switch to the structured tool; if the target still cannot be matched, tag that row as ' +
+  'unresolved and move on.';
 
 const TN_WRITER_HINT =
   'The pipeline has already run all mechanical preparation (prepare_notes, fill_orig_quotes, resolve_gl_quotes, flag_narrow_quotes). ' +
@@ -1243,6 +1248,11 @@ const TN_WRITER_MAX_TURNS = Number((config.notesGuardrails || {}).tnWriterMaxTur
 const TN_WRITER_MAX_TOOL_CALLS = Number((config.notesGuardrails || {}).tnWriterMaxToolCalls || 1000);
 const RESCUE_MAX_PASSES = Number((config.notesGuardrails || {}).rescueMaxPasses || 1);
 const USE_PER_NOTE_GENERATION = Boolean((config.notesGuardrails || {}).usePerNoteGeneration);
+// Tight repeated-error limits for the INITIAL tn-quality-check pass so it bails in minutes
+// (not ~53min) when it loops on edits; Fix 1 then degrades gracefully. The bounded rescue pass
+// keeps its own tighter 2/3 override.
+const TN_QC_MAX_CONSEC = Number((config.notesGuardrails || {}).qualityCheckMaxConsecutiveToolErrors || 6);
+const TN_QC_MAX_REPEAT = Number((config.notesGuardrails || {}).qualityCheckMaxRepeatedToolErrorSignature || 5);
 const TN_WRITER_RESTRICTED_TOOLS = DEFAULT_RESTRICTED_TOOLS.filter((tool) => !TN_WRITER_TOOL_BLOCKLIST.includes(tool));
 
 function buildAtValidatorSystemPrompt() {
@@ -1298,12 +1308,21 @@ function parseContextPathFlag(ctxFlag) {
 }
 
 function applySkillSpecificGuardrails(skill, guardrails) {
-  if (skill !== 'tn-writer') return guardrails;
-  return {
-    ...guardrails,
-    maxTurns: Math.min(Number(guardrails?.maxTurns || TN_WRITER_MAX_TURNS), TN_WRITER_MAX_TURNS),
-    maxToolCalls: Math.min(Number(guardrails?.maxToolCalls || TN_WRITER_MAX_TOOL_CALLS), TN_WRITER_MAX_TOOL_CALLS),
-  };
+  if (skill === 'tn-writer') {
+    return {
+      ...guardrails,
+      maxTurns: Math.min(Number(guardrails?.maxTurns || TN_WRITER_MAX_TURNS), TN_WRITER_MAX_TURNS),
+      maxToolCalls: Math.min(Number(guardrails?.maxToolCalls || TN_WRITER_MAX_TOOL_CALLS), TN_WRITER_MAX_TOOL_CALLS),
+    };
+  }
+  if (skill === 'tn-quality-check') {
+    return {
+      ...guardrails,
+      maxConsecutiveToolErrors: Math.min(Number(guardrails?.maxConsecutiveToolErrors || TN_QC_MAX_CONSEC), TN_QC_MAX_CONSEC),
+      maxRepeatedToolErrorSignature: Math.min(Number(guardrails?.maxRepeatedToolErrorSignature || TN_QC_MAX_REPEAT), TN_QC_MAX_REPEAT),
+    };
+  }
+  return guardrails;
 }
 
 function getSkillToolConfig(skill) {
@@ -2379,6 +2398,24 @@ async function notesPipeline(route, message) {
       if (skillError) {
         failedSkill = skill.name;
         const errText = skillError.message || String(skillError);
+        // A guardrail stop on the quality check (looping edits / budget exhaustion) must not
+        // discard the already-written, mechanically-validated notes. Treat it as "quality
+        // incomplete but non-fatal": fall through to the graceful-degradation path (bounded
+        // rescue + tag unresolved findings + canonical quote-sync + door43-push) instead of
+        // failing the chapter. Scope strictly to tn-quality-check — a guardrail stop on
+        // tn-writer means the notes are incomplete and must still hard-fail.
+        if (skill.name === 'tn-quality-check' && isGuardrailStop(errText)) {
+          failedSkill = null;
+          await status(`**${skill.name}** for ${ref} stopped by guardrail (${errText}); proceeding with notes as written and tagging any unresolved findings.`);
+          try {
+            const qResolved = resolveOutputFile(skill.expectedOutput, book);
+            if (qResolved && fs.existsSync(path.resolve(CSKILLBP_DIR, qResolved))) {
+              if (!skillOutputs[ch]) skillOutputs[ch] = {};
+              skillOutputs[ch]['tn-quality-check'] = qResolved;
+            }
+          } catch (_) { /* no partial findings on disk — push notes as-is */ }
+          break;
+        }
         if (isTransientOutageError(skillError)) {
           abortForOutage = true;
           setCheckpoint(checkpointRef, {

--- a/src/self-diagnosis.js
+++ b/src/self-diagnosis.js
@@ -3,7 +3,7 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
-const { runClaude } = require('./claude-runner');
+const { runClaude, isGuardrailStop } = require('./claude-runner');
 const { publishAdminStatus, readAdminStatus } = require('./admin-status');
 const { readSecret } = require('./secrets');
 const {
@@ -119,7 +119,7 @@ A concrete, minimal change. If the cause is unclear, list the next debugging ste
 
 The fingerprint marker will be appended automatically — do not include it.`;
 
-function buildContextSummary(event, contextEvents, checkpoint, errorText) {
+function buildContextSummary(event, contextEvents, checkpoint, errorText, workdir) {
   const lines = [];
   lines.push('## Failure event');
   lines.push(`- timestamp: ${event.timestamp}`);
@@ -145,6 +145,25 @@ function buildContextSummary(event, contextEvents, checkpoint, errorText) {
     lines.push(JSON.stringify(checkpoint, null, 2));
     lines.push('```');
     lines.push('');
+  }
+  {
+    const wd = workdir || process.env.CSKILLBP_DIR || '';
+    const outputs = (checkpoint && checkpoint.skillOutputs) || {};
+    let notesRel = null;
+    for (const ch of Object.keys(outputs)) {
+      const bySkill = outputs[ch] || {};
+      if (bySkill['tn-writer']) { notesRel = bySkill['tn-writer']; break; }
+    }
+    if (wd || notesRel) {
+      lines.push('## Working directory');
+      if (wd) lines.push(`- Pipeline working dir (CSKILLBP_DIR): ${wd}`);
+      if (notesRel) {
+        lines.push(`- Notes TSV (relative): ${notesRel}`);
+        if (wd) lines.push(`- Notes TSV (absolute): ${path.resolve(wd, notesRel)}`);
+      }
+      lines.push('- Read files by absolute path; do not run `find` to locate them.');
+      lines.push('');
+    }
   }
   if (errorText) {
     lines.push('## Error text from failure site');
@@ -264,9 +283,9 @@ async function runDiagnosisAgent({ contextSummary, runClaudeImpl }) {
     mcpToolSet: 'workspace',
     disableLocalSettings: true,
     appendSystemPrompt: SYSTEM_PROMPT,
-    maxTurns: 30,
-    timeoutMs: 3 * 60 * 1000,
-    guardrails: { maxToolCalls: 25, tokenBudget: 200000 },
+    maxTurns: 40,
+    timeoutMs: 5 * 60 * 1000,
+    guardrails: { maxToolCalls: 40, tokenBudget: 200000 },
   });
   return {
     subtype: result?.subtype || 'unknown',
@@ -344,6 +363,45 @@ function buildFallbackDiagnosis(event, rawText, parseError, contextSummary) {
   };
 }
 
+// Templated diagnosis for a recognized runner guardrail stop (looping tool errors
+// or budget exhaustion). No LLM investigation is run — the signature is well
+// understood — so we file a concise, actionable issue directly.
+function buildGuardrailStopDiagnosis(event, contextSummary) {
+  const targetRepo = classifyRepo(event);
+  const scopeLabel = event.scope || event.pipelineType || 'event';
+  const title = `Pipeline guardrail stop: ${event.pipelineType || 'unknown'} ${scopeLabel}`.slice(0, 120);
+  const body = [
+    '## Summary',
+    'A pipeline step was stopped by a runner guardrail (repeated tool errors, max tool calls,',
+    'or token budget). This is a known signature, so no agent investigation was run — it was',
+    'filed directly. The usual cause is a skill looping on `Edit` "string to replace not found"',
+    'against a TSV/JSON source; see the structured by-id tools (update_note_text /',
+    'update_prepared_quote / remove_note) and the per-skill repeated-error guardrails.',
+    '',
+    '## Failure event',
+    `- pipelineType: ${event.pipelineType || '(unknown)'}`,
+    `- scope: ${event.scope || '(none)'}`,
+    `- phase: ${event.phase || '(none)'}`,
+    `- severity: ${event.severity || '(unknown)'}`,
+    `- message: ${event.message || '(none)'}`,
+    '',
+    '## Diagnosis context',
+    '<details><summary>Click to expand</summary>',
+    '',
+    '```',
+    String(contextSummary || '').slice(0, 8000),
+    '```',
+    '</details>',
+  ].join('\n');
+  return {
+    repo: targetRepo,
+    title,
+    body,
+    labels: ['bug', 'pipeline-failure', 'guardrail-stop'],
+    classification: 'guardrail-stop',
+  };
+}
+
 async function dispatchSelfDiagnosis({
   event,
   checkpoint = null,
@@ -392,49 +450,60 @@ async function dispatchSelfDiagnosis({
     const recent = readEvents({ scope: event.scope || undefined, limit: 20 });
     const recentEvents = Array.isArray(recent) ? [...recent].reverse() : [];
 
-    const contextSummary = buildContextSummary(event, recentEvents, checkpoint, errorText);
-    const agentResult = await runDiagnosisAgent({ contextSummary, runClaudeImpl });
-    const rawText = agentResult.rawText;
-    const cleanSubtype = agentResult.subtype || 'unknown';
-    const nonSuccess = cleanSubtype !== 'success';
-    if (nonSuccess) {
-      const flavor = rawText ? 'agent_non_success_with_text' : 'agent_non_success_no_text';
-      try {
-        await publishAdminStatus({
-          source: 'self-diagnosis',
-          pipelineType: event.pipelineType || 'system',
-          scope: event.scope || null,
-          phase: 'self-diagnosis',
-          severity: 'warn',
-          message: `Diagnosis agent non-success (${flavor}): subtype=${cleanSubtype}`,
-        });
-      } catch (_) { /* non-fatal */ }
-    }
+    const workdir = process.env.CSKILLBP_DIR || process.cwd();
+    const contextSummary = buildContextSummary(event, recentEvents, checkpoint, errorText, workdir);
 
     let diagnosis;
     let usedFallback = false;
     let parseError = null;
-    try {
-      diagnosis = extractDiagnosisJson(rawText);
-    } catch (err) {
-      parseError = err;
-      const rawPath = persistRawDiagnosisOutput(fingerprint, rawText);
-      if (rawPath) {
-        console.error(`[self-diagnosis] Persisted unparseable raw output to ${rawPath}`);
+    let shortCircuited = false;
+
+    if (isGuardrailStop(errorText) || isGuardrailStop(event.message)) {
+      // Known signature — skip the LLM investigation and file a templated issue.
+      console.log('[self-diagnosis] Guardrail-stop signature recognized; filing templated issue without running the agent.');
+      diagnosis = buildGuardrailStopDiagnosis(event, contextSummary);
+      shortCircuited = true;
+    } else {
+      const agentResult = await runDiagnosisAgent({ contextSummary, runClaudeImpl });
+      const rawText = agentResult.rawText;
+      const cleanSubtype = agentResult.subtype || 'unknown';
+      const nonSuccess = cleanSubtype !== 'success';
+      if (nonSuccess) {
+        const flavor = rawText ? 'agent_non_success_with_text' : 'agent_non_success_no_text';
+        try {
+          await publishAdminStatus({
+            source: 'self-diagnosis',
+            pipelineType: event.pipelineType || 'system',
+            scope: event.scope || null,
+            phase: 'self-diagnosis',
+            severity: 'warn',
+            message: `Diagnosis agent non-success (${flavor}): subtype=${cleanSubtype}`,
+          });
+        } catch (_) { /* non-fatal */ }
       }
-      if (!looksLikeDiagnosisAttempt(rawText)) {
-        if (nonSuccess) {
-          throw new Error(
-            `Diagnosis agent did not complete cleanly: subtype=${cleanSubtype}; ` +
-            `error=${String(agentResult.error || '').slice(0, 200)}; ` +
-            `result_head=${String(agentResult.resultHead || '').slice(0, 200)}`
-          );
+
+      try {
+        diagnosis = extractDiagnosisJson(rawText);
+      } catch (err) {
+        parseError = err;
+        const rawPath = persistRawDiagnosisOutput(fingerprint, rawText);
+        if (rawPath) {
+          console.error(`[self-diagnosis] Persisted unparseable raw output to ${rawPath}`);
         }
-        throw err;
+        if (!looksLikeDiagnosisAttempt(rawText)) {
+          if (nonSuccess) {
+            throw new Error(
+              `Diagnosis agent did not complete cleanly: subtype=${cleanSubtype}; ` +
+              `error=${String(agentResult.error || '').slice(0, 200)}; ` +
+              `result_head=${String(agentResult.resultHead || '').slice(0, 200)}`
+            );
+          }
+          throw err;
+        }
+        console.error(`[self-diagnosis] JSON parse failed (${err.message.slice(0, 200)}); filing fallback issue with raw output`);
+        diagnosis = buildFallbackDiagnosis(event, rawText, err, contextSummary);
+        usedFallback = true;
       }
-      console.error(`[self-diagnosis] JSON parse failed (${err.message.slice(0, 200)}); filing fallback issue with raw output`);
-      diagnosis = buildFallbackDiagnosis(event, rawText, err, contextSummary);
-      usedFallback = true;
     }
 
     const finalRepo = VALID_REPOS.has(diagnosis.repo) ? diagnosis.repo : targetRepo;
@@ -456,7 +525,7 @@ async function dispatchSelfDiagnosis({
       });
     } catch (_) { /* non-fatal */ }
 
-    const action = usedFallback ? 'created-fallback' : 'created';
+    const action = shortCircuited ? 'created-guardrail' : (usedFallback ? 'created-fallback' : 'created');
     console.log(`[self-diagnosis] Done (action=${action} issue=${finalRepo}#${created.number}${usedFallback ? ' parse-error=' + (parseError && parseError.message ? parseError.message.slice(0, 120) : 'unknown') : ''})`);
     return { ok: true, action, issue: created, fingerprint, classification: diagnosis.classification };
   } catch (err) {
@@ -486,6 +555,7 @@ module.exports = {
   repairAgentJson,
   looksLikeDiagnosisAttempt,
   buildFallbackDiagnosis,
+  buildGuardrailStopDiagnosis,
   buildContextSummary,
   appendFingerprintMarker,
   FINGERPRINT_PREFIX,

--- a/src/workspace-tools/index.js
+++ b/src/workspace-tools/index.js
@@ -11,7 +11,7 @@ const { splitTsv, mergeTsvs, fixTrailingNewlines } = require('./tsv-tools');
 const { extractUltEnglish, filterPsalms, curlyQuotes, checkUstPassives, createAlignedUsfm, repairAlignmentXContent, readUsfmChapter, mergeAlignedUsfm, validateAlignmentJson, validateUltBrackets, checkUltVoiceMismatch } = require('./usfm-tools');
 const { buildStrongsIndex, buildTnIndex, buildUstIndex } = require('./index-tools');
 const { checkTwHeadwords, compareUltUst, detectAbstractNouns } = require('./issue-tools');
-const { extractAlignmentData, fixHebrewQuotes, flagNarrowQuotes, generateIds, resolveGlQuotes, verifyAtFit, assembleNotes, prepareNotes, prepareAndValidate, fixUnicodeQuotes, verifyBoldMatches, fillTsvIds, fillOrigQuotes, prepareATContext, readPreparedNotes } = require('./tn-tools');
+const { extractAlignmentData, fixHebrewQuotes, flagNarrowQuotes, generateIds, resolveGlQuotes, verifyAtFit, assembleNotes, updateNoteText, updatePreparedQuote, removeNote, prepareNotes, prepareAndValidate, fixUnicodeQuotes, verifyBoldMatches, fillTsvIds, fillOrigQuotes, prepareATContext, readPreparedNotes } = require('./tn-tools');
 const { validateTnTsv, checkTnQuality } = require('./quality-tools');
 const { giteaPr, prepareCompare, prepareTq, verifyTq, appendQuickref } = require('./misc-tools');
 
@@ -540,6 +540,23 @@ function createQualityTools(createSdkMcpServer, tool, z) {
       tool('curly_quotes', 'Convert straight quotes to curly quotes', {
         input: z.string(), output: z.string().optional(), inPlace: z.boolean().optional(),
       }, async (args) => ({ content: [{ type: 'text', text: curlyQuotes(args) }] })),
+      tool('update_note_text', 'Set the note text for one generated note by id (in generated_notes.json). Use this instead of hand-editing the JSON. After updating, re-run assemble_notes + curly_quotes.', {
+        generatedJson: z.string().describe('Path to generated_notes.json (runtime.generatedNotes)'),
+        id: z.string().describe('The note id to update'),
+        note: z.string().describe('The full replacement note text'),
+      }, async (args) => ({ content: [{ type: 'text', text: updateNoteText(args) }] })),
+      tool('update_prepared_quote', 'Set quote fields for one prepared note by id (in prepared_notes.json). Only the provided fields are changed. After updating, re-run assemble_notes + curly_quotes.', {
+        preparedJson: z.string().describe('Path to prepared_notes.json (runtime.preparedNotes)'),
+        id: z.string().describe('The prepared item id to update'),
+        glQuote: z.string().optional().describe('New gl_quote'),
+        glQuoteRoundtripped: z.string().optional().describe('New gl_quote_roundtripped'),
+        origQuote: z.string().optional().describe('New orig_quote'),
+      }, async (args) => ({ content: [{ type: 'text', text: updatePreparedQuote(args) }] })),
+      tool('remove_note', 'Remove one note by id from generated_notes.json and/or directly from an assembled TSV row. Use for antithetical-parallelism or redundant notes.', {
+        id: z.string().describe('The note id to remove'),
+        generatedJson: z.string().optional().describe('Path to generated_notes.json (runtime.generatedNotes)'),
+        tsvFile: z.string().optional().describe('Path to the assembled TN TSV (removes the row whose ID column matches)'),
+      }, async (args) => ({ content: [{ type: 'text', text: removeNote(args) }] })),
     ],
   });
 }

--- a/src/workspace-tools/tn-tools.js
+++ b/src/workspace-tools/tn-tools.js
@@ -1379,6 +1379,82 @@ function assembleNotes({ preparedJson, generatedJson, output }) {
   return res.join('\n');
 }
 
+// ---------------------------------------------------------------------------
+// Structured by-id edits for the quality-check skill.
+//
+// The quality skill previously fixed issues by freehand `Edit` on the upstream
+// JSON sources (generated_notes.json is a { id: noteText } map; prepared_notes.json
+// is { items: [ { id, gl_quote, gl_quote_roundtripped, orig_quote, ... } ] }).
+// Whitespace/escaping/already-edited mismatches produced "string to replace not
+// found" errors that looped until the runner guardrail tripped. These tools locate
+// items deterministically by id, so that whole error class disappears. A missing id
+// returns a plain message (not a tool error), so it never increments the runner's
+// repeated-tool-error guard \u2014 the skill should tag the row unresolved and move on.
+// ---------------------------------------------------------------------------
+
+function updateNoteText({ generatedJson, id, note }) {
+  if (!generatedJson) return 'ERROR: generatedJson is required';
+  if (!id) return 'ERROR: id is required';
+  const p = path.resolve(CSKILLBP_DIR, generatedJson);
+  const gen = JSON.parse(fs.readFileSync(p, 'utf8'));
+  if (!Object.prototype.hasOwnProperty.call(gen, id)) {
+    return `ERROR: id "${id}" not found in ${generatedJson} \u2014 no change made. Verify the id against the findings, or tag the row unresolved and move on.`;
+  }
+  gen[id] = String(note == null ? '' : note);
+  fs.writeFileSync(p, JSON.stringify(gen, null, 2) + '\n');
+  return `Updated note text for id "${id}" in ${generatedJson}. Re-run assemble_notes + curly_quotes to apply.`;
+}
+
+function updatePreparedQuote({ preparedJson, id, glQuote, glQuoteRoundtripped, origQuote }) {
+  if (!preparedJson) return 'ERROR: preparedJson is required';
+  if (!id) return 'ERROR: id is required';
+  const p = path.resolve(CSKILLBP_DIR, preparedJson);
+  const prep = JSON.parse(fs.readFileSync(p, 'utf8'));
+  const items = Array.isArray(prep.items) ? prep.items : [];
+  const item = items.find((it) => it && it.id === id);
+  if (!item) {
+    return `ERROR: id "${id}" not found in ${preparedJson} items \u2014 no change made. Verify the id, or tag the row unresolved and move on.`;
+  }
+  const changed = [];
+  if (glQuote !== undefined) { item.gl_quote = glQuote; changed.push('gl_quote'); }
+  if (glQuoteRoundtripped !== undefined) { item.gl_quote_roundtripped = glQuoteRoundtripped; changed.push('gl_quote_roundtripped'); }
+  if (origQuote !== undefined) { item.orig_quote = origQuote; changed.push('orig_quote'); }
+  if (!changed.length) return `No quote fields provided for id "${id}"; nothing changed.`;
+  fs.writeFileSync(p, JSON.stringify(prep, null, 2) + '\n');
+  return `Updated ${changed.join(', ')} for id "${id}" in ${preparedJson}. Re-run assemble_notes + curly_quotes to apply.`;
+}
+
+function removeNote({ id, generatedJson, tsvFile }) {
+  if (!id) return 'ERROR: id is required';
+  const msgs = [];
+  if (generatedJson) {
+    const p = path.resolve(CSKILLBP_DIR, generatedJson);
+    const gen = JSON.parse(fs.readFileSync(p, 'utf8'));
+    if (Object.prototype.hasOwnProperty.call(gen, id)) {
+      delete gen[id];
+      fs.writeFileSync(p, JSON.stringify(gen, null, 2) + '\n');
+      msgs.push(`removed id "${id}" from ${generatedJson}`);
+    } else {
+      msgs.push(`id "${id}" not present in ${generatedJson}`);
+    }
+  }
+  if (tsvFile) {
+    const tp = path.resolve(CSKILLBP_DIR, tsvFile);
+    const lines = fs.readFileSync(tp, 'utf8').split('\n');
+    let removed = 0;
+    const kept = lines.filter((line, idx) => {
+      if (idx === 0 || line.trim() === '') return true; // keep header and blank lines
+      const cols = line.split('\t');
+      if (cols[1] === id) { removed++; return false; }
+      return true;
+    });
+    fs.writeFileSync(tp, kept.join('\n'));
+    msgs.push(`removed ${removed} row(s) with id "${id}" from ${tsvFile}`);
+  }
+  if (!msgs.length) return 'ERROR: provide generatedJson and/or tsvFile';
+  return `remove_note: ${msgs.join('; ')}.`;
+}
+
 const HEBREW_QUOTE_STRIP_RE = /[\u0591-\u05AF\u2060\u05BD\u05C3]/g;
 
 function stripHebrewQuoteMarks(value) {
@@ -3078,6 +3154,9 @@ module.exports = {
   resolveGlQuotes,
   verifyAtFit,
   assembleNotes,
+  updateNoteText,
+  updatePreparedQuote,
+  removeNote,
   prepareNotes,
   prepareAndValidate,
   syncCanonicalHebrewQuotes,

--- a/test/quality-edit-tools.test.js
+++ b/test/quality-edit-tools.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// The structured edit tools resolve paths against CSKILLBP_DIR; point it at a
+// temp dir BEFORE requiring tn-tools (it reads the env var at module load).
+const WORK = fs.mkdtempSync(path.join(os.tmpdir(), 'qedit-'));
+process.env.CSKILLBP_DIR = WORK;
+
+const { updateNoteText, updatePreparedQuote, removeNote } = require('../src/workspace-tools/tn-tools');
+
+function writeJson(rel, obj) {
+  const p = path.join(WORK, rel);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(obj, null, 2));
+  return rel;
+}
+function readJson(rel) { return JSON.parse(fs.readFileSync(path.join(WORK, rel), 'utf8')); }
+
+test('updateNoteText sets the note text for an existing id and leaves others untouched', () => {
+  const rel = writeJson('gen1.json', { ab1c: 'old note', de2f: 'keep' });
+  const out = updateNoteText({ generatedJson: rel, id: 'ab1c', note: 'new note' });
+  assert.match(out, /Updated note text for id "ab1c"/);
+  const after = readJson('gen1.json');
+  assert.equal(after.ab1c, 'new note');
+  assert.equal(after.de2f, 'keep');
+});
+
+test('updateNoteText returns a clear non-throwing message for a missing id (no file change)', () => {
+  const rel = writeJson('gen2.json', { ab1c: 'x' });
+  const out = updateNoteText({ generatedJson: rel, id: 'zz9z', note: 'n' });
+  assert.match(out, /ERROR: id "zz9z" not found/);
+  assert.deepEqual(readJson('gen2.json'), { ab1c: 'x' });
+});
+
+test('updatePreparedQuote updates only the provided quote fields by id', () => {
+  const rel = writeJson('prep1.json', { items: [
+    { id: 'ab1c', gl_quote: 'old', gl_quote_roundtripped: 'oldR', orig_quote: 'oldO', other: 'keep' },
+    { id: 'de2f', gl_quote: 'untouched' },
+  ] });
+  const out = updatePreparedQuote({ preparedJson: rel, id: 'ab1c', glQuote: 'new', origQuote: 'newO' });
+  assert.match(out, /gl_quote, orig_quote/);
+  const item = readJson('prep1.json').items.find((i) => i.id === 'ab1c');
+  assert.equal(item.gl_quote, 'new');
+  assert.equal(item.orig_quote, 'newO');
+  assert.equal(item.gl_quote_roundtripped, 'oldR'); // not provided → unchanged
+  assert.equal(item.other, 'keep');
+  const untouched = readJson('prep1.json').items.find((i) => i.id === 'de2f');
+  assert.equal(untouched.gl_quote, 'untouched');
+});
+
+test('updatePreparedQuote returns a clear message for a missing id', () => {
+  const rel = writeJson('prep2.json', { items: [{ id: 'ab1c' }] });
+  const out = updatePreparedQuote({ preparedJson: rel, id: 'zz9z', glQuote: 'x' });
+  assert.match(out, /ERROR: id "zz9z" not found/);
+});
+
+test('removeNote drops the entry from generated JSON and the matching TSV row, preserving header', () => {
+  const genRel = writeJson('gen3.json', { ab1c: 'note A', de2f: 'note B' });
+  const tsvRel = 'notes3.tsv';
+  fs.writeFileSync(path.join(WORK, tsvRel),
+    'Reference\tID\tTags\tSupportReference\tQuote\tOccurrence\tNote\n' +
+    '6:1\tab1c\t\t\tQ1\t1\tnote A\n' +
+    '6:2\tde2f\t\t\tQ2\t1\tnote B\n');
+  const out = removeNote({ id: 'ab1c', generatedJson: genRel, tsvFile: tsvRel });
+  assert.match(out, /removed id "ab1c" from/);
+  assert.match(out, /removed 1 row\(s\) with id "ab1c"/);
+  assert.deepEqual(readJson('gen3.json'), { de2f: 'note B' });
+  const tsv = fs.readFileSync(path.join(WORK, tsvRel), 'utf8');
+  assert.doesNotMatch(tsv, /\tab1c\t/);
+  assert.match(tsv, /\tde2f\t/);
+  assert.match(tsv.split('\n')[0], /^Reference\tID\t/); // header preserved
+});
+
+test('removeNote is a no-op message when the id is absent from generated JSON', () => {
+  const genRel = writeJson('gen4.json', { de2f: 'note B' });
+  const out = removeNote({ id: 'ab1c', generatedJson: genRel });
+  assert.match(out, /id "ab1c" not present/);
+  assert.deepEqual(readJson('gen4.json'), { de2f: 'note B' });
+});

--- a/test/self-diagnosis.test.js
+++ b/test/self-diagnosis.test.js
@@ -18,6 +18,8 @@ const {
   repairAgentJson,
   looksLikeDiagnosisAttempt,
   appendFingerprintMarker,
+  buildContextSummary,
+  buildGuardrailStopDiagnosis,
   FINGERPRINT_PREFIX,
 } = require('../src/self-diagnosis');
 
@@ -383,4 +385,51 @@ test('dispatchSelfDiagnosis fails with subtype details when diagnosis subtype is
   assert.equal(result.ok, false);
   assert.equal(calls.createCount, 0);
   assert.match(result.reason, /subtype=error/);
+});
+
+test('dispatchSelfDiagnosis short-circuits a guardrail-stop without invoking the agent', async () => {
+  const event = makePsa1Event({
+    pipelineType: 'notes',
+    scope: 'ZEC 6',
+    message: 'Chapter ZEC 6 failed at **tn-quality-check** after 3212.7s',
+  });
+  const calls = {};
+  const fetchImpl = createGithubFetchStub({ captureCalls: calls });
+  let claudeWasCalled = false;
+  const runClaudeImpl = async () => { claudeWasCalled = true; return { subtype: 'success', result: VALID_AGENT_OUTPUT }; };
+
+  const result = await dispatchSelfDiagnosis({
+    event,
+    errorText: 'Skill that failed: tn-quality-check\nGuardrail stop: repeated tool errors (string_not_found, consecutive=17, repeats=25)',
+    checkpoint: { state: 'failed', skillOutputs: { '6': { 'tn-writer': 'output/notes/ZEC/ZEC-06.tsv' } } },
+    runClaudeImpl,
+    fetchImpl,
+    readSecretImpl: () => 'fake-token',
+    readAdminStatusImpl: () => [event],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.action, 'created-guardrail');
+  assert.equal(claudeWasCalled, false, 'a known guardrail stop must not invoke the diagnosis agent');
+  assert.equal(calls.createCount, 1);
+  assert.ok(calls.lastCreateBody.labels.includes('guardrail-stop'));
+  assert.match(calls.lastCreateBody.body, /pipeline-failure-fingerprint:/);
+});
+
+test('buildContextSummary surfaces the absolute notes path so the agent does not hunt', () => {
+  const event = makePsa1Event({ pipelineType: 'notes', scope: 'ZEC 6' });
+  const checkpoint = { state: 'failed', skillOutputs: { '6': { 'tn-writer': 'output/notes/ZEC/ZEC-06.tsv' } } };
+  const summary = buildContextSummary(event, [], checkpoint, 'err', '/data/workspace');
+  assert.match(summary, /Working directory/);
+  assert.match(summary, /CSKILLBP_DIR\): \/data\/workspace/);
+  assert.match(summary, /\/data\/workspace\/output\/notes\/ZEC\/ZEC-06\.tsv/);
+});
+
+test('buildGuardrailStopDiagnosis returns a templated issue tagged guardrail-stop', () => {
+  const event = makePsa1Event({ pipelineType: 'notes', scope: 'ZEC 6' });
+  const d = buildGuardrailStopDiagnosis(event, 'some context');
+  assert.ok(d.title.length <= 120);
+  assert.ok(d.labels.includes('guardrail-stop'));
+  assert.equal(d.classification, 'guardrail-stop');
+  assert.match(d.body, /guardrail/i);
 });


### PR DESCRIPTION
## Why
A guardrail stop on `tn-quality-check` (the runner aborting after repeated `string_not_found` edits or budget exhaustion) used to mark the chapter failed and skip the graceful-degradation/push path — so fully-written `tn-writer` notes were never delivered. Observed on **ZEC 6**: ~53 min of Opus looping on edits, then `0 ok, 1 failed`.

## Changes
- **Fix 1 (notes-pipeline):** a guardrail stop on `tn-quality-check` is now non-fatal — falls through to the existing rescue + tag-unresolved + canonical-quote-sync + `door43-push` path. Scoped strictly to `tn-quality-check`; `tn-writer` guardrail stops still hard-fail.
- **Fix 2 (notes-pipeline / config):** tighten the *initial* quality-check repeated-error guardrail (`qualityCheckMaxConsecutiveToolErrors`=6, `qualityCheckMaxRepeatedToolErrorSignature`=5) so it bails in minutes, not ~53 min.
- **Fix 3 (workspace-tools):** add structured by-id edit tools `update_note_text` / `update_prepared_quote` / `remove_note` to the `quality` MCP set; harden `TN_QUALITY_CHECK_HINT`. Removes the freehand-`Edit`-on-JSON loop at its source. Companion skill PR: unfoldingWord/bp-assistant-skills (link below once created).
- **Fix 4 (self-diagnosis):** inject the resolved notes path + workdir into the prompt (no more `find` hunting), raise the budget (25→40 tool calls, 3→5 min), and short-circuit known guardrail-stop signatures to a templated issue with no model call.

## Test plan
- `node --test test/*.test.js` → 263 pass; the only 3 failures are pre-existing and unrelated (MCP-SDK ESM resolution + 2 `fillOrigQuotes` Hebrew-anchoring assertions in untouched code), confirmed by stashing this branch and re-running.
- New: `test/quality-edit-tools.test.js` (structured tools) + added `self-diagnosis` short-circuit/context tests.
- Not auto-deployed; review-gate runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)