### PR TITLE
Gate invalid TN SupportReference as an error; allow sref correction

### DIFF
--- a/src/workspace-tools/index.js
+++ b/src/workspace-tools/index.js
@@ -573,12 +573,13 @@ function createQualityTools(createSdkMcpServer, tool, z) {
         id: z.string().describe('The note id to update'),
         note: z.string().describe('The full replacement note text'),
       }, async (args) => ({ content: [{ type: 'text', text: updateNoteText(args) }] })),
-      tool('update_prepared_quote', 'Set quote fields for one prepared note by id (in prepared_notes.json). Only the provided fields are changed. After updating, re-run assemble_notes + curly_quotes.', {
+      tool('update_prepared_quote', 'Set quote or support-reference fields for one prepared note by id (in prepared_notes.json). Only the provided fields are changed. After updating, re-run assemble_notes + curly_quotes.', {
         preparedJson: z.string().describe('Path to prepared_notes.json (runtime.preparedNotes)'),
         id: z.string().describe('The prepared item id to update'),
         glQuote: z.string().optional().describe('New gl_quote'),
         glQuoteRoundtripped: z.string().optional().describe('New gl_quote_roundtripped'),
         origQuote: z.string().optional().describe('New orig_quote'),
+        sref: z.string().optional().describe('New support reference issue type — a valid slug from data/translation-issues.csv (e.g. writing-poetry). The rc:// prefix is stripped if present.'),
       }, async (args) => ({ content: [{ type: 'text', text: updatePreparedQuote(args) }] })),
       tool('remove_note', 'Remove one note by id from generated_notes.json and/or directly from an assembled TSV row. Use for antithetical-parallelism or redundant notes.', {
         id: z.string().describe('The note id to remove'),

--- a/src/workspace-tools/quality-tools.js
+++ b/src/workspace-tools/quality-tools.js
@@ -683,7 +683,7 @@ async function checkTnQuality({ tsvPath, preparedJson, ultUsfm, ustUsfm, book, h
     if (n.sref) {
       const slugMatch = n.sref.match(/rc:\/\/\*\/ta\/man\/translate\/([^\s;,]+)/);
       if (slugMatch && validIssues.size && !validIssues.has(slugMatch[1])) {
-        addFinding(n.row, n.ref, n.id, 'warning', 'unknown_sref', `Unknown issue type: "${slugMatch[1]}"`);
+        addFinding(n.row, n.ref, n.id, 'error', 'unknown_sref', `Invalid issue type "${slugMatch[1]}" — not in the issue list. Re-select a valid type from data/translation-issues.csv (e.g. wordplay/paronomasia -> writing-poetry) and set it with update_prepared_quote sref. Do not invent slugs.`);
       }
     }
 

--- a/src/workspace-tools/tn-tools.js
+++ b/src/workspace-tools/tn-tools.js
@@ -1405,7 +1405,7 @@ function updateNoteText({ generatedJson, id, note }) {
   return `Updated note text for id "${id}" in ${generatedJson}. Re-run assemble_notes + curly_quotes to apply.`;
 }
 
-function updatePreparedQuote({ preparedJson, id, glQuote, glQuoteRoundtripped, origQuote }) {
+function updatePreparedQuote({ preparedJson, id, glQuote, glQuoteRoundtripped, origQuote, sref }) {
   if (!preparedJson) return 'ERROR: preparedJson is required';
   if (!id) return 'ERROR: id is required';
   const p = path.resolve(CSKILLBP_DIR, preparedJson);
@@ -1419,7 +1419,8 @@ function updatePreparedQuote({ preparedJson, id, glQuote, glQuoteRoundtripped, o
   if (glQuote !== undefined) { item.gl_quote = glQuote; changed.push('gl_quote'); }
   if (glQuoteRoundtripped !== undefined) { item.gl_quote_roundtripped = glQuoteRoundtripped; changed.push('gl_quote_roundtripped'); }
   if (origQuote !== undefined) { item.orig_quote = origQuote; changed.push('orig_quote'); }
-  if (!changed.length) return `No quote fields provided for id "${id}"; nothing changed.`;
+  if (sref !== undefined) { item.sref = String(sref).replace(/^rc:\/\/\*\/ta\/man\/translate\//, ''); changed.push('sref'); }
+  if (!changed.length) return `No fields provided for id "${id}"; nothing changed.`;
   fs.writeFileSync(p, JSON.stringify(prep, null, 2) + '\n');
   return `Updated ${changed.join(', ')} for id "${id}" in ${preparedJson}. Re-run assemble_notes + curly_quotes to apply.`;
 }

--- a/test/quality-edit-tools.test.js
+++ b/test/quality-edit-tools.test.js
@@ -59,6 +59,17 @@ test('updatePreparedQuote returns a clear message for a missing id', () => {
   assert.match(out, /ERROR: id "zz9z" not found/);
 });
 
+test('updatePreparedQuote sets sref and strips the rc:// prefix', () => {
+  const rel = writeJson('prep3.json', { items: [
+    { id: 'ab1c', gl_quote: 'q', sref: 'figs-paronomasia' },
+  ] });
+  const out = updatePreparedQuote({ preparedJson: rel, id: 'ab1c', sref: 'rc://*/ta/man/translate/writing-poetry' });
+  assert.match(out, /sref/);
+  const item = readJson('prep3.json').items.find((i) => i.id === 'ab1c');
+  assert.equal(item.sref, 'writing-poetry');
+  assert.equal(item.gl_quote, 'q'); // not provided → unchanged
+});
+
 test('removeNote drops the entry from generated JSON and the matching TSV row, preserving header', () => {
   const genRel = writeJson('gen3.json', { ab1c: 'note A', de2f: 'note B' });
   const tsvRel = 'notes3.tsv';


### PR DESCRIPTION
## Problem
A Zec 6 run produced a translation note with SupportReference `figs-paronomasia` — an invented slug with no corresponding issue type. The `unknown_sref` check already validated support references against `data/translation-issues.csv`, but only as an advisory warning, so it could not gate delivery.

## Changes
- **quality-tools.js**: escalate `unknown_sref` from warning to **error**, with a message directing re-selection of a valid type (e.g. wordplay/paronomasia → `writing-poetry`).
- **tn-tools.js / index.js**: `update_prepared_quote` now accepts an optional `sref` field (strips the `rc://` prefix) so a wrong issue type can be corrected in place instead of deleting the note.
- **test/quality-edit-tools.test.js**: covers the new sref path.

Existing quality tests pass (13/13); the unrelated `fillOrigQuotes` failures are pre-existing on `main`.

## Companion
Paired with bp-assistant-skills PR #98, which routes wordplay/sound play to `writing-poetry`, constrains the supportreference column to listed slugs, and documents this gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)