### PR TITLE
fix: forward PR number to verifyRepoPush and add direct PR lookup

### DIFF
--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -1466,6 +1466,8 @@ async function generatePipeline(route, message) {
       const pushStartTime = new Date().toISOString();
       let ultNoChanges = false;
       let ustNoChanges = false;
+      let ultPrNumber;
+      let ustPrNumber;
 
       // door43-push ULT
       if (!chapterFailed && pushUlt) {
@@ -1483,6 +1485,7 @@ async function generatePipeline(route, message) {
             chapterFailed = true;
           } else {
             ultNoChanges = pushResultUlt.noChanges === true;
+            ultPrNumber = pushResultUlt.prNumber;
             await status(`**door43-push** (ULT) done for ${book} ${chData.ch}: ${pushResultUlt.details}`);
           }
         } catch (err) {
@@ -1508,6 +1511,7 @@ async function generatePipeline(route, message) {
             chapterFailed = true;
           } else {
             ustNoChanges = pushResultUst.noChanges === true;
+            ustPrNumber = pushResultUst.prNumber;
             await status(`**door43-push** (UST) done for ${book} ${chData.ch}: ${pushResultUst.details}`);
           }
         } catch (err) {
@@ -1529,8 +1533,8 @@ async function generatePipeline(route, message) {
         if (verifyUlt || verifyUst) {
           await status(`Verifying merges for ${book} ${chData.ch}...`);
         }
-        const ultVerify = verifyUlt ? await verifyRepoPush({ repo: 'en_ult', stagingBranch, since: pushStartTime }) : { success: true };
-        const ustVerify = verifyUst ? await verifyRepoPush({ repo: 'en_ust', stagingBranch, since: pushStartTime }) : { success: true };
+        const ultVerify = verifyUlt ? await verifyRepoPush({ repo: 'en_ult', stagingBranch, since: pushStartTime, prNumber: ultPrNumber }) : { success: true };
+        const ustVerify = verifyUst ? await verifyRepoPush({ repo: 'en_ust', stagingBranch, since: pushStartTime, prNumber: ustPrNumber }) : { success: true };
 
         if (verifyUlt && !ultVerify.success) {
           await status(`Repo verify FAILED (ULT) for ${book} ${chData.ch}: ${ultVerify.details}`);

--- a/src/insertion-resume.js
+++ b/src/insertion-resume.js
@@ -161,6 +161,8 @@ async function runGenerateInsertPhase(completedChapters, username, book, notify)
     let chapterFailed = false;
     let ultNoChanges = false;
     let ustNoChanges = false;
+    let ultPrNumber;
+    let ustPrNumber;
     const pushStartTime = new Date().toISOString();
 
     // door43-push ULT
@@ -177,6 +179,7 @@ async function runGenerateInsertPhase(completedChapters, username, book, notify)
         chapterFailed = true;
       } else {
         ultNoChanges = pushResultUlt.noChanges === true;
+        ultPrNumber = pushResultUlt.prNumber;
         await status(`**door43-push** (ULT) done for ${book} ${ch.ch}: ${pushResultUlt.details}`);
       }
     } catch (err) {
@@ -200,6 +203,7 @@ async function runGenerateInsertPhase(completedChapters, username, book, notify)
           chapterFailed = true;
         } else {
           ustNoChanges = pushResultUst.noChanges === true;
+          ustPrNumber = pushResultUst.prNumber;
           await status(`**door43-push** (UST) done for ${book} ${ch.ch}: ${pushResultUst.details}`);
         }
       } catch (err) {
@@ -221,8 +225,8 @@ async function runGenerateInsertPhase(completedChapters, username, book, notify)
       if (verifyUlt || verifyUst) {
         await status(`Verifying merges for ${book} ${ch.ch}...`);
       }
-      const ultVerify = verifyUlt ? await verifyRepoPush({ repo: 'en_ult', stagingBranch, since: pushStartTime }) : { success: true };
-      const ustVerify = verifyUst ? await verifyRepoPush({ repo: 'en_ust', stagingBranch, since: pushStartTime }) : { success: true };
+      const ultVerify = verifyUlt ? await verifyRepoPush({ repo: 'en_ult', stagingBranch, since: pushStartTime, prNumber: ultPrNumber }) : { success: true };
+      const ustVerify = verifyUst ? await verifyRepoPush({ repo: 'en_ust', stagingBranch, since: pushStartTime, prNumber: ustPrNumber }) : { success: true };
 
       if (verifyUlt && !ultVerify.success) {
         await status(`Repo verify FAILED (ULT) for ${book} ${ch.ch}: ${ultVerify.details}`);
@@ -260,6 +264,7 @@ async function runNotesInsertPhase(completedChapters, username, book, notify) {
   for (const ch of completedChapters) {
     let chapterFailed = false;
     let pushNoChanges = false;
+    let pushPrNumber;
     const pushStartTime = new Date().toISOString();
 
     await status(`Running deferred **door43-push** (TN) for ${book} ${ch.ch}...`);
@@ -275,6 +280,7 @@ async function runNotesInsertPhase(completedChapters, username, book, notify) {
         chapterFailed = true;
       } else {
         pushNoChanges = pushResult.noChanges === true;
+        pushPrNumber = pushResult.prNumber;
         await status(`**door43-push** (TN) done for ${book} ${ch.ch}: ${pushResult.details}`);
       }
     } catch (err) {
@@ -290,7 +296,7 @@ async function runNotesInsertPhase(completedChapters, username, book, notify) {
       } else {
         const stagingBranch = buildBranchName(book, ch.ch);
         await status(`Verifying merge for ${book} ${ch.ch}...`);
-        const verify = await verifyRepoPush({ repo: 'en_tn', stagingBranch, since: pushStartTime });
+        const verify = await verifyRepoPush({ repo: 'en_tn', stagingBranch, since: pushStartTime, prNumber: pushPrNumber });
         if (!verify.success) {
           await status(`Repo verify FAILED for ${book} ${ch.ch}: ${verify.details}`);
           chapterFailed = true;

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -2804,6 +2804,7 @@ async function notesPipeline(route, message) {
     }
 
     let pushNoChanges = false;
+    let pushPrNumber;
     if (!chapterFailed) await status(`Running **door43-push** (TN) for ${ref}...`);
     const pushStartTime = new Date().toISOString();
     if (!chapterFailed) try {
@@ -2818,6 +2819,7 @@ async function notesPipeline(route, message) {
         chapterFailed = true;
       } else {
         pushNoChanges = pushResult.noChanges === true;
+        pushPrNumber = pushResult.prNumber;
         await status(`**door43-push** (TN) done for ${ref}: ${pushResult.details}`);
       }
     } catch (err) {
@@ -2833,7 +2835,7 @@ async function notesPipeline(route, message) {
     if (!chapterFailed && !pushNoChanges) {
       await status(`Verifying push for ${ref}...`);
       const stagingBranch = buildBranchName(book, ch);
-      const verify = await verifyRepoPush({ repo: 'en_tn', stagingBranch, since: pushStartTime });
+      const verify = await verifyRepoPush({ repo: 'en_tn', stagingBranch, since: pushStartTime, prNumber: pushPrNumber });
       if (!verify.success) {
         await status(`Repo verify FAILED for ${ref}: ${verify.details}`);
         console.warn(`[notes] Repo verify failed for ${ref}: ${verify.details}`);

--- a/src/repo-verify.js
+++ b/src/repo-verify.js
@@ -52,13 +52,19 @@ function apiGet(path, token) {
  * This avoids the false-positive where a never-pushed branch is absent
  * and mistakenly interpreted as "merged and deleted."
  *
+ * When a `prNumber` is supplied, a direct PR-by-number lookup is used first.
+ * This is resilient to Gitea's behavior of stripping `head.label`/`head.ref`
+ * from merged PR records once the source branch is deleted — which breaks
+ * both the head-filtered query and the field-based fallback scan below.
+ *
  * @param {object} opts
  * @param {string} opts.repo - Repo name (en_tn, en_ult, en_ust)
  * @param {string} opts.stagingBranch - The staging branch name that should have been merged+deleted
  * @param {string} [opts.since] - ISO timestamp; only accept PRs merged after this time
+ * @param {number} [opts.prNumber] - Numeric PR id from door43Push; enables direct PR lookup
  * @returns {{ success: boolean, details: string }}
  */
-async function verifyRepoPush({ repo, stagingBranch, since }) {
+async function verifyRepoPush({ repo, stagingBranch, since, prNumber }) {
   const token = readSecret('door43_token', 'DOOR43_TOKEN') || readSecret('gitea_token', 'GITEA_TOKEN');
 
   if (!token) {
@@ -86,6 +92,26 @@ async function verifyRepoPush({ repo, stagingBranch, since }) {
       success: false,
       details: `Token validation failed: ${err.message}`,
     };
+  }
+
+  // Direct PR-by-number lookup when door43Push provided one. This works even
+  // after Gitea strips head.label/head.ref from the PR record on branch deletion.
+  if (prNumber) {
+    try {
+      const prRes = await apiGet(`/repos/${ORG}/${repo}/pulls/${prNumber}`, token);
+      if (prRes.status === 200 && prRes.data && typeof prRes.data === 'object') {
+        const pr = prRes.data;
+        const isMerged = pr.merged === true || pr.merged_by != null;
+        if (isMerged && pr.merged_at && new Date(pr.merged_at) >= new Date(effectiveSince)) {
+          return {
+            success: true,
+            details: `PR #${prNumber} merged ${stagingBranch} into master on ${repo} (confirmed via direct PR lookup)`,
+          };
+        }
+      }
+    } catch (_) {
+      // Non-fatal: fall through to the head-filter + fallback scan logic below.
+    }
   }
 
   // Search for a merged PR from this staging branch

--- a/src/tqs-pipeline.js
+++ b/src/tqs-pipeline.js
@@ -428,7 +428,7 @@ async function tqsPipeline(route, message) {
       continue; // skip verifyRepoPush — nothing was pushed
     }
 
-    const verifyPush = await verifyRepoPush({ repo: 'en_tq', stagingBranch: branch, since: pushStartTime });
+    const verifyPush = await verifyRepoPush({ repo: 'en_tq', stagingBranch: branch, since: pushStartTime, prNumber: pushResult.prNumber });
     if (!verifyPush.success) {
       totalFail++;
       setCheckpoint(checkpointRef, {


### PR DESCRIPTION
Closes #116.

## Summary

`verifyRepoPush` was reporting a false-negative failure (`No merged PR found for 'AI-ISA-24' on en_tn and branch does not exist`) on ISA 24 even though `door43-push` had successfully merged PR #7057 nine seconds earlier. Root cause: Gitea strips `head.label` and `head.ref` from merged PR records once the source branch is deleted, breaking both the head-filtered query and the field-based fallback scan. There was no PR-number-based lookup available as a final fallback because `pushResult.prNumber` was not forwarded from the pipelines to the verify call.

## Changes

1. `src/repo-verify.js` — `verifyRepoPush` now accepts an optional `prNumber` and uses `/repos/{org}/{repo}/pulls/{prNumber}` as the first verification step before falling through to the existing head-filter query and recent-PR fallback scan. The PR record remains addressable by numeric id even after the head label is stripped, so this confirms the merge directly.
2. Forward `pushResult.prNumber` into every `verifyRepoPush` call:
   - `src/notes-pipeline.js` (TN)
   - `src/tqs-pipeline.js` (TQ)
   - `src/generate-pipeline.js` (ULT + UST)
   - `src/insertion-resume.js` (deferred ULT/UST and TN inserts)

The change is fully backward-compatible: when `prNumber` is absent or the direct lookup fails for any reason, control falls through to the existing logic.

## Test plan

- [x] `node --test test/tqs-pipeline.test.js` — passes (12/12)
- [x] `node --test test/generate-pipeline-early-exit.test.js` — passes (7/7)
- [x] `node --test test/pending-merges.test.js test/insert-tn-rows.test.js` — passes (9/9)
- [x] Standalone smoke test confirms:
  - With `prNumber` and a merged PR record → succeeds via "confirmed via direct PR lookup"
  - Without `prNumber` and a deleted branch → falls through to the original failure path
- [ ] Observe a real ISA-style merge on next pipeline run and confirm verify reports success via direct PR lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)