### PR TITLE
Extend self-diagnosis to alignment, push, and verify phases

### DIFF
--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -389,10 +389,15 @@ async function generatePipeline(route, message) {
 
   // Convenience wrapper for terminal failures outside Phase 1 (alignment
   // validation, door43-push, repo-verify): attaches the current checkpoint and
-  // a short error context. No-ops unless the event severity is 'error', so it
-  // is safe to call on any status event.
+  // a short error context. Callers invoke this ONLY at terminal failures, so it
+  // forces 'error' severity rather than trusting inferSeverity on the status
+  // text — e.g. a "source file missing" message infers as 'warn', which would
+  // otherwise silently suppress the diagnosis. This decouples the dispatch
+  // decision from the human-facing wording.
   function fireDiagnosisFor(event, errorText) {
-    fireDiagnosis(event, { checkpoint: getCheckpoint(checkpointRef), errorText });
+    if (!event) return;
+    const errorEvent = event.severity === 'error' ? event : { ...event, severity: 'error' };
+    fireDiagnosis(errorEvent, { checkpoint: getCheckpoint(checkpointRef), errorText });
   }
 
   // Helper: reply to the originating stream
@@ -1520,12 +1525,12 @@ async function generatePipeline(route, message) {
       const pushUlt = contentTypes.includes('ult') && chData.ultAligned;
       const pushUst = contentTypes.includes('ust') && chData.ustAligned;
       if (pushUlt && !fs.existsSync(path.resolve(CSKILLBP_DIR, chData.ultAligned))) {
-        const ultMissingEvent = await status(`**door43-push** SKIPPED (ULT) for ${book} ${chData.ch}: source file missing: ${chData.ultAligned}`);
+        const ultMissingEvent = await status(`**door43-push** failed (ULT) for ${book} ${chData.ch}: aligned source file missing: ${chData.ultAligned}`);
         fireDiagnosisFor(ultMissingEvent, `Phase: door43-push (ULT)\nChapter: ${book} ${chData.ch}\nAligned source file missing at push time: ${chData.ultAligned}`);
         chapterFailed = true;
       }
       if (!chapterFailed && pushUst && !fs.existsSync(path.resolve(CSKILLBP_DIR, chData.ustAligned))) {
-        const ustMissingEvent = await status(`**door43-push** SKIPPED (UST) for ${book} ${chData.ch}: source file missing: ${chData.ustAligned}`);
+        const ustMissingEvent = await status(`**door43-push** failed (UST) for ${book} ${chData.ch}: aligned source file missing: ${chData.ustAligned}`);
         fireDiagnosisFor(ustMissingEvent, `Phase: door43-push (UST)\nChapter: ${book} ${chData.ch}\nAligned source file missing at push time: ${chData.ustAligned}`);
         chapterFailed = true;
       }

--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -387,6 +387,14 @@ async function generatePipeline(route, message) {
     });
   }
 
+  // Convenience wrapper for terminal failures outside Phase 1 (alignment
+  // validation, door43-push, repo-verify): attaches the current checkpoint and
+  // a short error context. No-ops unless the event severity is 'error', so it
+  // is safe to call on any status event.
+  function fireDiagnosisFor(event, errorText) {
+    fireDiagnosis(event, { checkpoint: getCheckpoint(checkpointRef), errorText });
+  }
+
   // Helper: reply to the originating stream
   async function reply(text) {
     try {
@@ -1182,7 +1190,7 @@ async function generatePipeline(route, message) {
 
         if ((needUlt && !alignedUltRel) || (needUst && !alignedUstRel)) {
           const missing = [needUlt && !alignedUltRel && 'ULT', needUst && !alignedUstRel && 'UST'].filter(Boolean).join(', ');
-          await status(`**align-all-parallel** failed for ${book} ${ch} at ${new Date().toISOString()} — aligned ${missing} file(s) not found (${alignDuration}s)`);
+          const missingAlignEvent = await status(`**align-all-parallel** failed for ${book} ${ch} at ${new Date().toISOString()} — aligned ${missing} file(s) not found (${alignDuration}s)`);
           fail++;
           setCheckpoint(checkpointRef, {
             state: 'failed',
@@ -1192,11 +1200,12 @@ async function generatePipeline(route, message) {
             current: { chapter: ch, skill: 'align-all-parallel', status: 'failed', errorKind: 'missing_output', outputStatus: 'missing' },
             resume: { chapter: ch, skill: 'align-all-parallel' },
           });
+          fireDiagnosisFor(missingAlignEvent, `Phase: align-all-parallel\nChapter: ${book} ${ch}\nAligned ${missing} output file(s) not found after alignment completed.`);
           alignmentTerminalFailure = true;
           break;
         }
         if ((needUlt && !isFreshOutput(alignedUltRel, chapterStart)) || (needUst && !isFreshOutput(alignedUstRel, chapterStart))) {
-          await status(`**align-all-parallel** failed for ${book} ${ch} at ${new Date().toISOString()} — aligned output appears stale from an earlier run`);
+          const staleAlignEvent = await status(`**align-all-parallel** failed for ${book} ${ch} at ${new Date().toISOString()} — aligned output appears stale from an earlier run`);
           fail++;
           setCheckpoint(checkpointRef, {
             state: 'failed',
@@ -1206,6 +1215,7 @@ async function generatePipeline(route, message) {
             current: { chapter: ch, skill: 'align-all-parallel', status: 'failed', errorKind: 'stale_output', outputStatus: 'stale' },
             resume: { chapter: ch, skill: 'align-all-parallel' },
           });
+          fireDiagnosisFor(staleAlignEvent, `Phase: align-all-parallel\nChapter: ${book} ${ch}\nAligned output appears stale (mtime older than this run) — alignment may not have rewritten it.`);
           alignmentTerminalFailure = true;
           break;
         }
@@ -1264,7 +1274,7 @@ async function generatePipeline(route, message) {
       if (alignmentTerminalFailure) continue;
 
       if (!alignmentValidated) {
-        await status(`**align-all-parallel** failed for ${book} ${ch} at ${new Date().toISOString()} — degraded alignment (${finalValidationSummary})`);
+        const degradedEvent = await status(`**align-all-parallel** failed for ${book} ${ch} at ${new Date().toISOString()} — degraded alignment (${finalValidationSummary})`);
         fail++;
         setCheckpoint(checkpointRef, {
           state: 'failed',
@@ -1281,6 +1291,7 @@ async function generatePipeline(route, message) {
           },
           resume: { chapter: ch, skill: 'align-all-parallel' },
         });
+        fireDiagnosisFor(degradedEvent, `Phase: align-all-parallel\nChapter: ${book} ${ch}\nDegraded alignment after retries: ${finalValidationSummary}`);
         continue;
       }
 
@@ -1509,11 +1520,13 @@ async function generatePipeline(route, message) {
       const pushUlt = contentTypes.includes('ult') && chData.ultAligned;
       const pushUst = contentTypes.includes('ust') && chData.ustAligned;
       if (pushUlt && !fs.existsSync(path.resolve(CSKILLBP_DIR, chData.ultAligned))) {
-        await status(`**door43-push** SKIPPED (ULT) for ${book} ${chData.ch}: source file missing: ${chData.ultAligned}`);
+        const ultMissingEvent = await status(`**door43-push** SKIPPED (ULT) for ${book} ${chData.ch}: source file missing: ${chData.ultAligned}`);
+        fireDiagnosisFor(ultMissingEvent, `Phase: door43-push (ULT)\nChapter: ${book} ${chData.ch}\nAligned source file missing at push time: ${chData.ultAligned}`);
         chapterFailed = true;
       }
       if (!chapterFailed && pushUst && !fs.existsSync(path.resolve(CSKILLBP_DIR, chData.ustAligned))) {
-        await status(`**door43-push** SKIPPED (UST) for ${book} ${chData.ch}: source file missing: ${chData.ustAligned}`);
+        const ustMissingEvent = await status(`**door43-push** SKIPPED (UST) for ${book} ${chData.ch}: source file missing: ${chData.ustAligned}`);
+        fireDiagnosisFor(ustMissingEvent, `Phase: door43-push (UST)\nChapter: ${book} ${chData.ch}\nAligned source file missing at push time: ${chData.ustAligned}`);
         chapterFailed = true;
       }
 
@@ -1535,7 +1548,8 @@ async function generatePipeline(route, message) {
           });
           if (!pushResultUlt.success) {
             console.error(`[generate] door43-push ULT failed for ${book} ${chData.ch}: ${pushResultUlt.details}`);
-            await status(`**door43-push** (ULT) failed for ${book} ${chData.ch}: ${pushResultUlt.details}`);
+            const ultPushFailEvent = await status(`**door43-push** (ULT) failed for ${book} ${chData.ch}: ${pushResultUlt.details}`);
+            fireDiagnosisFor(ultPushFailEvent, `Phase: door43-push (ULT)\nChapter: ${book} ${chData.ch}\nSource: ${chData.ultAligned}\nPush failed: ${pushResultUlt.details}`);
             chapterFailed = true;
           } else {
             ultNoChanges = pushResultUlt.noChanges === true;
@@ -1544,7 +1558,8 @@ async function generatePipeline(route, message) {
           }
         } catch (err) {
           console.error(`[generate] door43-push ULT error for ${book} ${chData.ch}: ${err.message}`);
-          await status(`**door43-push** (ULT) failed for ${book} ${chData.ch}: ${err.message}`);
+          const ultPushErrEvent = await status(`**door43-push** (ULT) failed for ${book} ${chData.ch}: ${err.message}`);
+          fireDiagnosisFor(ultPushErrEvent, `Phase: door43-push (ULT)\nChapter: ${book} ${chData.ch}\nSource: ${chData.ultAligned}\nThrew: ${err.message}`);
           chapterFailed = true;
         }
       }
@@ -1561,7 +1576,8 @@ async function generatePipeline(route, message) {
           });
           if (!pushResultUst.success) {
             console.error(`[generate] door43-push UST failed for ${book} ${chData.ch}: ${pushResultUst.details}`);
-            await status(`**door43-push** (UST) failed for ${book} ${chData.ch}: ${pushResultUst.details}`);
+            const ustPushFailEvent = await status(`**door43-push** (UST) failed for ${book} ${chData.ch}: ${pushResultUst.details}`);
+            fireDiagnosisFor(ustPushFailEvent, `Phase: door43-push (UST)\nChapter: ${book} ${chData.ch}\nSource: ${chData.ustAligned}\nPush failed: ${pushResultUst.details}`);
             chapterFailed = true;
           } else {
             ustNoChanges = pushResultUst.noChanges === true;
@@ -1570,7 +1586,8 @@ async function generatePipeline(route, message) {
           }
         } catch (err) {
           console.error(`[generate] door43-push UST error for ${book} ${chData.ch}: ${err.message}`);
-          await status(`**door43-push** (UST) failed for ${book} ${chData.ch}: ${err.message}`);
+          const ustPushErrEvent = await status(`**door43-push** (UST) failed for ${book} ${chData.ch}: ${err.message}`);
+          fireDiagnosisFor(ustPushErrEvent, `Phase: door43-push (UST)\nChapter: ${book} ${chData.ch}\nSource: ${chData.ustAligned}\nThrew: ${err.message}`);
           chapterFailed = true;
         }
       }
@@ -1591,11 +1608,13 @@ async function generatePipeline(route, message) {
         const ustVerify = verifyUst ? await verifyRepoPush({ repo: 'en_ust', stagingBranch, since: pushStartTime, prNumber: ustPrNumber }) : { success: true };
 
         if (verifyUlt && !ultVerify.success) {
-          await status(`Repo verify FAILED (ULT) for ${book} ${chData.ch}: ${ultVerify.details}`);
+          const ultVerifyEvent = await status(`Repo verify FAILED (ULT) for ${book} ${chData.ch}: ${ultVerify.details}`);
+          fireDiagnosisFor(ultVerifyEvent, `Phase: repo-verify (ULT)\nChapter: ${book} ${chData.ch}\nPush reported success but post-merge verification failed: ${ultVerify.details}`);
           chapterFailed = true;
         }
         if (verifyUst && !ustVerify.success) {
-          await status(`Repo verify FAILED (UST) for ${book} ${chData.ch}: ${ustVerify.details}`);
+          const ustVerifyEvent = await status(`Repo verify FAILED (UST) for ${book} ${chData.ch}: ${ustVerify.details}`);
+          fireDiagnosisFor(ustVerifyEvent, `Phase: repo-verify (UST)\nChapter: ${book} ${chData.ch}\nPush reported success but post-merge verification failed: ${ustVerify.details}`);
           chapterFailed = true;
         }
         const verifiedTypes = [verifyUlt && 'ULT', verifyUst && 'UST'].filter(Boolean).join(' and ');

--- a/test/generate-pipeline-early-exit.test.js
+++ b/test/generate-pipeline-early-exit.test.js
@@ -508,6 +508,41 @@ test('generatePipeline fires self-diagnosis when door43-push fails', async () =>
   }
 });
 
+test('generatePipeline fires self-diagnosis when an aligned source is missing at push time', async () => {
+  // Resume at door43-push with a checkpoint that references aligned files which
+  // no longer exist on disk. The pre-flight existence check must dispatch
+  // diagnosis — its status text ("source file missing") infers as 'warn', so
+  // this guards against the severity-gating regression caught in PR #123 review.
+  const harness = createHarness({
+    initialCheckpoint: {
+      state: 'failed',
+      success: 1,
+      completedChapters: [{
+        ch: 52,
+        ultAligned: 'output/AI-ULT/ISA/ISA-52-aligned.usfm',
+        ustAligned: 'output/AI-UST/ISA/ISA-52-aligned.usfm',
+      }],
+      resume: { chapter: 52, skill: 'door43-push' },
+    },
+    // Phase 1 is skipped on a door43-push resume, so runClaude must not be called.
+    runClaudeImpl: async () => { throw new Error('runClaude should not run when resuming at door43-push'); },
+  });
+
+  try {
+    await harness.generatePipeline(
+      { _synthetic: true, _book: 'ISA', _startChapter: 52, _endChapter: 52, skill: 'initial-pipeline', operations: 6 },
+      buildMessage('generate isa 52', { sender_id: 7 })
+    );
+
+    assert.equal(harness.runClaudeCalls.length, 0);
+    const missingDiag = harness.diagnosisCalls.find((c) => /source file missing/.test(c.errorText || ''));
+    assert.ok(missingDiag, 'expected a self-diagnosis dispatch for the missing aligned source');
+    assert.equal(missingDiag.event.severity, 'error');
+  } finally {
+    harness.cleanup();
+  }
+});
+
 test('generatePipeline reruns align-all-parallel when first post-align validation fails', async () => {
   let alignCalls = 0;
   const harness = createHarness({

--- a/test/generate-pipeline-early-exit.test.js
+++ b/test/generate-pipeline-early-exit.test.js
@@ -27,7 +27,7 @@ function buildMessage(content, overrides = {}) {
   };
 }
 
-function createHarness({ runClaudeImpl, initialCheckpoint = null }) {
+function createHarness({ runClaudeImpl, initialCheckpoint = null, door43PushImpl = null }) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'generate-pipeline-'));
   const oldBaseDir = process.env.CSKILLBP_DIR;
   const oldStatusFile = process.env.ADMIN_STATUS_FILE;
@@ -62,6 +62,9 @@ function createHarness({ runClaudeImpl, initialCheckpoint = null }) {
   const pipelineUtilsPath = require.resolve('../src/pipeline-utils');
   const adminStatusPath = require.resolve('../src/admin-status');
   const selfDiagnosisPath = require.resolve('../src/self-diagnosis');
+  // usfm-tools captures CSKILLBP_DIR at module load; reload it per-harness so
+  // validateAlignedUsfmCompleteness/mergeAlignedUsfm read from this temp dir.
+  const usfmToolsPath = require.resolve('../src/workspace-tools/usfm-tools');
 
   const sent = {
     stream: [],
@@ -79,6 +82,7 @@ function createHarness({ runClaudeImpl, initialCheckpoint = null }) {
   delete require.cache[pipelineUtilsPath];
   delete require.cache[adminStatusPath];
   delete require.cache[selfDiagnosisPath];
+  delete require.cache[usfmToolsPath];
 
   installStub(configPath, {
     adminUserId: 1,
@@ -125,7 +129,7 @@ function createHarness({ runClaudeImpl, initialCheckpoint = null }) {
   installStub(door43PushPath, {
     REPO_MAP: {},
     checkConflictingBranches: async () => [],
-    door43Push: async () => ({ success: true, details: 'ok', noChanges: false }),
+    door43Push: door43PushImpl || (async () => ({ success: true, details: 'ok', noChanges: false })),
     getRepoFilename: () => 'dummy.usfm',
   });
   installStub(repoVerifyPath, {
@@ -190,6 +194,7 @@ function createHarness({ runClaudeImpl, initialCheckpoint = null }) {
       delete require.cache[pipelineContextPath];
       delete require.cache[adminStatusPath];
       delete require.cache[selfDiagnosisPath];
+      delete require.cache[usfmToolsPath];
       if (oldBaseDir == null) delete process.env.CSKILLBP_DIR;
       else process.env.CSKILLBP_DIR = oldBaseDir;
       if (oldStatusFile == null) delete process.env.ADMIN_STATUS_FILE;
@@ -451,6 +456,53 @@ test('generatePipeline retries alignment once and fails with degraded_alignment 
     assert.equal(alignCalls, 2);
     assert.ok(harness.checkpoints.some((patch) => patch.current?.errorKind === 'degraded_alignment'));
     assert.ok(harness.readStatusTexts().some((text) => text.includes('Retrying **align-all-parallel**')));
+    // Self-diagnosis now covers the alignment phase (previously Phase 1 only).
+    assert.equal(harness.diagnosisCalls.length, 1);
+    assert.equal(harness.diagnosisCalls[0].event.severity, 'error');
+    assert.equal(harness.diagnosisCalls[0].checkpoint.current.errorKind, 'degraded_alignment');
+    assert.match(harness.diagnosisCalls[0].errorText, /align-all-parallel/);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('generatePipeline fires self-diagnosis when door43-push fails', async () => {
+  const harness = createHarness({
+    door43PushImpl: async ({ type }) => ({ success: false, details: `Verse 1 not found in chapter 52 (${type})` }),
+    runClaudeImpl: async ({ options, tempDir }) => {
+      if (options.skill === 'initial-pipeline') {
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA'), { recursive: true });
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-UST', 'ISA'), { recursive: true });
+        fs.mkdirSync(path.join(tempDir, 'output', 'issues', 'ISA'), { recursive: true });
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA', 'ISA-52.usfm'), '\\id ISA\n\\c 52\n\\v 1 ult\n');
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-UST', 'ISA', 'ISA-52.usfm'), '\\id ISA\n\\c 52\n\\v 1 ust\n');
+        fs.writeFileSync(path.join(tempDir, 'output', 'issues', 'ISA', 'ISA-52.tsv'), 'Reference\tID\nISA 52:1\ta1b2\n');
+        return { subtype: 'success', usage: {}, total_cost_usd: 0 };
+      }
+      if (options.skill === 'align-all-parallel') {
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA'), { recursive: true });
+        fs.mkdirSync(path.join(tempDir, 'output', 'AI-UST', 'ISA'), { recursive: true });
+        const good = '\\id ISA\n\\c 52\n\\v 1 \\zaln-s |x-strong="H1" x-content="א"\\*\\w Joshua|x-occurrence="1" x-occurrences="1"\\w*\\zaln-e\\*\n';
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-ULT', 'ISA', 'ISA-52-aligned.usfm'), good);
+        fs.writeFileSync(path.join(tempDir, 'output', 'AI-UST', 'ISA', 'ISA-52-aligned.usfm'), good);
+        return { subtype: 'success', usage: {}, total_cost_usd: 0 };
+      }
+      return { subtype: 'success', usage: {}, total_cost_usd: 0 };
+    },
+  });
+
+  try {
+    await harness.generatePipeline(
+      { _synthetic: true, _book: 'ISA', _startChapter: 52, _endChapter: 52, skill: 'initial-pipeline', operations: 6 },
+      buildMessage('generate isa 52', { sender_id: 7 })
+    );
+
+    // door43-push failures used to only set a checkpoint; now they dispatch
+    // self-diagnosis like Phase-1 failures do.
+    const pushDiag = harness.diagnosisCalls.find((c) => /door43-push/.test(c.errorText || ''));
+    assert.ok(pushDiag, 'expected a door43-push self-diagnosis dispatch');
+    assert.equal(pushDiag.event.severity, 'error');
+    assert.match(pushDiag.errorText, /Verse 1 not found/);
   } finally {
     harness.cleanup();
   }


### PR DESCRIPTION
## Why

Follow-up to the JER 29 incident. When the JER 29 door43-push failed ("Verse 1 not found"), **no self-diagnosis issue was filed** — because `fireDiagnosis` was only wired into Phase-1 generation failures (SDK error, non-success, early-exit, missing/stale output). The delivery-side phases — alignment validation, `door43-push`, and repo-verify — only set a checkpoint and posted a Zulip status, so failures there were invisible to the auto-issue-handler.

## What

- New `fireDiagnosisFor(event, errorText)` helper (attaches the current checkpoint + a phase-tagged context; no-ops unless severity is `error`).
- Wired into every terminal failure site across the previously-uncovered phases:
  - **alignment** — missing output, stale output, degraded-after-retries
  - **door43-push** — source-file-missing, push-returned-failure, push-threw (ULT and UST)
  - **repo-verify** — post-merge verification failed (ULT and UST)
- `dispatchSelfDiagnosis`'s existing fingerprint dedup prevents duplicate issues from repeated/related failures.

## Testing

- Extended the degraded-alignment test to assert a diagnosis is dispatched (event severity `error`, checkpoint `errorKind: degraded_alignment`).
- New test: a `door43-push` failure dispatches a diagnosis carrying the push error.
- Harness fix: reload `usfm-tools` per harness so its module-level `CSKILLBP_DIR` binds to the current temp dir. The harness previously leaked an earlier test's dir, so validators couldn't find aligned files — which is why no prior test exercised the Phase-2 push path.
- Full suite: 280 pass (3 pre-existing unrelated failures, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
