### PR TITLE
chore: upgrade Claude Agent SDK to 0.3.179 (Opus 4.8) + adaptive thinking/effort

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Keeps the Claude Agent SDK / bundled claude-code CLI (and its peer deps)
+# current. Each release is what teaches the bot new models (e.g. Opus 4.8) and
+# reasoning controls (adaptive thinking, effort). PRs run through the existing
+# review-gate + automerge workflows — no unattended SDK upgrade reaches the live
+# bot without passing the gate.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # The agent SDK, the API SDK, MCP SDK, and zod are peer-coupled
+      # (agent-sdk pins @anthropic-ai/sdk >= X, zod ^4, mcp ^1.29). Bump them
+      # together so a coordinated upgrade lands as one reviewable PR rather than
+      # several that fail each other's peer-dependency checks.
+      claude-sdk:
+        patterns:
+          - "@anthropic-ai/*"
+          - "@modelcontextprotocol/*"
+          - "zod"

--- a/model-provider-config.json
+++ b/model-provider-config.json
@@ -1,15 +1,20 @@
 {
     "providers": {
         "claude": {
-            "defaultModel": "claude-opus-4-7",
+            "defaultModel": "claude-opus-4-8",
             "secretName": "anthropic_api_key",
             "envName": "ANTHROPIC_API_KEY",
             "modelAliases": {
-                "opus": "claude-opus-4-7",
+                "opus": "claude-opus-4-8",
                 "sonnet": "claude-sonnet-4-6",
                 "haiku": "claude-haiku-4-5-20251001"
             },
             "models": {
+                "claude-opus-4-8": {
+                    "label": "Claude Opus 4.8",
+                    "inputPer1M": 5.0,
+                    "outputPer1M": 25.0
+                },
                 "claude-opus-4-7": {
                     "label": "Claude Opus 4.7",
                     "inputPer1M": 5.0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.87",
-        "@anthropic-ai/sdk": "^0.74.0",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.179",
+        "@anthropic-ai/sdk": "^0.104.2",
         "@google/genai": "^1.46.0",
-        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@openai/agents": "^0.8.3",
         "ccusage": "^18.0.10",
         "dotenv": "^17.2.4",
@@ -26,59 +26,141 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.101",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.101.tgz",
-      "integrity": "sha512-LwDQ6ueXnd1EVJbP0XICUO5en4FYJ8Cv/98/+RofoRr4l1cdAdYn1/n758DrTeGkMvTqb4lbdyMNs0RnT7mtoA==",
+      "version": "0.3.179",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.179.tgz",
+      "integrity": "sha512-BlZULVW61ZCcho6mb026QoOQbGZnfxbsEtcoNaW5lF0sIEu7D+/nnQjHSMK8buS/h7HVmIx2RtGbHVX1y4V0uQ==",
       "license": "SEE LICENSE IN README.md",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.81.0",
-        "@modelcontextprotocol/sdk": "^1.29.0"
-      },
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.34.2",
-        "@img/sharp-darwin-x64": "^0.34.2",
-        "@img/sharp-linux-arm": "^0.34.2",
-        "@img/sharp-linux-arm64": "^0.34.2",
-        "@img/sharp-linux-x64": "^0.34.2",
-        "@img/sharp-linuxmusl-arm64": "^0.34.2",
-        "@img/sharp-linuxmusl-x64": "^0.34.2",
-        "@img/sharp-win32-arm64": "^0.34.2",
-        "@img/sharp-win32-x64": "^0.34.2"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.179",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.179",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.179",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.179",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.179",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.179",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.179",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.179"
       },
       "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.0.0"
       }
     },
-    "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/sdk": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
-      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.179",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.179.tgz",
+      "integrity": "sha512-2QoEl7p+RTkF4ARZ40N9OWWi+at8Iy9ZZg3UeP6sWoGrM0GL6NJSv8pbYUdoSRySbNeZshqWar5DF41265J5Sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.179",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.179.tgz",
+      "integrity": "sha512-U5683Hi4uP5Wkg9IhHayqx8co9rgeZaAJcutLAgJiAN9ZnL128+WT0K4DKaBVuMbeeoORodVs9IJgM38lBxUxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.179",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.179.tgz",
+      "integrity": "sha512-Io9X2xF5J3cHR20b0oflLe0sLHyT/KFMCA7sVJhwuSvcqeCHqXTxn6sG+4lArD9wNf+RtLVKgSvOt5Oz4j7mew==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.179",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.179.tgz",
+      "integrity": "sha512-ehqWR9bV0dJONkoKleKg/LJIGDVevLGLPVIQpol+Bqrgyv05DE1hx68g6mBnfp9IEKo2BMZCba3aHKhkHlZvnQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.179",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.179.tgz",
+      "integrity": "sha512-Ck2pLG2GJ5lYULK0Rb6FvAUhkLSvIFgJ77MsbVhvBJHG3C31Fuk6FnkXEL614WSZZdI1ST0Y7s7wc9yLI2kmiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.179",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.179.tgz",
+      "integrity": "sha512-Q+clijh01m+Gg/tSNjHQWfPFRvXSVMIQJZqu6v28vFduaucL7ZL+p6o6VOSdlgLjhqtIFFjOO37aL+VkvEu9MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.179",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.179.tgz",
+      "integrity": "sha512-7wc4j3vDE/TiuiCEPV024U/TDNKXUJ89V0N9WteYJ57YrIUm0RA51WiKCrEmSxSqstQ7Slq26e0gWGHRf7ljDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.179",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.179.tgz",
+      "integrity": "sha512-gFad1AVUZOXbEyS9lf3Pr0LDXrLuO6limZoZoUZQmjhjy0LnudnTU8P/VbCY0AHmT46YMZ/ieisFzeq8X5jTcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.74.0.tgz",
-      "integrity": "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==",
+      "version": "0.104.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.2.tgz",
+      "integrity": "sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -133,310 +215,6 @@
       },
       "peerDependencies": {
         "hono": "^4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -643,6 +421,12 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
@@ -1388,6 +1172,12 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -2803,6 +2593,16 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.87",
-    "@anthropic-ai/sdk": "^0.74.0",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.179",
+    "@anthropic-ai/sdk": "^0.104.2",
     "@google/genai": "^1.46.0",
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/agents": "^0.8.3",
     "ccusage": "^18.0.10",
     "dotenv": "^17.2.4",

--- a/src/claude-runner.js
+++ b/src/claude-runner.js
@@ -54,9 +54,11 @@ const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'];
 // Fable); Haiku and others get no thinking option (effort would 400 there).
 function resolveReasoning(thinking, resolvedModel) {
   const supportsEffort = typeof resolvedModel === 'string' && /opus|sonnet|fable/i.test(resolvedModel);
-  // Explicit off — disable extended thinking.
+  // Explicit off — disable extended thinking. Only effort-capable models accept
+  // a `thinking` param; others must omit it entirely (matches prior behavior of
+  // returning null/setting nothing) to avoid a 400.
   if (thinking === false || thinking === 'off' || thinking === 'none') {
-    return { thinking: { type: 'disabled' } };
+    return supportsEffort ? { thinking: { type: 'disabled' } } : {};
   }
   // Explicit effort level (e.g. 'high', 'xhigh').
   if (typeof thinking === 'string') {
@@ -65,9 +67,17 @@ function resolveReasoning(thinking, resolvedModel) {
     }
     return supportsEffort ? { thinking: { type: 'adaptive' }, effort: thinking } : {};
   }
-  // Legacy numeric budget: adaptive thinking ignores fixed budgets — use high effort.
+  // Legacy numeric budget: adaptive thinking has no fixed token budget. Map by
+  // magnitude to an effort level (preserving "max"-sized hints) and warn, so
+  // callers migrate to an explicit effort string ('low'..'max').
   if (typeof thinking === 'number') {
-    return supportsEffort ? { thinking: { type: 'adaptive' }, effort: 'high' } : {};
+    if (!supportsEffort) return {};
+    const effort = thinking >= 31999 ? 'max'
+      : thinking >= 20000 ? 'high'
+      : thinking >= 10000 ? 'medium'
+      : 'low';
+    console.warn(`[claude-runner] Numeric thinking budget (${thinking}) is deprecated; mapping to effort '${effort}'. Pass an effort level ('low'|'medium'|'high'|'xhigh'|'max') instead.`);
+    return { thinking: { type: 'adaptive' }, effort };
   }
   // Auto-default (null/undefined): floor of `high` effort for effort-capable
   // models; Haiku/others let the model default (no extended thinking).

--- a/src/claude-runner.js
+++ b/src/claude-runner.js
@@ -42,39 +42,36 @@ async function createFreshWorkspaceToolsServer(toolSet) {
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_MAX_TURNS = 200;
 
-// Extended-thinking budgets (token counts for Claude Agent SDK thinking option).
-// Mirrors Claude Code's keyword tiers: think / megathink / ultrathink, plus an
-// extra "high" tier we use as the default for Opus calls.
-const THINKING_LOW = 4000;
-const THINKING_MEDIUM = 10000;
-const THINKING_HIGH = 20000;
-const THINKING_MAX = 31999;
+// Reasoning controls for the Claude Agent SDK. Opus 4.6+ and Sonnet 4.6 use
+// adaptive thinking plus an `effort` level instead of a fixed token budget;
+// `thinking: {type:'enabled', budget_tokens}` is removed on Opus 4.7/4.8 and
+// returns a 400. We translate the runner's `thinking` arg into {thinking, effort}.
+const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'];
 
-const THINKING_LEVELS = {
-  low: THINKING_LOW,
-  medium: THINKING_MEDIUM,
-  high: THINKING_HIGH,
-  max: THINKING_MAX,
-};
-
-function resolveThinkingBudget(thinking, resolvedModel) {
-  if (thinking === false || thinking === 'off' || thinking === 'none') return null;
-  if (typeof thinking === 'number') {
-    if (thinking < 1024 || thinking > THINKING_MAX) {
-      throw new Error(`Invalid thinking budget: ${thinking} (must be between 1024 and ${THINKING_MAX} tokens)`);
-    }
-    return thinking;
+// Map the runner's `thinking` arg to Agent SDK reasoning options.
+// Returns { thinking?: ThinkingConfig, effort?: EffortLevel }.
+// Effort + adaptive thinking apply only to effort-capable models (Opus, Sonnet,
+// Fable); Haiku and others get no thinking option (effort would 400 there).
+function resolveReasoning(thinking, resolvedModel) {
+  const supportsEffort = typeof resolvedModel === 'string' && /opus|sonnet|fable/i.test(resolvedModel);
+  // Explicit off — disable extended thinking.
+  if (thinking === false || thinking === 'off' || thinking === 'none') {
+    return { thinking: { type: 'disabled' } };
   }
+  // Explicit effort level (e.g. 'high', 'xhigh').
   if (typeof thinking === 'string') {
-    if (thinking in THINKING_LEVELS) return THINKING_LEVELS[thinking];
-    throw new Error(`Unrecognized thinking level: '${thinking}' (expected one of: ${Object.keys(THINKING_LEVELS).join(', ')}, 'off')`);
+    if (!EFFORT_LEVELS.includes(thinking)) {
+      throw new Error(`Unrecognized thinking level: '${thinking}' (expected one of: ${EFFORT_LEVELS.join(', ')}, 'off')`);
+    }
+    return supportsEffort ? { thinking: { type: 'adaptive' }, effort: thinking } : {};
   }
-  // Auto-default (thinking == null/undefined): Opus → HIGH, Sonnet → MEDIUM, Haiku/others → none.
-  if (typeof resolvedModel === 'string') {
-    if (/opus/i.test(resolvedModel)) return THINKING_HIGH;
-    if (/sonnet/i.test(resolvedModel)) return THINKING_MEDIUM;
+  // Legacy numeric budget: adaptive thinking ignores fixed budgets — use high effort.
+  if (typeof thinking === 'number') {
+    return supportsEffort ? { thinking: { type: 'adaptive' }, effort: 'high' } : {};
   }
-  return null;
+  // Auto-default (null/undefined): floor of `high` effort for effort-capable
+  // models; Haiku/others let the model default (no extended thinking).
+  return supportsEffort ? { thinking: { type: 'adaptive' }, effort: 'high' } : {};
 }
 
 const DEFAULT_ALLOWED_TOOLS = [
@@ -153,10 +150,9 @@ function buildOptions({
     options.resume = resume;
   }
   options.model = model || 'opus';
-  const thinkingBudget = resolveThinkingBudget(thinking, options.model);
-  if (thinkingBudget) {
-    options.thinking = { type: 'enabled', budget_tokens: thinkingBudget };
-  }
+  const reasoning = resolveReasoning(thinking, options.model);
+  if (reasoning.thinking) options.thinking = reasoning.thinking;
+  if (reasoning.effort) options.effort = reasoning.effort;
   if (betas) {
     options.betas = betas;
   }
@@ -636,9 +632,5 @@ module.exports = {
   ClaudeTransientOutageError,
   isTransientOutageError,
   isGuardrailStop,
-  THINKING_LOW,
-  THINKING_MEDIUM,
-  THINKING_HIGH,
-  THINKING_MAX,
-  resolveThinkingBudget,
+  resolveReasoning,
 };

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -1936,6 +1936,7 @@ async function notesPipeline(route, message) {
         expectedOutput: issuesPath,
         mcpTools: 'issue-id',
         ops: 3, // 2 analysts + challenger/merge
+        thinking: 'xhigh', // 3 issue-id agents inherit xhigh effort from this orchestrator session
       });
     }
 
@@ -1970,7 +1971,7 @@ async function notesPipeline(route, message) {
     });
 
     // tn-quality-check runs as a separate Opus invocation for independent review
-    // (auto-defaults to THINKING_HIGH via claude-runner's thinking-budget logic)
+    // (auto-defaults to high effort + adaptive thinking via claude-runner)
     const qualityTag = hasVerseRange ? `${tag}-vv${verseStart}-${verseEnd}` : tag;
     const defaultNotesPath = hasVerseRange ? notesShardRel : notesChapterRel;
     skills.push({
@@ -2349,6 +2350,7 @@ async function notesPipeline(route, message) {
             label: `${ref} ${skill.name}`,
             cwd: CSKILLBP_DIR,
             model: model || skill.model, // TEST_FAST haiku overrides per-skill model
+            thinking: skill.thinking, // per-stage effort (e.g. deep-issue-id: xhigh); undefined -> high default
             skill: skill.name,
             tools: toolConfig.tools,
             disallowedTools: toolConfig.disallowedTools,


### PR DESCRIPTION
## What

Upgrades the Claude Agent SDK so the bot runs on **Opus 4.8**, and switches the runner to the current reasoning API (adaptive thinking + `effort`).

## Why

The bundled claude-code CLI (2.1.101) only knew Opus &le; 4.6, so the pipeline's `opus` alias resolved to an older model — the likely source of recently degraded output. The runner also still sent `thinking: {type:'enabled', budget_tokens}`, which **400s on Opus 4.7/4.8** — so pointing at 4.8 *without* this change would have broken every generation call. Upgrading the SDK and the thinking API together is required.

## Changes

- **Deps:** `@anthropic-ai/claude-agent-sdk` 0.2.101 → 0.3.179 (bundled CLI 2.1.101 → 2.1.179), `@anthropic-ai/sdk` 0.74 → 0.104.2, `@modelcontextprotocol/sdk` 1.27 → 1.29. The new CLI resolves models at runtime, so `opus` now tracks the latest Opus (4.8) with no hardcoded ID to maintain.
- **`src/claude-runner.js`:** `resolveThinkingBudget` → `resolveReasoning`, mapping the runner's `thinking` arg to `{thinking:{type:'adaptive'}, effort}`. Floor of `high` for Opus/Sonnet; effort gated off for Haiku (would 400).
- **`src/notes-pipeline.js`:** `deep-issue-id` stage runs at `xhigh` (its 3 issue-id agents inherit it); the stage runner now plumbs per-stage `thinking`.
- **`model-provider-config.json`:** `--provider claude` opus alias → `claude-opus-4-8`.
- **`.github/dependabot.yml`:** weekly grouped updates for the peer-coupled SDK packages, so future CLI/model support arrives as review-gated PRs.

## Testing

`npm test` → **291/293**. The 2 failures (`fillOrigQuotes` in `test/tn-tools.test.js`) pre-date this branch and are unrelated — pure Hebrew-quote logic, no bumped deps; confirmed by reverting the source edits (they still fail). Tracked separately.

## Notes

- The `initial-pipeline` (generate) path runs as one session, so its Wave-2 analysts inherit the session effort (`high`) and can't be isolated to `xhigh` — only the notes / `deep-issue-id` path gets `xhigh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
