### PR TITLE
Add validation-gate MCP tools backed by bp-assistant-skills validators

### DIFF
--- a/plans/validation-gates-wiring.md
+++ b/plans/validation-gates-wiring.md
@@ -1,0 +1,101 @@
+# Wiring Validation Gates into the Pipelines
+
+Status: planned (MCP wrappers landed; pipeline enforcement not yet wired)
+Owner: Benjamin / bp-assistant
+Companion work: bp-assistant-skills branch `claude/jolly-payne-b1c14e` (validators,
+regression checks, golden benchmark), `src/workspace-tools/validation-tools.js` here.
+
+## Goal
+
+Catch structural and previously-fixed mistakes **inside the pipeline run**, so what
+auto-merges to Door43 is already clean. Hard requirement: the pipeline keeps running
+**end-to-end with no human intervention**. Humans review after merge in the friendly
+UI tools — nobody reads aligned USFM. So a gate has exactly three outcomes:
+
+1. **pass** → continue silently
+2. **fail** → feed the validator's output back to the working Claude session to fix,
+   then re-validate (bounded retries)
+3. **still failing** → abort *that artifact's push*, post the validator report to the
+   Zulip thread, and let the rest of the run continue where independent
+
+A gate never waits for a person.
+
+## What exists already
+
+- Five gate functions in `src/workspace-tools/validation-tools.js`. They dynamic-import
+  the actual check logic from the skills clone (`CSKILLBP_DIR/.claude/skills/utilities/
+  scripts/validation/`), so check updates ship via the skills repo with no bot deploy.
+- The same five are registered as MCP tools (`mcp__workspace-tools__validate_usfm_structure`,
+  `validate_alignment_integrity`, `check_duplicate_ids`, `preflight_data_check`,
+  `run_regression_checks`) in the main toolset, and the last two also in the quality
+  subset. Agents can self-check; the skills' SKILL.md files already instruct the
+  Bash/MCP variants at the right steps.
+- `repairAlignmentXContent` already runs inside every `createAlignedUsfm` call —
+  the integrity gate **verifies** what repair claims to have fixed.
+
+The missing piece is *enforcement*: deterministic gate calls in pipeline JS between
+steps, so quality does not depend on the agent remembering to self-check.
+
+## Gate placement (implementation anchors)
+
+All calls are plain async functions from `require('./workspace-tools/validation-tools')`
+— no MCP round-trip needed in pipeline code. Branch on `result.startsWith('FAIL:')`.
+
+| # | Pipeline point | Gate call | On FAIL |
+|---|----------------|-----------|---------|
+| 1 | `generate-pipeline.js` before starting the initial skill session (~the step launcher near line 615) | `preflightDataCheck({ book, stage: 'all' })` | Run the relevant `fetch_*` tools programmatically once, re-check; still failing → abort run, Zulip report. No agent involved. |
+| 2 | `generate-pipeline.js` after the initial session writes ULT/UST (the early-exit output checks already verify files exist — extend there) | `validateUsfmStructure({ usfm, source: hebrewPath, chapter })` for each of AI-ULT and AI-UST, plus `runRegressionChecks({ stage, file, book, chapter })` | One resume turn into the same session: "validator output below — fix the file and stop". Re-validate. Second failure → abort artifact, Zulip. |
+| 3 | `generate-pipeline.js` after each alignment subagent completes (the Sonnet alignment steps near lines 1068/1188) | `validateAlignmentIntegrityGate({ aligned, hebrew, chapter, ust })` + `validateUsfmStructure` on the aligned file | Re-run that alignment step once with the problem list appended to its prompt. Second failure → abort artifact, Zulip. |
+| 4 | `notes-pipeline.js` after assembly/post-process, before the door43-push step (the skill chain completes near line 2281; tn-quality-check invocation ~1965 already exists — add the deterministic pair next to it) | `runRegressionChecks({ stage: 'TN', file, book, chapter })` + `checkDuplicateIdsGate({ files: [file] })` | tn-quality-check (Opus) already runs and fixes; feed regression FAILs into that same review pass. Persisting failure → abort push, Zulip. |
+| 5 | TQ path (`tqs` pipeline) before insertion | `checkDuplicateIdsGate({ files: chapterFiles, against: [publishedTqTsv] })` + `runRegressionChecks({ stage: 'TQ', ... })` | Deterministic ID fix is safe to automate (regenerate colliding ID, no semantics); regression FAILs → one fix turn, then abort. |
+| 6 | `door43-push.js` inside `door43Push()` just before commit (belt-and-suspenders; it already validates TN bracket pairing) | structure gate for USFM types, ID gate for TSV types | Return `{ success: false, details: <validator first lines> }` — callers already surface failures to Zulip. No retry here; this gate should never fire if 1-5 ran. |
+
+## Retry semantics (uniform)
+
+- `MAX_GATE_RETRIES = 1` (one fix attempt per gate; the fix prompt includes the full
+  validator output verbatim — it is written to be actionable line-by-line).
+- A gate failure after retry marks that artifact `blocked` in the run status, posts
+  the report to the Zulip thread (existing `publishAdminStatus` / thread-reply path),
+  and the run continues with remaining artifacts. The machine still stops itself —
+  never left waiting.
+- Escape hatch: env `VALIDATION_GATES=off|log|enforce` (default `log` initially,
+  flip to `enforce` after burn-in). `off` exists for emergency unblocking only.
+
+## Rollout
+
+1. **Phase A — log-only (1-2 weeks of real runs).** Wire all six points with
+   `VALIDATION_GATES=log`: gates run, results land in the run log and a one-line
+   Zulip note when they would have blocked. Measures false-positive rate on real
+   books at zero risk to throughput. (TN convention checks were calibrated against
+   published NAM/MAL/JOS 1, so expected FP rate is low; the pinned ISA checks skip
+   automatically when their verses aren't in the file.)
+2. **Phase B — enforce.** Flip to `enforce` once a week of runs shows no false
+   blocks, or after fixing any check that misfires (checks live in the skills repo:
+   `.claude/skills/utilities/regression/regression-checks.json` — edit + push there,
+   no bot deploy).
+3. **Phase C — benchmark cadence (optional, later).** Monthly: run the golden-benchmark
+   skill on JOS 1 / NAM 1 / MAL 1 and post scorecards to Zulip, so drift is visible
+   even when no one changed anything on purpose.
+
+## Test plan
+
+- Unit: `test/validation-tools.test.js` (landed) — gates pass/fail/skip correctly and
+  fail loudly when the skills clone is stale.
+- Integration: one `--test-fast` style dry run per pipeline with a deliberately broken
+  artifact (drop a verse from the ULT; duplicate a TQ ID) confirming log-mode logs and
+  enforce-mode blocks + reports without hanging the run.
+- Regression: full `npm test` (2 pre-existing failures in `tn-tools.test.js`
+  `fillOrigQuotes` are unrelated and predate this work — tracked separately).
+
+## Explicitly out of scope
+
+- **gemini-review**: dormant; no Gemini model meaningfully better than flash is
+  available (as of 2026-06), so the second-opinion wave stays parked. The skills'
+  `--gemini` flags remain opt-in no-ops in practice. Consider removing the wave
+  references in a future cleanup rather than fixing the integration.
+- Human approval steps anywhere in the run — deliberately none, per the post-merge
+  review workflow in the UI tools.
+- Model assignment changes (separate decision; see June 2026 audit: the generate
+  session inherits the runner's Opus default via `claude-runner.js:155` — if cost
+  matters, set `"model": "sonnet"` on the generate pipeline config since its Opus
+  workers are pinned separately).

--- a/src/workspace-tools/index.js
+++ b/src/workspace-tools/index.js
@@ -14,6 +14,7 @@ const { checkTwHeadwords, compareUltUst, detectAbstractNouns } = require('./issu
 const { extractAlignmentData, fixHebrewQuotes, flagNarrowQuotes, generateIds, resolveGlQuotes, verifyAtFit, assembleNotes, updateNoteText, updatePreparedQuote, removeNote, prepareNotes, prepareAndValidate, fixUnicodeQuotes, verifyBoldMatches, fillTsvIds, fillOrigQuotes, prepareATContext, readPreparedNotes } = require('./tn-tools');
 const { validateTnTsv, checkTnQuality } = require('./quality-tools');
 const { giteaPr, prepareCompare, prepareTq, verifyTq, appendQuickref } = require('./misc-tools');
+const { validateUsfmStructure, validateAlignmentIntegrityGate, checkDuplicateIdsGate, preflightDataCheck, runRegressionChecks } = require('./validation-tools');
 
 function asTextToolResult(value) {
   if (typeof value === 'string') return { content: [{ type: 'text', text: value }] };
@@ -515,6 +516,33 @@ function createTnWriterTools(createSdkMcpServer, tool, z) {
         end: z.number().int().optional().describe('Last item index (inclusive). Default: start+19'),
         summaryOnly: z.boolean().optional().describe('Return only total count and item IDs — no bodies'),
       }, async (args) => ({ content: [{ type: 'text', text: readPreparedNotes(args) }] })),
+
+      // --- Validation gates (logic lives in bp-assistant-skills; see validation-tools.js) ---
+      tool('validate_usfm_structure', 'Structural gate for generated USFM: verse completeness (vs Hebrew source when given), duplicate/out-of-order verses, marker balance, empty verses, balanced {braces}. First line of result starts OK:/FAIL:.', {
+        usfm: z.string().describe('Generated USFM path (relative to workspace)'),
+        source: z.string().optional().describe('Reference USFM (e.g. Hebrew source) whose verse set must match'),
+        chapter: z.number().int().optional().describe('Validate only this chapter'),
+      }, async (args) => ({ content: [{ type: 'text', text: await validateUsfmStructure(args) }] })),
+      tool('validate_alignment_integrity', 'Field-level gate for aligned USFM: byte-exact x-content/x-lemma vs Hebrew source (flags visually-identical Unicode drift), occurrence numbering, Hebrew coverage (ULT mode). Run after create_aligned_usfm/repair. First line starts OK:/FAIL:.', {
+        aligned: z.string().describe('Aligned USFM path (relative to workspace)'),
+        hebrew: z.string().describe('Hebrew source USFM path (relative to workspace)'),
+        chapter: z.number().int().optional().describe('Validate only this chapter'),
+        ust: z.boolean().optional().describe('UST mode: unaligned Hebrew words are allowed'),
+      }, async (args) => ({ content: [{ type: 'text', text: await validateAlignmentIntegrityGate(args) }] })),
+      tool('check_duplicate_ids', 'ID gate for TN/TQ TSVs: format [a-z][a-z0-9]{3}, uniqueness within and across files, optional collision check vs a published book TSV. First line starts OK:/FAIL:.', {
+        files: z.array(z.string()).describe('TSV file paths to check together (relative to workspace)'),
+        against: z.array(z.string()).optional().describe('Published TSVs to check collisions against'),
+      }, async (args) => ({ content: [{ type: 'text', text: await checkDuplicateIdsGate(args) }] })),
+      tool('preflight_data_check', 'Loud check that required reference data exists before generation (issues_resolved, glossaries, Hebrew source, T4T, Strong\'s index). First line starts OK:/FAIL: — do not generate on FAIL.', {
+        book: z.string().describe('Book code (e.g. NAM)'),
+        stage: z.enum(['ult', 'ust', 'tn', 'all']).optional().describe('Which stage\'s requirements to check (default all)'),
+      }, async (args) => ({ content: [{ type: 'text', text: await preflightDataCheck(args) }] })),
+      tool('run_regression_checks', 'Re-test every mechanizable closed quality bug against a generated file (checks live in the skills repo). FAIL means a previously fixed mistake has returned. First line starts OK:/FAIL:.', {
+        stage: z.enum(['ULT', 'UST', 'TN', 'TQ', 'alignment']).describe('Content stage of the file'),
+        file: z.string().describe('Generated file path (relative to workspace)'),
+        book: z.string().optional().describe('Book code (enables book-scoped checks)'),
+        chapter: z.number().int().optional().describe('Chapter number (scopes chapter-pinned checks)'),
+      }, async (args) => ({ content: [{ type: 'text', text: await runRegressionChecks(args) }] })),
     ],
   });
 }
@@ -557,6 +585,13 @@ function createQualityTools(createSdkMcpServer, tool, z) {
         generatedJson: z.string().optional().describe('Path to generated_notes.json (runtime.generatedNotes)'),
         tsvFile: z.string().optional().describe('Path to the assembled TN TSV (removes the row whose ID column matches)'),
       }, async (args) => ({ content: [{ type: 'text', text: removeNote(args) }] })),
+      tool('check_duplicate_ids', 'ID gate for TN/TQ TSVs: format, uniqueness within/across files, optional collision vs published. First line starts OK:/FAIL:.', {
+        files: z.array(z.string()), against: z.array(z.string()).optional(),
+      }, async (args) => ({ content: [{ type: 'text', text: await checkDuplicateIdsGate(args) }] })),
+      tool('run_regression_checks', 'Re-test mechanizable closed quality bugs against a generated file. FAIL = a fixed mistake returned. First line starts OK:/FAIL:.', {
+        stage: z.enum(['ULT', 'UST', 'TN', 'TQ', 'alignment']), file: z.string(),
+        book: z.string().optional(), chapter: z.number().int().optional(),
+      }, async (args) => ({ content: [{ type: 'text', text: await runRegressionChecks(args) }] })),
     ],
   });
 }

--- a/src/workspace-tools/validation-tools.js
+++ b/src/workspace-tools/validation-tools.js
@@ -1,0 +1,143 @@
+// workspace-tools/validation-tools.js — validation gates backed by bp-assistant-skills
+//
+// Unlike other workspace tools, these do NOT port logic into the bot. They
+// dynamically import the validator modules from the skills clone
+// (CSKILLBP_DIR/.claude/skills/utilities/scripts/validation/), so the checks
+// stay single-source: updating bp-assistant-skills updates the gates without
+// a bot redeploy. Imports are cache-busted on file mtime, so a refreshed
+// clone takes effect without restarting the bot process. (Sibling modules
+// imported relatively by a validator are cached per their own URL; they
+// change together with the entry module in practice.)
+//
+// Every function returns a text report whose first line starts with "OK:" or
+// "FAIL:" so both agents and pipeline code can branch on it. Pipeline code
+// can also call these functions directly (not via MCP) for enforced gates.
+
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const CSKILLBP_DIR = process.env.CSKILLBP_DIR || '/srv/bot/workspace';
+const VALIDATION_DIR = path.join(CSKILLBP_DIR, '.claude/skills/utilities/scripts/validation');
+const REGRESSION_CHECKS = path.join(CSKILLBP_DIR, '.claude/skills/utilities/regression/regression-checks.json');
+
+function resolveWs(p) {
+  return path.isAbsolute(p) ? p : path.resolve(CSKILLBP_DIR, p);
+}
+
+async function importValidator(fileName) {
+  const p = path.join(VALIDATION_DIR, fileName);
+  if (!fs.existsSync(p)) {
+    throw new Error(
+      `Validator not found: ${p} — the bp-assistant-skills clone is missing the validation scripts. ` +
+      'Pull/refresh the skills repo (they shipped with the quality-gates work).');
+  }
+  const mtime = fs.statSync(p).mtimeMs;
+  return import(pathToFileURL(p).href + '?v=' + mtime);
+}
+
+function formatProblems(label, problems, okMessage) {
+  if (problems.length === 0) return `OK: ${okMessage}`;
+  const lines = problems.map((p) => {
+    const loc = p.ref ? ` ${p.ref}` : (p.chapter ? ` ${p.chapter}${p.verse ? ':' + p.verse : ''}` : '');
+    return `${(p.level || 'error').toUpperCase()}${loc} [${p.code}] ${p.message}`;
+  });
+  return `FAIL: ${problems.length} problem(s) in ${label}\n${lines.join('\n')}`;
+}
+
+/**
+ * Structural gate for generated USFM: verse completeness (against the Hebrew
+ * source when given), duplicate/out-of-order verses, marker balance, empty
+ * verses, balanced supplied-word braces, debug artifacts.
+ */
+async function validateUsfmStructure({ usfm, source, chapter }) {
+  const mod = await importValidator('validate_usfm_structure.mjs');
+  const text = fs.readFileSync(resolveWs(usfm), 'utf8');
+  const sourceText = source ? fs.readFileSync(resolveWs(source), 'utf8') : null;
+  const problems = mod.validateStructure(text, { sourceText, chapter: chapter ?? null });
+  return formatProblems(usfm, problems, `${usfm} passed structure validation`);
+}
+
+/**
+ * Field-level gate for aligned USFM: byte-exact x-content/x-lemma vs the
+ * Hebrew source (flags visually-identical Unicode byte drift separately),
+ * occurrence numbering consistency, and (ULT mode) full Hebrew coverage.
+ */
+async function validateAlignmentIntegrityGate({ aligned, hebrew, chapter, ust }) {
+  const mod = await importValidator('validate_alignment_integrity.mjs');
+  const alignedText = fs.readFileSync(resolveWs(aligned), 'utf8');
+  const hebrewText = fs.readFileSync(resolveWs(hebrew), 'utf8');
+  const problems = mod.validateAlignmentIntegrity(alignedText, hebrewText, {
+    chapter: chapter ?? null,
+    ustMode: !!ust,
+  });
+  return formatProblems(aligned, problems, `${aligned} passed alignment integrity validation`);
+}
+
+/**
+ * ID gate for TN/TQ TSVs: format ([a-z][a-z0-9]{3}), uniqueness within and
+ * across the given files, and optional collision check against a published
+ * book TSV. Duplicate IDs break downstream merge/delete operations.
+ */
+async function checkDuplicateIdsGate({ files, against }) {
+  const mod = await importValidator('check_duplicate_ids.mjs');
+  const loaded = files.map((f) => ({ label: f, text: fs.readFileSync(resolveWs(f), 'utf8') }));
+  const loadedAgainst = (against || []).map((f) => ({ label: f, text: fs.readFileSync(resolveWs(f), 'utf8') }));
+  const problems = mod.checkDuplicateIds(loaded, loadedAgainst);
+  return formatProblems(files.join(', '), problems, `no duplicate or malformed IDs across ${files.length} file(s)`);
+}
+
+/**
+ * Loud preflight for reference data: issues_resolved, glossaries, Hebrew
+ * source, T4T, Strong's index. Run before generation so a failed fetch stops
+ * the run instead of silently degrading output quality.
+ */
+async function preflightDataCheck({ book, stage }) {
+  const mod = await importValidator('preflight_data_check.mjs');
+  const { results, ok } = mod.preflightCheck({ book, stage: stage || 'all', root: CSKILLBP_DIR });
+  const width = Math.max(...results.map((r) => r.path.length));
+  const table = results.map((r) => `${r.status.padEnd(8)} ${r.path.padEnd(width)}  ${r.note}`).join('\n');
+  if (ok) return `OK: required reference data for ${book} (${stage || 'all'}) is present.\n${table}`;
+  const missing = results.filter((r) => r.status === 'MISSING').length;
+  return `FAIL: ${missing} required data source(s) missing for ${book} (${stage || 'all'}).\n${table}\n` +
+    'Fetch them before generating (fetch_* tools / curate-published-data.mjs). ' +
+    'Generating without them will silently diverge from content-team decisions.';
+}
+
+/**
+ * Re-test every closed quality bug that could be mechanized against a
+ * generated file. A FAIL means a previously fixed mistake has returned.
+ * Checks live in the skills repo: .claude/skills/utilities/regression/regression-checks.json
+ */
+async function runRegressionChecks({ stage, file, book, chapter }) {
+  const mod = await importValidator('run_regression_checks.mjs');
+  if (!fs.existsSync(REGRESSION_CHECKS)) {
+    throw new Error(`Regression checks file not found: ${REGRESSION_CHECKS} — refresh the bp-assistant-skills clone.`);
+  }
+  const checksData = JSON.parse(fs.readFileSync(REGRESSION_CHECKS, 'utf8'));
+  const text = fs.readFileSync(resolveWs(file), 'utf8');
+  const results = mod.runChecks({
+    stage, text,
+    book: book ? book.toUpperCase() : null,
+    chapter: chapter ?? null,
+    checksData,
+  });
+  const failed = results.filter((r) => r.status === 'fail');
+  const advisory = results.filter((r) => r.status === 'advisory');
+  const passed = results.filter((r) => r.status === 'pass');
+  const lines = [];
+  for (const r of failed) lines.push(`FAIL [#${r.issue}] ${r.explain}${r.detail ? ` — ${r.detail}` : ''}`);
+  for (const r of advisory) lines.push(`ADVISORY [#${r.issue}] ${r.detail}`);
+  if (failed.length === 0) {
+    return `OK: ${passed.length} regression check(s) passed (${advisory.length} advisory, ${results.filter((r) => r.status === 'skip').length} skipped) for ${file}${lines.length ? '\n' + lines.join('\n') : ''}`;
+  }
+  return `FAIL: ${failed.length} regression check(s) failed for ${file} — a previously fixed mistake has returned\n${lines.join('\n')}`;
+}
+
+module.exports = {
+  validateUsfmStructure,
+  validateAlignmentIntegrityGate,
+  checkDuplicateIdsGate,
+  preflightDataCheck,
+  runRegressionChecks,
+};

--- a/test/validation-tools.test.js
+++ b/test/validation-tools.test.js
@@ -1,0 +1,124 @@
+// Tests for workspace-tools/validation-tools.js — the validation gates that
+// dynamic-import their logic from the bp-assistant-skills clone.
+//
+// CSKILLBP_DIR is pointed at the skills checkout for the test run. If the
+// validation scripts are not present there (e.g. CI without the skills repo,
+// or a skills clone older than the quality-gates work), the suite skips
+// rather than fails.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Candidate skills checkouts, most specific first. Override with SKILLS_DIR_FOR_TESTS.
+const candidates = [
+  process.env.SKILLS_DIR_FOR_TESTS,
+  process.env.CSKILLBP_DIR,
+  path.resolve(__dirname, '../../bp-assistant-skills/.claude/worktrees/jolly-payne-b1c14e'),
+  path.resolve(__dirname, '../../bp-assistant-skills'),
+  '/srv/bot/workspace',
+].filter(Boolean);
+
+const skillsDir = candidates.find((d) =>
+  fs.existsSync(path.join(d, '.claude/skills/utilities/scripts/validation/validate_usfm_structure.mjs')));
+
+const SKIP = !skillsDir;
+if (!SKIP) {
+  process.env.CSKILLBP_DIR = skillsDir;
+  delete require.cache[require.resolve('../src/workspace-tools/validation-tools')];
+}
+const tools = SKIP ? null : require('../src/workspace-tools/validation-tools');
+
+const skipNote = 'skills validation scripts not found in any known checkout';
+
+function tmpFile(name, content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'valtools-'));
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+const HEBREW = `\\id TST Test
+\\c 1
+\\v 1
+\\w שָׁלוֹם|lemma="שָׁלוֹם" strong="H7965" x-morph="He,Ncmsa"\\w*
+\\v 2
+\\w ט֣וֹב|lemma="טוֹב" strong="H2896a" x-morph="He,Aamsa"\\w*
+`;
+
+test('validate_usfm_structure: passes clean USFM, fails missing verse', { skip: SKIP && skipNote }, async () => {
+  const good = tmpFile('good.usfm', '\\id TST\n\\c 1\n\\v 1 Peace.\n\\v 2 Good.\n');
+  let out = await tools.validateUsfmStructure({ usfm: good });
+  assert.match(out, /^OK:/);
+
+  const hebrew = tmpFile('heb.usfm', HEBREW);
+  const missing = tmpFile('missing.usfm', '\\id TST\n\\c 1\n\\v 1 Peace.\n');
+  out = await tools.validateUsfmStructure({ usfm: missing, source: hebrew, chapter: 1 });
+  assert.match(out, /^FAIL:/);
+  assert.match(out, /missing_vs_source/);
+});
+
+test('validate_alignment_integrity: flags content not in Hebrew', { skip: SKIP && skipNote }, async () => {
+  const hebrew = tmpFile('heb.usfm', HEBREW);
+  const aligned = tmpFile('aligned.usfm',
+    '\\id TST\n\\c 1\n\\v 1\n'
+    + '\\zaln-s |x-strong="H7965" x-lemma="שָׁלוֹם" x-morph="" x-occurrence="1" x-occurrences="1" x-content="שָׁלוֹם"\\*\\w peace|x-occurrence="1" x-occurrences="1"\\w*\\zaln-e\\*\n');
+  let out = await tools.validateAlignmentIntegrityGate({ aligned, hebrew, chapter: 1 });
+  assert.match(out, /^OK:/, out);
+
+  const bad = tmpFile('bad.usfm',
+    '\\id TST\n\\c 1\n\\v 1\n'
+    + '\\zaln-s |x-strong="H7965" x-lemma="שָׁלוֹם" x-morph="" x-occurrence="1" x-occurrences="1" x-content="טעות"\\*\\w peace|x-occurrence="1" x-occurrences="1"\\w*\\zaln-e\\*\n');
+  out = await tools.validateAlignmentIntegrityGate({ aligned: bad, hebrew, chapter: 1 });
+  assert.match(out, /^FAIL:/);
+  assert.match(out, /content_not_in_hebrew/);
+});
+
+test('check_duplicate_ids: catches duplicates across files', { skip: SKIP && skipNote }, async () => {
+  const header = 'Reference\tID\tTags\tQuote\tOccurrence\tNote\n';
+  const a = tmpFile('a.tsv', header + '1:1\tab12\t\tq\t1\tn\n');
+  const b = tmpFile('b.tsv', header + '2:1\tab12\t\tq\t1\tn\n');
+  let out = await tools.checkDuplicateIdsGate({ files: [a] });
+  assert.match(out, /^OK:/);
+  out = await tools.checkDuplicateIdsGate({ files: [a, b] });
+  assert.match(out, /^FAIL:/);
+  assert.match(out, /duplicate_id/);
+});
+
+test('preflight_data_check: reports missing reference data', { skip: SKIP && skipNote }, async () => {
+  // The real CSKILLBP_DIR for tests is the dev checkout, which intentionally
+  // has little data — preflight should FAIL loudly, never throw.
+  const out = await tools.preflightDataCheck({ book: 'NAM', stage: 'ult' });
+  assert.match(out, /^(OK|FAIL):/);
+  assert.match(out, /issues_resolved|hebrew_bible/);
+});
+
+test('run_regression_checks: catches a reintroduced closed bug', { skip: SKIP && skipNote }, async () => {
+  const bad = tmpFile('isa51.usfm', '\\id ISA\n\\c 51\n\\v 7 Listen to me. Do not fear the reproach of man.\n');
+  let out = await tools.runRegressionChecks({ stage: 'ULT', file: bad, book: 'ISA', chapter: 51 });
+  assert.match(out, /^FAIL:/);
+  assert.match(out, /#24/);
+
+  const good = tmpFile('isa51-good.usfm', '\\id ISA\n\\c 51\n\\v 7 Listen to me. May you not fear the reproach of man, and may you not be dismayed.\n');
+  out = await tools.runRegressionChecks({ stage: 'ULT', file: good, book: 'ISA', chapter: 51 });
+  assert.match(out, /^OK:/, out);
+});
+
+test('validators missing from clone produce a clear error', { skip: SKIP && skipNote }, async () => {
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'noskills-'));
+  const old = process.env.CSKILLBP_DIR;
+  process.env.CSKILLBP_DIR = empty;
+  delete require.cache[require.resolve('../src/workspace-tools/validation-tools')];
+  const fresh = require('../src/workspace-tools/validation-tools');
+  try {
+    await assert.rejects(
+      () => fresh.preflightDataCheck({ book: 'NAM' }),
+      /Validator not found.*refresh the skills repo|missing the validation scripts/i,
+    );
+  } finally {
+    process.env.CSKILLBP_DIR = old;
+    delete require.cache[require.resolve('../src/workspace-tools/validation-tools')];
+  }
+});


### PR DESCRIPTION
## What this does

Exposes the bp-assistant-skills validation gates as in-process MCP tools, and lays out the plan to wire them into the pipelines as enforced gates.

## Design: single source of truth

`src/workspace-tools/validation-tools.js` does **not** port the check logic into the bot. It dynamic-imports the validator modules from the skills clone (`CSKILLBP_DIR/.claude/skills/utilities/scripts/validation/`) with mtime-based cache-busting. So improving a check in bp-assistant-skills takes effect on the bot's next run with **no redeploy** — and we avoid the two-implementations drift that caused the June alignment churn.

## New MCP tools

Registered as `mcp__workspace-tools__*` in the main toolset (and the notes-relevant pair in the quality subset):

- `validate_usfm_structure`
- `validate_alignment_integrity`
- `check_duplicate_ids`
- `preflight_data_check`
- `run_regression_checks`

Each returns a text report whose first line starts `OK:` or `FAIL:`, so both agents and pipeline JS can branch on it. The functions are also callable directly from pipeline code for enforced gates.

## Wiring plan (not yet enforced)

`plans/validation-gates-wiring.md` specifies six gate points across generate / notes / TQ / push, with uniform **pass / one fix-retry / abort-artifact-and-report** semantics. Hard constraint honored throughout: **no human in the loop** — review happens post-merge in the UI tools, so a gate never waits for a person; it fixes, or skips that one artifact and posts the report to Zulip while the run continues. Rollout is `VALIDATION_GATES=log` (observe false-positive rate on real books) before flipping to `enforce`.

## Verification

- `test/validation-tools.test.js` — 6 new cases (pass/fail/skip paths + a clear error when the skills clone is stale), all passing.
- Full suite: 263/265 passing. The 2 failures (`fillOrigQuotes` in `tn-tools.test.js`) **predate this branch** — confirmed by stashing this change and re-running on main. Unrelated; tracked separately.

## Out of scope

- Pipeline enforcement itself (this PR adds the tools + plan; enforcement is the next step, deliberately staged behind a log-only burn-in).
- **gemini-review** stays dormant — no Gemini model meaningfully better than flash is available, so the second-opinion wave remains parked rather than fixed.

## Depends on

unfoldingWord/bp-assistant-skills (validators + regression checks). **Merge the skills PR first** — these tools import their logic from that clone; until skills lands, the tools return a clear "Validator not found, refresh the skills repo" rather than running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
