### PR TITLE
fix: poll for the review marker instead of one stale flyctl logs fetch

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -202,22 +202,39 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # Pull recent logs and extract the latest PR_REVIEW_RESULT marker line.
-          # run-pr-review.js emits a single-line marker so we don't need to
-          # reassemble multi-line pretty JSON across log entries.
-          # The success-path JSON serializes as `{"request":...,"decision":...,...}`
-          # because executePrReview returns `{ request, ...aggregate, summary }`,
-          # so anchoring on `{"decision":` would only match the catch-block
-          # failure object and silently drop every PASS result.
-          # Scope to this run via the prNumber and headSha downstream filters
-          # (those substrings are emitted in the request block).
-          flyctl logs --app "$FLY_APP_NAME" --no-tail > all-logs.txt 2>&1 || true
-          marker_line="$(grep -E 'PR_REVIEW_RESULT:[[:space:]]*\{' all-logs.txt \
-            | grep "\"prNumber\":${PR_NUMBER}" \
-            | grep "\"headSha\":\"${HEAD_SHA}\"" \
-            | tail -1 || true)"
+          # Extract the PR_REVIEW_RESULT marker for THIS PR head SHA from the
+          # Fly logs. run-pr-review.js emits a single-line marker so we don't
+          # need to reassemble multi-line pretty JSON across log entries.
+          #
+          # Fly's log pipeline is eventually-consistent: a single fetch right
+          # after the machine stops often returns a stale snapshot that predates
+          # this run's marker (the machine is shared, so other PRs' markers may
+          # be all that has propagated yet — which is exactly how this step used
+          # to fail the run with no verdict). Poll, re-fetching, until this head
+          # SHA's marker appears or we time out.
+          #
+          # Scope solely on headSha: a git SHA is globally unique, present in
+          # both the success marker (executePrReview's request block) and the
+          # failure/fallback markers, and correctly distinguishes re-pushes of
+          # the same PR number.
+          deadline=$((SECONDS + 180))
+          marker_line=""
+          attempt=0
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            attempt=$((attempt + 1))
+            flyctl logs --app "$FLY_APP_NAME" --no-tail > all-logs.txt 2>&1 || true
+            marker_line="$(grep -E 'PR_REVIEW_RESULT:[[:space:]]*\{' all-logs.txt \
+              | grep "\"headSha\":\"${HEAD_SHA}\"" \
+              | tail -1 || true)"
+            if [ -n "$marker_line" ]; then
+              echo "Found PR_REVIEW_RESULT marker for SHA ${HEAD_SHA} on attempt ${attempt}."
+              break
+            fi
+            echo "No marker yet for SHA ${HEAD_SHA} (attempt ${attempt}); waiting 10s for Fly log propagation..."
+            sleep 10
+          done
           if [ -z "$marker_line" ]; then
-            echo "No PR_REVIEW_RESULT marker found in logs for PR #${PR_NUMBER} SHA ${HEAD_SHA} (run may have crashed before emitting)." >&2
+            echo "No PR_REVIEW_RESULT marker found for PR #${PR_NUMBER} SHA ${HEAD_SHA} after ${attempt} attempts (~180s); the reviewer machine likely never emitted a result for this commit." >&2
             tail -100 all-logs.txt >&2 || true
             exit 1
           fi


### PR DESCRIPTION
## Problem

The Review Gate reads the PASS/FAIL verdict by grepping a single `flyctl logs --no-tail` snapshot, fetched immediately after the reviewer Fly machine stops, for a `PR_REVIEW_RESULT` marker scoped to the PR head SHA.

Fly's log pipeline is eventually-consistent, so that one-shot fetch routinely predates this run's marker. Because the reviewer machine is **shared** across all PRs, the snapshot often contains only a *sibling* PR's marker:

- [Run 27643200025](https://github.com/unfoldingWord/bp-assistant/actions/runs/27643200025) (PR #122): at fetch time the newest log line was **2.5 min stale** and held only PR #98's marker.
- [Run 27039311497](https://github.com/unfoldingWord/bp-assistant/actions/runs/27039311497) (PR #112): found only PR #113's marker.

The head-SHA grep correctly rejected the sibling, found nothing for the actual commit, and failed the run with **no verdict** — 6 such `Read review result from logs` failures over the last month (the "the run fails itself" symptom).

## Fix

Poll instead of single-shot: re-fetch `flyctl logs` every 10s for up to ~180s until **this head SHA's** marker appears, then extract the decision. In the common case it's found on attempt 1.

- Scope solely on `headSha`: a git SHA is globally unique, is present in both the success marker and (after the companion fix) the failure/fallback markers, and correctly distinguishes re-pushes of the same PR number.
- Only fail the run if no marker appears for this commit after the full window — and the message now says exactly that.

Companion PR in `deferredreward/bp-assistant-auto-issue-handler` makes the reviewer **always** emit a findable marker (success, crash, or pre-reviewer harness death), so the only remaining failure mode is a machine that genuinely never reviewed the commit.

## Testing

- YAML parses; `bash -n` clean on the embedded step.
- Simulated Fly returning a stale sibling-only snapshot on attempts 1–2 then the real marker on attempt 3 → resolves to the correct PASS. Simulated never-emitted → fails cleanly with the new message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
