### PR TITLE
Fail loudly when an alignment-batch merge fails

### DIFF
--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -334,7 +334,16 @@ function resolveMergedChapterAligned(book, discoveredRel) {
 
   const parts = batches.map((b) => path.join(dirRel, b.f));
   const outputRel = path.join(dirRel, `${chapterPrefix}-aligned.usfm`);
+  // mergeAlignedUsfm signals failure by returning an "Error: …" string rather
+  // than throwing. Returning outputRel regardless would point validation at a
+  // file that was never written, masking the real cause behind a misleading
+  // "missing file" retry. Throw instead so the chapter fails with a clear
+  // diagnostic and no wasted re-alignment.
   const result = mergeAlignedUsfm({ parts, output: outputRel });
+  if (String(result).startsWith('Error:')
+      || !fs.existsSync(path.resolve(CSKILLBP_DIR, outputRel))) {
+    throw new Error(`Failed to merge alignment batches for ${chapterPrefix}: ${result}`);
+  }
   console.log(`[generate] Merged ${batches.length} alignment batches → ${outputRel}: ${result}`);
   return outputRel;
 }

--- a/test/aligned-batch-merge.test.js
+++ b/test/aligned-batch-merge.test.js
@@ -48,7 +48,7 @@ test('merges sibling batches into a single full-chapter file', () => {
   const merged = fs.readFileSync(path.join(TMP, resolved), 'utf8');
   // Full verse sequence, batch headers stripped from the second part.
   for (const v of ['1-2', '3', '4', '17', '18', '32']) {
-    assert.match(merged, new RegExp(`\\\\v ${v.replace('-', '-')}\\b`));
+    assert.match(merged, new RegExp(`\\\\v ${v}\\b`));
   }
   // Only one \c 29 (second batch's header was stripped).
   assert.equal((merged.match(/\\c 29/g) || []).length, 1);
@@ -70,6 +70,19 @@ test('a lone batch with no sibling is left as-is (push guard handles it)', () =>
   const rel = writeRel(`${DIR}/JER-32-v01-v16-aligned.usfm`, batch(32, ['1', '2']));
   const resolved = resolveMergedChapterAligned('JER', rel);
   assert.equal(resolved, rel); // fewer than 2 batches → nothing to merge
+});
+
+test('throws (instead of returning a non-existent path) when a merge fails', () => {
+  // Two "batches" exist, but one is a directory — the merge cannot read it, so
+  // resolveMergedChapterAligned must throw rather than return the canonical
+  // path to a file that was never written (which would mask the cause behind a
+  // misleading "missing file" alignment retry).
+  writeRel(`${DIR}/JER-33-v01-v16-aligned.usfm`, batch(33, ['1', '2']));
+  fs.mkdirSync(path.join(TMP, DIR, 'JER-33-v17-v32-aligned.usfm'), { recursive: true });
+
+  assert.throws(() => resolveMergedChapterAligned('JER', `${DIR}/JER-33-v01-v16-aligned.usfm`));
+  // The canonical merged file must NOT have been left behind as a valid result.
+  assert.equal(fs.existsSync(path.join(TMP, DIR, 'JER-33-aligned.usfm')), false);
 });
 
 test('null input returns null', () => {


### PR DESCRIPTION
## What

Follow-up to the [#120](https://github.com/unfoldingWord/bp-assistant/pull/120) review (blocking-list finding #1).

`resolveMergedChapterAligned` called `mergeAlignedUsfm` and returned the canonical merged path unconditionally. But `mergeAlignedUsfm` signals failure by **returning an `"Error: …"` string**, not by throwing. So if the merge failed (e.g. a filesystem race between `readdirSync` and the read), the function returned a path to a file that was never written — `validateAlignedUsfmCompleteness` then failed on a *missing file*, triggering a wasteful full alignment retry instead of surfacing the real cause.

## Fix

Throw a clear error when the merge returns an `Error:` string **or** the output file is absent after the call, so the chapter fails fast with a useful diagnostic (the alignment loop's existing `catch` reports it) and no unnecessary re-alignment.

Also: removed a no-op `.replace('-','-')` in `test/aligned-batch-merge.test.js` and added a test asserting a failed merge throws rather than returning a non-existent path.

## Testing

`node --test test/aligned-batch-merge.test.js test/insert-usfm-verses.test.js` → 12 pass. Full suite: 279 pass (3 pre-existing unrelated failures, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
