### PR TITLE
fix: order translation notes by reading position within a verse

### DIFF
--- a/src/workspace-tools/tn-tools.js
+++ b/src/workspace-tools/tn-tools.js
@@ -1134,11 +1134,9 @@ function verifyAtFit({ preparedJson, generatedJson }) {
     for (const atRaw of atMatches) {
       const at = atRaw.slice(1, -1);
       const ult = item.ult_verse || '';
-      const glq = (item.gl_quote || '').replace(/\{[^}]*\}/g, '').replace(/\s+/g, ' ').trim();
-      let idx = ult.indexOf(glq);
-      if (idx < 0) idx = ult.toLowerCase().indexOf(glq.toLowerCase());
-      if (idx >= 0) { results.push(`${item.reference} (${id}) [${item.sref}]\n  [${at}]\n  -> ${(ult.slice(0, idx) + at + ult.slice(idx + glq.length)).slice(0, 150)}`); }
-      else errors.push(`${item.reference} (${id}): gl_quote "${glq}" not found in ULT`);
+      const preview = substituteAT(ult, item.gl_quote || '', at);
+      if (preview !== null) { results.push(`${item.reference} (${id}) [${item.sref}]\n  [${at}]\n  -> ${preview.slice(0, 150)}`); }
+      else errors.push(`${item.reference} (${id}): gl_quote "${item.gl_quote || ''}" not found in ULT`);
     }
   }
   const lines = [`AT check: ${results.length} OK, ${errors.length} errors`];
@@ -1327,12 +1325,13 @@ function assembleNotes({ preparedJson, generatedJson, output }) {
     return [ch, vs];
   }
   function intraKey(item) {
-    const ult = (item.ult_verse || '').toLowerCase();
-    const glq = (item.gl_quote || '').replace(/\{[^}]*\}/g, '').replace(/\s+/g, ' ').trim().toLowerCase();
-    if (!ult || !glq) return [9998, 0];
-    let pos = ult.indexOf(glq);
-    if (pos < 0) pos = 9999;
-    return [pos, -glq.length];
+    const ult = item.ult_verse || '';
+    const glq = item.gl_quote || '';
+    if (!ult.trim() || !glq.trim()) return [9998, 0];
+    const pos = locateQuoteStart(ult, glq);
+    // pos = reading position of the quote; -length = longest-first so a
+    // containing quote sorts before the sub-quotes nested inside it.
+    return [pos < 0 ? 9999 : pos, -comparableQuoteLength(glq)];
   }
   const rows = [];
   const missing = [];
@@ -2917,6 +2916,124 @@ function prepareAndValidate({ inputTsv, ultUsfm, ustUsfm, alignedUsfm, output })
   return lines.join('\n\n');
 }
 
+// --- GL-quote <-> verse matching (shared) ----------------------------------
+// Locates a GL quote inside a verse, tolerant of supplied-word braces
+// ({word} keeps the inner word), curly quotes/dashes, collapsed whitespace,
+// and case. Shared by substituteAT (AT preview), verifyAtFit, and the
+// intra-verse note sort in assembleNotes so all three agree on where a quote
+// sits in its verse. (Previously each site re-derived this; the note sort and
+// the AT check used a naive match that stripped brace *content* and ignored
+// discontinuous separators, so supplied-word / discontinuous quotes failed to
+// match and sorted to the end of the verse.)
+function buildComparableIndex(text) {
+  const normalizedChars = [];
+  const offsets = [];
+  let pendingSpace = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '{') {
+      const end = text.indexOf('}', i + 1);
+      if (end !== -1) {
+        for (let j = i + 1; j < end; j++) {
+          const inner = text[j];
+          if (/\s/.test(inner)) {
+            pendingSpace = normalizedChars.length > 0;
+            continue;
+          }
+          if (pendingSpace && normalizedChars.length > 0 && normalizedChars[normalizedChars.length - 1] !== ' ') {
+            normalizedChars.push(' ');
+            offsets.push(j);
+          }
+          pendingSpace = false;
+          normalizedChars.push(inner.toLowerCase());
+          offsets.push(j);
+        }
+        i = end;
+        continue;
+      }
+    }
+
+    let next = ch;
+    if (/[\u2018\u2019]/.test(ch)) next = '\'';
+    else if (/[\u201C\u201D]/.test(ch)) next = '"';
+    else if (/[\u2010-\u2015]/.test(ch)) next = '-';
+
+    if (/\s/.test(next)) {
+      pendingSpace = normalizedChars.length > 0;
+      continue;
+    }
+    if (pendingSpace && normalizedChars.length > 0 && normalizedChars[normalizedChars.length - 1] !== ' ') {
+      normalizedChars.push(' ');
+      offsets.push(i);
+    }
+    pendingSpace = false;
+    normalizedChars.push(next.toLowerCase());
+    offsets.push(i);
+  }
+
+  while (normalizedChars[0] === ' ') {
+    normalizedChars.shift();
+    offsets.shift();
+  }
+  while (normalizedChars[normalizedChars.length - 1] === ' ') {
+    normalizedChars.pop();
+    offsets.pop();
+  }
+
+  return { text: normalizedChars.join(''), offsets };
+}
+
+function findComparableSpan(haystack, needle, fromOriginalIndex = 0) {
+  const hay = buildComparableIndex(haystack);
+  const ndl = buildComparableIndex(needle).text;
+  if (!hay.text || !ndl) return null;
+
+  let fromNormalizedIndex = 0;
+  while (fromNormalizedIndex < hay.offsets.length && hay.offsets[fromNormalizedIndex] < fromOriginalIndex) {
+    fromNormalizedIndex++;
+  }
+  const idx = hay.text.indexOf(ndl, fromNormalizedIndex);
+  if (idx === -1) return null;
+  return {
+    start: hay.offsets[idx],
+    end: hay.offsets[idx + ndl.length - 1] + 1,
+  };
+}
+
+// Discontinuous GL quotes join segments with an ellipsis, "..." or " & ".
+function splitQuoteSegments(glQuote) {
+  const s = String(glQuote || '');
+  const sep = s.includes('\u2026') ? '\u2026' : s.includes('...') ? '...' : s.includes(' & ') ? ' & ' : null;
+  if (!sep) return [s];
+  return s.split(sep).map((p) => p.trim()).filter(Boolean);
+}
+
+// Normalized length of a GL quote (segments flattened to spaces). Used as the
+// longest-first tiebreak so a containing quote sorts before sub-quotes nested
+// inside it.
+function comparableQuoteLength(glQuote) {
+  return buildComparableIndex(splitQuoteSegments(glQuote).join(' ')).text.length;
+}
+
+// Start offset (in the verse's normalized index space) of the first segment of
+// glQuote within verse, or -1 if not found. Offsets are comparable across
+// quotes in the same verse, so they order notes by reading position.
+function locateQuoteStart(verse, glQuote) {
+  const hay = buildComparableIndex(verse);
+  if (!hay.text) return -1;
+  const segments = splitQuoteSegments(glQuote);
+  const head = buildComparableIndex(segments[0] || '').text;
+  if (head) {
+    const idx = hay.text.indexOf(head);
+    if (idx !== -1) return idx;
+  }
+  // Fall back to the whole quote flattened (separators -> space) in case the
+  // first segment alone is not locatable but the joined form is.
+  const whole = buildComparableIndex(segments.join(' ')).text;
+  return whole ? hay.text.indexOf(whole) : -1;
+}
+
 // --- AT Generation Support ---
 
 /**
@@ -2927,82 +3044,6 @@ function prepareAndValidate({ inputTsv, ultUsfm, ustUsfm, alignedUsfm, output })
  */
 function substituteAT(verse, glQuote, atText) {
   if (!verse || !glQuote || !atText) return null;
-
-  function buildComparableIndex(text) {
-    const normalizedChars = [];
-    const offsets = [];
-    let pendingSpace = false;
-
-    for (let i = 0; i < text.length; i++) {
-      const ch = text[i];
-      if (ch === '{') {
-        const end = text.indexOf('}', i + 1);
-        if (end !== -1) {
-          for (let j = i + 1; j < end; j++) {
-            const inner = text[j];
-            if (/\s/.test(inner)) {
-              pendingSpace = normalizedChars.length > 0;
-              continue;
-            }
-            if (pendingSpace && normalizedChars.length > 0 && normalizedChars[normalizedChars.length - 1] !== ' ') {
-              normalizedChars.push(' ');
-              offsets.push(j);
-            }
-            pendingSpace = false;
-            normalizedChars.push(inner.toLowerCase());
-            offsets.push(j);
-          }
-          i = end;
-          continue;
-        }
-      }
-
-      let next = ch;
-      if (/[\u2018\u2019]/.test(ch)) next = '\'';
-      else if (/[\u201C\u201D]/.test(ch)) next = '"';
-      else if (/[\u2010-\u2015]/.test(ch)) next = '-';
-
-      if (/\s/.test(next)) {
-        pendingSpace = normalizedChars.length > 0;
-        continue;
-      }
-      if (pendingSpace && normalizedChars.length > 0 && normalizedChars[normalizedChars.length - 1] !== ' ') {
-        normalizedChars.push(' ');
-        offsets.push(i);
-      }
-      pendingSpace = false;
-      normalizedChars.push(next.toLowerCase());
-      offsets.push(i);
-    }
-
-    while (normalizedChars[0] === ' ') {
-      normalizedChars.shift();
-      offsets.shift();
-    }
-    while (normalizedChars[normalizedChars.length - 1] === ' ') {
-      normalizedChars.pop();
-      offsets.pop();
-    }
-
-    return { text: normalizedChars.join(''), offsets };
-  }
-
-  function findComparableSpan(haystack, needle, fromOriginalIndex = 0) {
-    const hay = buildComparableIndex(haystack);
-    const ndl = buildComparableIndex(needle).text;
-    if (!hay.text || !ndl) return null;
-
-    let fromNormalizedIndex = 0;
-    while (fromNormalizedIndex < hay.offsets.length && hay.offsets[fromNormalizedIndex] < fromOriginalIndex) {
-      fromNormalizedIndex++;
-    }
-    const idx = hay.text.indexOf(ndl, fromNormalizedIndex);
-    if (idx === -1) return null;
-    return {
-      start: hay.offsets[idx],
-      end: hay.offsets[idx + ndl.length - 1] + 1,
-    };
-  }
 
   const ellipsis = '\u2026';
   if (/(?:\u2026|\.{3}| & )/.test(glQuote)) {
@@ -3188,4 +3229,6 @@ module.exports = {
   _inspectOpeningBold: inspectOpeningBold,
   _resolveGlQuotes: resolveGlQuotes,
   _stripAlternateTranslation: stripAlternateTranslation,
+  _locateQuoteStart: locateQuoteStart,
+  _comparableQuoteLength: comparableQuoteLength,
 };

--- a/test/tn-tools.test.js
+++ b/test/tn-tools.test.js
@@ -1503,3 +1503,69 @@ test('applyHintsToPreparedNotes — multiple hints all applied', () => {
   const ids = data.items.map((it) => it.id).sort();
   assert.deepEqual(ids, ['ab12', 'cd34']);
 });
+
+// ---------------------------------------------------------------------------
+// Intra-verse note ordering (locateQuoteStart / assembleNotes sort)
+//
+// Regression: the note sort located the GL quote in the verse with a naive
+// indexOf that stripped brace *content* ({is} -> '') and ignored discontinuous
+// separators, so supplied-word, discontinuous, and curly-vs-straight-quote
+// notes fell to pos 9999 and sorted to the END of the verse — even when they
+// covered the very first words. The shared matcher now keeps brace content,
+// folds curly quotes/dashes, and matches discontinuous quotes by their first
+// segment.
+// ---------------------------------------------------------------------------
+
+const { _locateQuoteStart, _comparableQuoteLength, assembleNotes } = require('../src/workspace-tools/tn-tools');
+
+test('locateQuoteStart resolves supplied-word, discontinuous, and curly-quote quotes to their real position', () => {
+  const verse = 'Yahweh is my shepherd; I shall not want, for the LORD’s mercy endures';
+
+  // Supplied word in braces — content is kept, not deleted.
+  assert.equal(_locateQuoteStart(verse, 'Yahweh {is} my shepherd'), 0);
+  // Discontinuous quote — located by its first segment.
+  assert.equal(_locateQuoteStart(verse, 'Yahweh…shepherd'), 0);
+  // Straight apostrophe in the quote vs curly apostrophe in the verse.
+  assert.ok(_locateQuoteStart(verse, "the LORD's mercy") > 0);
+  // A genuinely absent quote still reports -1.
+  assert.equal(_locateQuoteStart(verse, 'no such phrase'), -1);
+  // A containing quote is longer than a quote nested inside it.
+  assert.ok(
+    _comparableQuoteLength('Yahweh {is} my shepherd; I shall not want')
+      > _comparableQuoteLength('Yahweh {is} my shepherd'),
+  );
+});
+
+test('assembleNotes orders a verse by reading position, longest-first for nested quotes', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tn-tools-order-'));
+  const preparedAbs = path.join(tempDir, 'prepared_notes.json');
+  const generatedAbs = path.join(tempDir, 'generated_notes.json');
+  const outAbs = path.join(tempDir, 'out.tsv');
+
+  const verse = 'Yahweh is my shepherd; I shall not want, for the LORD’s mercy endures';
+  // Deliberately scrambled input order; ids encode the expected output order.
+  const items = [
+    { id: 'e_late_straight', reference: '1:1', sref: 'figs-abstractnouns', orig_quote: 'q5', gl_quote: "the LORD's mercy", ult_verse: verse },
+    { id: 'c_start_discont', reference: '1:1', sref: 'figs-metaphor',      orig_quote: 'q3', gl_quote: 'Yahweh…shepherd', ult_verse: verse },
+    { id: 'a_start_full',    reference: '1:1', sref: 'figs-parallelism',   orig_quote: 'q1', gl_quote: 'Yahweh {is} my shepherd; I shall not want', ult_verse: verse },
+    { id: 'd_mid_plain',     reference: '1:1', sref: 'figs-idiom',         orig_quote: 'q4', gl_quote: 'I shall not want', ult_verse: verse },
+    { id: 'b_start_sub',     reference: '1:1', sref: 'figs-metaphor',      orig_quote: 'q2', gl_quote: 'Yahweh {is} my shepherd', ult_verse: verse },
+  ];
+  fs.writeFileSync(preparedAbs, JSON.stringify({ book: 'PSA', chapter: '23', items }, null, 2));
+  fs.writeFileSync(generatedAbs, JSON.stringify(
+    Object.fromEntries(items.map((it) => [it.id, `Note for ${it.id}.`])), null, 2));
+
+  assembleNotes({ preparedJson: preparedAbs, generatedJson: generatedAbs, output: outAbs });
+
+  const idOrder = fs.readFileSync(outAbs, 'utf8')
+    .trim().split('\n').slice(1)            // drop header
+    .map((line) => line.split('\t')[1]);    // ID column
+
+  assert.deepEqual(idOrder, [
+    'a_start_full',    // pos 0, whole verse (longest) -> first
+    'b_start_sub',     // pos 0, nested in a_start_full -> after it
+    'c_start_discont', // pos 0, shortest -> after b
+    'd_mid_plain',     // mid-verse
+    'e_late_straight', // late, curly/straight apostrophe resolved
+  ]);
+});


### PR DESCRIPTION
## Problem

Translation notes were appearing out of order within a verse: notes about words near the start of the ULT verse showed up near the end of the verse's note list.

The single intra-verse sort key (`intraKey` in `assembleNotes`) located each note's GL quote in the verse with a raw `indexOf`, dropping any quote it couldn't match verbatim to position 9999 — the end of the verse. Three normal cases broke the match:

- **Supplied words** — `Yahweh {is} my shepherd`: the regex stripped braces *and* their content, but the verse keeps the word.
- **Discontinuous quotes** — `…`, `...`, ` & ` searched as one literal string never appear in the verse.
- **Curly vs. straight quotes/dashes** — `LORD's` vs `LORD’s`.

This was a regression from the prior Python sort, which kept brace content on both sides and handled `&`. The same brace bug also lived in `verifyAtFit`, producing false "gl_quote not found in ULT" errors.

`mergeTsvs` (parallel-batch path) was not the cause — its stable verse-only sort inherits whatever order assembly produces.

## Fix

- Lift the robust matcher already used by `substituteAT` (`buildComparableIndex`/`findComparableSpan`) to module scope; add `locateQuoteStart` (reading position, tolerant of braces/curly-quotes/dashes/discontinuity) and `comparableQuoteLength` (longest-first tiebreak). One shared matcher now serves AT substitution, the AT check, and the note sort.
- `intraKey` sorts by `(position, -length)` so notes follow reading order and a containing quote precedes its nested sub-quotes.
- `verifyAtFit` reuses `substituteAT`, fixing the parallel brace bug.

## Tests

- New `locateQuoteStart` unit test and an end-to-end `assembleNotes` ordering test (scrambled input → reading order with longest-first nesting). Both pass.
- Full `tn-tools.test.js`: all prior tests pass except 2 pre-existing `fillOrigQuotes` failures that also fail on `main` (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
