### PR TITLE
Fix batched-chapter truncation and verse-bridge push failures

### DIFF
--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -22,7 +22,7 @@ const { getCheckpoint, setCheckpoint, clearCheckpoint, buildCheckpointKey } = re
 const { buildGenerateContext, buildUstContext } = require('./pipeline-context');
 const { publishAdminStatus } = require('./admin-status');
 const { dispatchSelfDiagnosis } = require('./self-diagnosis');
-const { validateAlignedUsfmCompleteness } = require('./workspace-tools/usfm-tools');
+const { validateAlignedUsfmCompleteness, mergeAlignedUsfm } = require('./workspace-tools/usfm-tools');
 
 const LOG_DIR = path.resolve(__dirname, '../logs');
 const REQUIRED_INITIAL_PIPELINE_FILES = [
@@ -300,6 +300,43 @@ function isFreshOutput(relPath, minMs) {
   } catch {
     return false;
   }
+}
+
+// When a chapter is aligned in batches (e.g. JER-29-v01-v16-aligned.usfm +
+// JER-29-v17-v32-aligned.usfm), the pipeline must push a single merged
+// full-chapter file — never an individual batch, which would truncate the
+// chapter on door43. If the freshest discovered aligned file is a batch,
+// merge all sibling batches (in verse order) into the canonical
+// <book>-<ch>-aligned.usfm and return that path. Otherwise return the input
+// unchanged. Only batch files (…-vNN-vMM-aligned.usfm) trigger a merge;
+// full-chapter and verse-range (…-vvN-M-aligned.usfm) files pass through.
+function resolveMergedChapterAligned(book, discoveredRel) {
+  if (!discoveredRel) return discoveredRel;
+  const name = path.basename(discoveredRel);
+  const batchRe = new RegExp(`^(${book}-\\d+)-v\\d+-v\\d+-aligned\\.usfm$`);
+  const m = name.match(batchRe);
+  if (!m) return discoveredRel; // already a full-chapter or verse-range file
+
+  const dirRel = path.dirname(discoveredRel);
+  const absDir = path.resolve(CSKILLBP_DIR, dirRel);
+  const chapterPrefix = m[1]; // e.g. "JER-29"
+  const siblingRe = new RegExp(`^${chapterPrefix}-v(\\d+)-v\\d+-aligned\\.usfm$`);
+  let batches;
+  try {
+    batches = fs.readdirSync(absDir)
+      .map((f) => { const sm = f.match(siblingRe); return sm ? { f, start: parseInt(sm[1], 10) } : null; })
+      .filter(Boolean)
+      .sort((a, b) => a.start - b.start);
+  } catch (_) {
+    return discoveredRel;
+  }
+  if (batches.length < 2) return discoveredRel; // nothing to merge
+
+  const parts = batches.map((b) => path.join(dirRel, b.f));
+  const outputRel = path.join(dirRel, `${chapterPrefix}-aligned.usfm`);
+  const result = mergeAlignedUsfm({ parts, output: outputRel });
+  console.log(`[generate] Merged ${batches.length} alignment batches → ${outputRel}: ${result}`);
+  return outputRel;
 }
 
 function summarizeAlignmentValidation({ book, chapter, ultCheck, ustCheck }) {
@@ -1164,6 +1201,14 @@ async function generatePipeline(route, message) {
           break;
         }
 
+        // If alignment was split into batches, merge them into a single
+        // full-chapter file before validating/pushing. Skipped for verse-range
+        // runs, whose source is intentionally a verse subset.
+        if (!hasVerseRange) {
+          if (needUlt) alignedUltRel = resolveMergedChapterAligned(book, alignedUltRel);
+          if (needUst) alignedUstRel = resolveMergedChapterAligned(book, alignedUstRel);
+        }
+
         const ultCheck = needUlt ? validateAlignedUsfmCompleteness({ alignedUsfm: alignedUltRel }) : null;
         const ustCheck = needUst ? validateAlignedUsfmCompleteness({ alignedUsfm: alignedUstRel }) : null;
         finalValidationSummary = summarizeAlignmentValidation({ book, chapter: ch, ultCheck, ustCheck });
@@ -1625,4 +1670,5 @@ module.exports = {
   buildParsedGenerateRequest,
   hasRequiredGeneratedOutputs,
   shouldUseFileResponseMode,
+  resolveMergedChapterAligned,
 };

--- a/src/lib/insert-usfm-verses.js
+++ b/src/lib/insert-usfm-verses.js
@@ -19,6 +19,23 @@ function parseVerseRange(spec) {
   return [v, v];
 }
 
+// Collect every verse number covered by the source content, expanding verse
+// bridges (\v 1-2 covers both 1 and 2). Only matches \v at the start of a line
+// (optionally after a paragraph/poetry marker) so it never picks up a stray
+// \v inside alignment attribute data.
+function collectCoveredVerses(lines) {
+  const covered = new Set();
+  const pat = /^(?:\\[pqmsd]\d?\s+)?\\v\s+(\d+)(?:-(\d+))?/;
+  for (const line of lines) {
+    const m = line.trim().match(pat);
+    if (!m) continue;
+    const lo = parseInt(m[1], 10);
+    const hi = m[2] ? parseInt(m[2], 10) : lo;
+    for (let v = lo; v <= hi; v++) covered.add(v);
+  }
+  return covered;
+}
+
 function stripSourceHeader(lines) {
   const result = [];
   let foundVerse = false;
@@ -79,8 +96,11 @@ function findVerseBoundaries(lines, startIdx, endIdx, verseStart, verseEnd) {
   let replaceStart = null;
   let replaceEnd = null;
   const nextVerse = verseEnd + 1;
-  const verseStartPat = new RegExp(`\\\\v\\s+${verseStart}(?:\\s|$)`);
-  const nextVersePat = new RegExp(`\\\\v\\s+${nextVerse}(?:\\s|$)`);
+  // Allow a '-' after the verse number so a bridge (e.g. \v 1-2) is matched
+  // when looking for verse 1 — otherwise a chapter that opens with a bridge
+  // can't be located and the whole push aborts with "Verse N not found".
+  const verseStartPat = new RegExp(`\\\\v\\s+${verseStart}(?:[-\\s]|$)`);
+  const nextVersePat = new RegExp(`\\\\v\\s+${nextVerse}(?:[-\\s]|$)`);
 
   for (let i = startIdx; i < endIdx; i++) {
     const line = lines[i];
@@ -168,6 +188,24 @@ function insertUsfmVerses({ bookFile, sourceFile, chapter, verses, backup = fals
     throw new Error(`Chapter ${chapter} not found in ${bookFile}`);
   }
 
+  // Guard against pushing a truncated chapter: the source must cover every
+  // verse in the requested range. A partial source (e.g. only the first batch
+  // of a split chapter) would otherwise silently overwrite and delete the
+  // verses it's missing. Bridges in the source count for each verse they span.
+  const covered = collectCoveredVerses(sourceVerses);
+  const missing = [];
+  for (let v = verseStart; v <= verseEnd; v++) {
+    if (!covered.has(v)) missing.push(v);
+  }
+  if (missing.length) {
+    const have = [...covered].sort((a, b) => a - b);
+    throw new Error(
+      `Source is missing verse(s) ${missing.join(', ')} for chapter ${chapter} `
+      + `(requested ${verseStart}-${verseEnd}, source covers ${have[0]}-${have[have.length - 1]}) `
+      + `— refusing to push a partial chapter`
+    );
+  }
+
   // Find verse boundaries
   const [vStart, vEnd] = findVerseBoundaries(bookLines, chStart, chEnd, verseStart, verseEnd);
   if (vStart === null) {
@@ -191,14 +229,6 @@ function insertUsfmVerses({ bookFile, sourceFile, chapter, verses, backup = fals
     log.push(`WARNING: Verse marker count changed! Before: ${preCount}, After: ${postCount}`);
   } else {
     log.push(`Verse marker count: ${postCount} (unchanged)`);
-  }
-
-  // Verify inserted verses are present
-  const insertedText = sourceVerses.join('\n');
-  for (let v = verseStart; v <= verseEnd; v++) {
-    if (!new RegExp(`\\\\v\\s+${v}\\s`).test(insertedText)) {
-      log.push(`WARNING: \\v ${v} not found in inserted content`);
-    }
   }
 
   // Backup

--- a/test/aligned-batch-merge.test.js
+++ b/test/aligned-batch-merge.test.js
@@ -1,0 +1,81 @@
+// aligned-batch-merge.test.js — regression test for the JER 29 perfect storm.
+// When a chapter is aligned in batches, the pipeline must merge them into one
+// full-chapter file before pushing, never select a single batch (which pushed
+// only verses 1-16 of JER 29 and truncated en_ult master).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// CSKILLBP_DIR is captured at module load by pipeline-utils/usfm-tools, so it
+// must be set before requiring generate-pipeline.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'batch-merge-'));
+process.env.CSKILLBP_DIR = TMP;
+
+const { resolveMergedChapterAligned } = require('../src/generate-pipeline');
+
+function writeRel(rel, content) {
+  const full = path.join(TMP, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf8');
+  return rel;
+}
+
+const DIR = 'output/AI-UST/JER';
+
+function batch(ch, verses) {
+  return [
+    '\\id JER EN_UST - Aligned',
+    '\\usfm 3.0',
+    '\\h Jeremiah',
+    `\\c ${ch}`,
+    '\\p',
+    ...verses.map((v) => `\\v ${v} \\zaln-s |x-strong="H1"\\*\\w word|x-occurrence="1" x-occurrences="1"\\w*\\zaln-e\\*`),
+    '',
+  ].join('\n');
+}
+
+test('merges sibling batches into a single full-chapter file', () => {
+  writeRel(`${DIR}/JER-29-v01-v16-aligned.usfm`, batch(29, ['1-2', '3', '4']));
+  writeRel(`${DIR}/JER-29-v17-v32-aligned.usfm`, batch(29, ['17', '18', '32']));
+
+  // discoverFreshOutput would return the freshest batch; pretend that's v01-v16.
+  const resolved = resolveMergedChapterAligned('JER', `${DIR}/JER-29-v01-v16-aligned.usfm`);
+
+  assert.equal(resolved, `${DIR}/JER-29-aligned.usfm`);
+  const merged = fs.readFileSync(path.join(TMP, resolved), 'utf8');
+  // Full verse sequence, batch headers stripped from the second part.
+  for (const v of ['1-2', '3', '4', '17', '18', '32']) {
+    assert.match(merged, new RegExp(`\\\\v ${v.replace('-', '-')}\\b`));
+  }
+  // Only one \c 29 (second batch's header was stripped).
+  assert.equal((merged.match(/\\c 29/g) || []).length, 1);
+});
+
+test('passes a full-chapter file through unchanged', () => {
+  const rel = writeRel(`${DIR}/JER-30-aligned.usfm`, batch(30, ['1', '2', '3']));
+  const resolved = resolveMergedChapterAligned('JER', rel);
+  assert.equal(resolved, rel);
+});
+
+test('passes a verse-range (vv) file through unchanged', () => {
+  const rel = writeRel(`${DIR}/JER-31-vv3-4-aligned.usfm`, batch(31, ['3', '4']));
+  const resolved = resolveMergedChapterAligned('JER', rel);
+  assert.equal(resolved, rel); // must NOT be treated as a batch
+});
+
+test('a lone batch with no sibling is left as-is (push guard handles it)', () => {
+  const rel = writeRel(`${DIR}/JER-32-v01-v16-aligned.usfm`, batch(32, ['1', '2']));
+  const resolved = resolveMergedChapterAligned('JER', rel);
+  assert.equal(resolved, rel); // fewer than 2 batches → nothing to merge
+});
+
+test('null input returns null', () => {
+  assert.equal(resolveMergedChapterAligned('JER', null), null);
+});
+
+test.after(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});

--- a/test/insert-usfm-verses.test.js
+++ b/test/insert-usfm-verses.test.js
@@ -1,0 +1,194 @@
+// insert-usfm-verses.test.js — regression tests for the JER 29 perfect storm.
+// Covers: (1) verse-bridge matching at the chapter's start verse (\v 1 must
+// match a \v 1-2 bridge), and (2) the hard guard that refuses to push a
+// chapter whose source is missing verses in the requested range — which
+// previously truncated en_ult JER 29 from 32 verses to 16.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { insertUsfmVerses } = require('../src/lib/insert-usfm-verses');
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'insert-usfm-'));
+}
+
+function write(dir, name, content) {
+  const full = path.join(dir, name);
+  fs.writeFileSync(full, content, 'utf8');
+  return full;
+}
+
+// A minimal two-chapter book file. The marker after \c lives on its own line
+// so findChapterRange's `^\c N$` anchor matches.
+function bookFile(ch29Verses) {
+  return [
+    '\\id JER',
+    '\\h Jeremiah',
+    '\\c 29',
+    '\\p',
+    ...ch29Verses,
+    '\\c 30',
+    '\\p',
+    '\\v 1 Chapter thirty verse one.',
+    '',
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Bridge matching at the start verse
+// ---------------------------------------------------------------------------
+
+test('replaces a chapter that opens with a verse bridge (\\v 1-2)', () => {
+  const dir = makeTempDir();
+  try {
+    const book = write(dir, '24-JER.usfm', bookFile([
+      '\\v 1-2 old one and two',
+      '\\v 3 old three',
+    ]));
+    const source = write(dir, 'src.usfm', [
+      '\\id JER EN_UST - Aligned',
+      '\\c 29',
+      '\\p',
+      '\\v 1-2 new one and two',
+      '\\v 3 new three',
+      '',
+    ].join('\n'));
+
+    insertUsfmVerses({ bookFile: book, sourceFile: source, chapter: 29, verses: '1-3' });
+
+    const out = fs.readFileSync(book, 'utf8');
+    assert.match(out, /\\v 1-2 new one and two/);
+    assert.match(out, /\\v 3 new three/);
+    assert.doesNotMatch(out, /old one and two/);
+    // chapter 30 must be left intact
+    assert.match(out, /\\c 30[\s\S]*Chapter thirty verse one\./);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Truncation guard — the core of the JER 29 regression
+// ---------------------------------------------------------------------------
+
+test('throws when the source is missing verses in the requested range', () => {
+  const dir = makeTempDir();
+  try {
+    const book = write(dir, '24-JER.usfm', bookFile([
+      '\\v 1 a', '\\v 2 b', '\\v 3 c', '\\v 4 d',
+    ]));
+    // Source only covers verses 1-2 (a single batch of a split chapter).
+    const source = write(dir, 'src.usfm', [
+      '\\id JER', '\\c 29', '\\p', '\\v 1 new a', '\\v 2 new b', '',
+    ].join('\n'));
+
+    assert.throws(
+      () => insertUsfmVerses({ bookFile: book, sourceFile: source, chapter: 29, verses: '1-4' }),
+      /missing verse\(s\) 3, 4 for chapter 29/,
+    );
+
+    // The book file must be untouched — the guard fires before any write.
+    const out = fs.readFileSync(book, 'utf8');
+    assert.match(out, /\\v 3 c/);
+    assert.match(out, /\\v 4 d/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a bridge in the source counts for every verse it spans', () => {
+  const dir = makeTempDir();
+  try {
+    const book = write(dir, '24-JER.usfm', bookFile([
+      '\\v 1 a', '\\v 2 b', '\\v 3 c',
+    ]));
+    // Source covers 1,2 (via bridge) and 3 — full coverage of 1-3.
+    const source = write(dir, 'src.usfm', [
+      '\\id JER', '\\c 29', '\\p', '\\v 1-2 new bridge', '\\v 3 new three', '',
+    ].join('\n'));
+
+    // Should NOT throw — coverage is complete once the bridge is expanded.
+    insertUsfmVerses({ bookFile: book, sourceFile: source, chapter: 29, verses: '1-3' });
+    const out = fs.readFileSync(book, 'utf8');
+    assert.match(out, /\\v 1-2 new bridge/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Existing behaviour preserved
+// ---------------------------------------------------------------------------
+
+test('full-chapter replacement with complete source still works', () => {
+  const dir = makeTempDir();
+  try {
+    const book = write(dir, '24-JER.usfm', bookFile([
+      '\\v 1 a', '\\v 2 b', '\\v 3 c',
+    ]));
+    const source = write(dir, 'src.usfm', [
+      '\\id JER', '\\c 29', '\\p', '\\v 1 A', '\\v 2 B', '\\v 3 C', '',
+    ].join('\n'));
+
+    insertUsfmVerses({ bookFile: book, sourceFile: source, chapter: 29, verses: '1-3' });
+    const out = fs.readFileSync(book, 'utf8');
+    assert.match(out, /\\v 1 A/);
+    assert.match(out, /\\v 3 C/);
+    assert.doesNotMatch(out, /\\v 1 a\b/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('verse-range (subset) push only replaces the requested verses', () => {
+  const dir = makeTempDir();
+  try {
+    const book = write(dir, '24-JER.usfm', bookFile([
+      '\\v 1 a', '\\v 2 b', '\\v 3 c', '\\v 4 d', '\\v 5 e',
+    ]));
+    // Requesting only 3-4; source covers exactly 3-4.
+    const source = write(dir, 'src.usfm', [
+      '\\id JER', '\\c 29', '\\p', '\\v 3 NEW3', '\\v 4 NEW4', '',
+    ].join('\n'));
+
+    insertUsfmVerses({ bookFile: book, sourceFile: source, chapter: 29, verses: '3-4' });
+    const out = fs.readFileSync(book, 'utf8');
+    assert.match(out, /\\v 3 NEW3/);
+    assert.match(out, /\\v 4 NEW4/);
+    // Surrounding verses untouched
+    assert.match(out, /\\v 1 a/);
+    assert.match(out, /\\v 2 b/);
+    assert.match(out, /\\v 5 e/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('multi-digit start verse anchors exactly (\\v 10 boundary)', () => {
+  const dir = makeTempDir();
+  try {
+    // Requesting 10-11 must anchor at \v 10 and stop before \v 12, leaving the
+    // earlier verses and \v 12 intact. Exercises the bridge-tolerant regex on a
+    // multi-digit start verse without matching \v 1.
+    const book = write(dir, '24-JER.usfm', bookFile([
+      '\\v 1 a', '\\v 10 old ten', '\\v 11 old eleven', '\\v 12 l',
+    ]));
+    const source = write(dir, 'src.usfm', [
+      '\\id JER', '\\c 29', '\\p', '\\v 10 NEW10', '\\v 11 NEW11', '',
+    ].join('\n'));
+
+    insertUsfmVerses({ bookFile: book, sourceFile: source, chapter: 29, verses: '10-11' });
+    const out = fs.readFileSync(book, 'utf8');
+    assert.match(out, /\\v 10 NEW10/);
+    assert.match(out, /\\v 11 NEW11/);
+    assert.match(out, /\\v 1 a/);   // earlier verse untouched
+    assert.match(out, /\\v 12 l/);  // next verse untouched
+    assert.doesNotMatch(out, /old ten/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

The JER 29 generate pipeline pushed **only verses 1–16** to door43:

- **en_ult**: merged a PR that replaced chapter 29 (32 verses) with just the first 16 — **verses 17–32 were deleted from master** (since repaired manually).
- **en_ust**: aborted entirely with `Verse 1 not found in chapter 29`, because en_ust's chapter opens with a verse bridge `\v 1-2`.

## Root cause (a perfect storm)

JER 29 (32 verses) was aligned in two batches — `JER-29-v01-v16-aligned.usfm` and `JER-29-v17-v32-aligned.usfm` — that were never merged into a full-chapter file. A per-batch alignment **retry** rewrote the v01-v16 batch, making it the freshest match, so `discoverFreshOutput` selected a single batch as the chapter source. The push then:

1. **ULT**: inserted "verses 1–32" from a 16-verse source — `insertUsfmVerses` only *warned* on the missing verses and overwrote anyway (32 → 16).
2. **UST**: `findVerseBoundaries` looked for `\v 1` with a regex that can't match the `\v 1-2` bridge, and aborted.

`validateAlignedUsfmCompleteness` didn't catch the truncation: it measures alignment quality as a ratio *within the file it's given*, so a complete 16-verse batch scores 100% — it has no notion that 32 verses were expected.

## Fix — defense in depth

Either layer alone would have prevented the data loss.

**1. Self-heal — `generate-pipeline.js`**
`resolveMergedChapterAligned()` detects when the discovered aligned file is a batch (`…-vNN-vMM-aligned.usfm`) and merges all sibling batches (in verse order) into the canonical `<book>-<ch>-aligned.usfm` before validation/push. Skipped for verse-range (`…-vvN-M-aligned.usfm`) runs.

**2. Hard backstop — `insert-usfm-verses.js`**
- Bridge-safe matching: the start/next verse regexes allow a `-` after the number, so `\v 1` matches a `\v 1-2` bridge.
- Truncation guard: `collectCoveredVerses()` expands bridges and the insert now **throws** (`Source is missing verse(s) … — refusing to push a partial chapter`) when the source doesn't cover the full requested range, replacing the old silent `WARNING:` loop. The throw fires before any write, so the target file is left untouched on failure.

## Testing

- New: `test/insert-usfm-verses.test.js` (bridge replace, truncation guard, bridge coverage, full + subset pushes, multi-digit anchoring) and `test/aligned-batch-merge.test.js` (batch merge, full-chapter/verse-range passthrough, lone-batch, null) — 11 tests, all passing.
- Full suite: 278 pass. The 3 unrelated failures (`check_tn_quality`, `fillOrigQuotes` ×2) are pre-existing — confirmed by stashing these changes and re-running.

> Note: JER 29 itself is already correct on door43 master (repaired out-of-band). This PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
