### PR TITLE
fix: stop fillOrigQuotes doubling repeated weak tokens and dropping missing ones

### DIFF
--- a/src/workspace-tools/tn-tools.js
+++ b/src/workspace-tools/tn-tools.js
@@ -2376,12 +2376,21 @@ function fillOrigQuotes({ preparedJson, alignmentJson, hebrewUsfm, masterUltUsfm
 
   function chooseClosestHebrewTokenLocations(rawVerse, strippedVerse, offsetMap, targetWords, allowPartial = false) {
     const groups = [];
+    const requestedByToken = new Map();
     for (const heb of targetWords) {
       const locations = findHebrewTokenLocations(rawVerse, strippedVerse, offsetMap, heb);
       if (!locations.length) {
         if (!allowPartial) return null;
         continue;
       }
+      // Several alignment words can point at one Hebrew token (e.g. English
+      // "Is ... not" both mapping to הֲלוֹא). Only ask for as many distinct verse
+      // locations as the token actually has; any extra request refers to a word
+      // already covered, so skip it instead of dead-ending the location search.
+      const tokenKey = stripForSearch(heb).normalize('NFKD');
+      const alreadyRequested = requestedByToken.get(tokenKey) || 0;
+      if (alreadyRequested >= locations.length) continue;
+      requestedByToken.set(tokenKey, alreadyRequested + 1);
       groups.push(locations);
     }
 
@@ -2517,6 +2526,14 @@ function fillOrigQuotes({ preparedJson, alignmentJson, hebrewUsfm, masterUltUsfm
       hebWords.map(h => normalizeHeb(h)),
       normalizeHeb
     );
+
+    // Exact extraction must place every alignment token. If any token is absent
+    // from the verse, an exact span would silently drop it; defer to the
+    // plain-text fallback instead so the missing token is still represented.
+    const allLocatable = targetWords.every(
+      (heb) => findHebrewTokenLocations(rawVerse, strippedVerse, offsetMap, heb).length > 0
+    );
+    if (!allLocatable) return null;
 
     const selected = chooseClosestHebrewTokenLocations(
       rawVerse,


### PR DESCRIPTION
## Summary

Fixes two pre-existing logic bugs in `fillOrigQuotes` (`src/workspace-tools/tn-tools.js`) that fail two tests in `test/tn-tools.test.js` on `main`, independent of any other in-flight work.

- **Repeated weak token doubled** (`test/tn-tools.test.js:560`): when several alignment words map to one Hebrew token (e.g. English "Is ... not" both -> הֲלוֹא) but the verse contains that token only once, `chooseClosestHebrewTokenLocations` demanded a distinct verse location per request, dead-ended to `null`, and the fallback emitted the raw token list verbatim -- doubling the repeated word. Each token's location requests are now capped to the occurrences actually present in the verse, so the extra request collapses onto the word already covered.
- **Missing alignment token dropped** (`test/tn-tools.test.js:973`): `extractHebrewQuote` ran with `allowPartial=true`, silently skipping any alignment token absent from the verse and returning a span that dropped it. An exact span is now produced only when every token is locatable; otherwise it returns `null` so the plain-text fallback preserves the missing token.

## Test plan

- `node --test test/tn-tools.test.js` -- all pass (the two listed tests previously failed)
- `npm test` -- full suite green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
