### PR TITLE
Tighten TN hint validation: reject empty quote+seed, add shared contract doc

### DIFF
--- a/docs/bp-assistant-tn-hints-contract.md
+++ b/docs/bp-assistant-tn-hints-contract.md
@@ -1,0 +1,207 @@
+# TN Note Hints — bible-editor ↔ bp-assistant Contract
+
+> Shared, authoritative contract for the **`options.hints`** field on
+> `POST /api/pipeline/start` with `pipelineType: "notes"`. Both repos
+> (`bible-editor` and `bp-assistant`) work from this file. It is the hint-
+> specific companion to the full pipeline API spec in
+> `pipeline-api-contract.md` (§3.1); where they overlap, this file is the
+> source of truth for hint validation and behavior.
+>
+> Server-side implementation: `src/api/pipeline.js` (`HintSchema`,
+> `StartBodySchema`), `src/workspace-tools/tn-tools.js`
+> (`applyHintsToPreparedNotes`), `src/notes-pipeline.js` (application point).
+
+---
+
+## 1. What a hint is
+
+A hint is the translator (via bible-editor) saying: *"I have already decided
+there should be a TN note here, framed like this — produce it, and don't let
+the AI generate a competing note for the same spot."*
+
+The editor marks a row in its chapter view; bp-assistant expands it into a
+full, house-style TN row **and preserves the row's id**, so bible-editor can
+reconcile the result back into its store by id rather than by diffing prose.
+
+Hints are only valid on `pipelineType: "notes"`.
+
+---
+
+## 2. What bible-editor sends
+
+```ts
+interface PipelineHint {
+  rowId: string;              // ^[a-z][a-z0-9]{3}$  — see §3
+  verse: number;              // 1..200, 1-based
+  quote: string;              // source-language phrase; may be "" (see §4)
+  supportReference: string | null;  // rc:// TA link, or null
+  seed: string | null;        // prose framing the writer expands; see §4
+}
+```
+
+Sent as `options.hints: PipelineHint[]` (max 50) on the start request:
+
+```json
+{
+  "pipelineType": "notes",
+  "book": "HOS",
+  "startChapter": 7,
+  "endChapter": 7,
+  "username": "stephen-wunrow",
+  "sessionKey": "bible-editor/123/9f1c...",
+  "options": {
+    "hints": [
+      {
+        "rowId": "k7p2",
+        "verse": 4,
+        "quote": "חַסְדְּכֶם",
+        "supportReference": "rc://*/ta/man/translate/figs-metaphor",
+        "seed": "Their loyalty is as fleeting as morning dew — keep the dew image."
+      }
+    ]
+  }
+}
+```
+
+Field meanings:
+
+- **`rowId`** — the stable TN row identifier. Preserved verbatim as TSV
+  column 1 (`ID`) on the produced row. This is the reconciliation key.
+- **`verse`** — which verse the note targets. Hints carry a verse but **no
+  chapter**, which is why a hint request must be single-chapter (§3).
+- **`quote`** — the source-language (Hebrew/Greek) phrase the note anchors
+  to. Used both to suppress the competing AI note and as the produced row's
+  `OrigWords`. May be `""` for a whole-verse general note (§4).
+- **`supportReference`** — the rc:// TA article link, or `null`. Part of the
+  suppression match key.
+- **`seed`** — prose framing the `tn-writer` skill expands into a complete
+  note. `null`/empty means "write from scratch" — only valid when `quote`
+  is non-empty (§4).
+
+---
+
+## 3. Validation rules (enforced server-side)
+
+Every rule below is enforced per-hint; a violation returns
+`400 validation_failed`. The response carries the **full `issues[]` array** —
+a single request can fail on several hints at once, so read **all** of them,
+not just `issues[0]`. Each issue's `path` carries the offending hint's index,
+e.g. `["options","hints",1,"rowId"]`.
+
+| Rule | Detail |
+|---|---|
+| `pipelineType` must be `"notes"` | Hints are rejected on `generate`/`tqs`. |
+| Single-chapter scope | `startChapter === endChapter` (or `endChapter` omitted). Hints carry a verse but no chapter, so a multi-chapter scope would be ambiguous. |
+| `rowId` grammar `^[a-z][a-z0-9]{3}$` | **First char must be a lowercase letter**, then 3 lowercase-alphanumerics. This is the canonical TN TSV `ID` grammar — verified against production data, 0 of 8,666 real TN IDs start with a digit. A digit-first id (e.g. `"4mte"`) cannot legally exist in a TN TSV and is rejected. **bible-editor's row-id generator must produce letter-first ids.** |
+| `rowId` unique within the request | Duplicate ids would produce ambiguous matches on the apply side. |
+| At least one of `quote` / `seed` non-empty | See §4. A hint with `quote: ""` **and** empty/null `seed` is rejected. |
+| ≤ 50 hints per request | Body cap is 32 KB. |
+| `quote` ≤ 500 chars, `seed` ≤ 4000 chars, `supportReference` ≤ 200 chars | Per-field caps. |
+| No unknown keys on the hint object | `HintSchema` is `.strict()`. |
+
+---
+
+## 4. Empty quote, empty seed, and the "general note" case
+
+`quote` and `seed` are each independently optional-ish, but **never both
+empty**:
+
+| `quote` | `seed` | Meaning | Valid? |
+|---|---|---|---|
+| non-empty | non-empty | Phrase-anchored note, with framing. | ✅ |
+| non-empty | `null`/`""` | Phrase-anchored note; writer chooses the angle from quote + supportReference. | ✅ |
+| `""` | non-empty | **General-information note** for the whole verse (no specific phrase), framed by the seed. | ✅ |
+| `""` | `null`/`""` | Nothing to anchor, nothing to expand — the writer has no signal. | ❌ `400` |
+
+For a **general-information note** (no specific source phrase), send
+`quote: ""` **with a non-empty `seed`**. The seed is the only thing telling
+`tn-writer` what the note should say, so it is required in this case. An
+empty-quote + empty-seed hint is a client error, not a silently-produced
+empty note.
+
+> bible-editor note: when coercing a general-info hint, send `quote: ""`
+> (empty string), **not** `null` — `quote` is a non-nullable string. And
+> always include a real `seed`.
+
+---
+
+## 5. What bp-assistant does with a hint
+
+Hints are applied after mechanical note-prep and before the `tn-writer`
+skill. For each hint:
+
+1. **Suppress** — delete any AI-prepared note matching the hint on
+   `(verse, supportReference, fuzzy-quote)`. The quote match is fuzzy
+   (token-overlap ≥ 0.6 after Hebrew cantillation/whitespace normalization),
+   so the editor's quote need not be byte-identical. An **empty `quote`**
+   matches on `(verse, supportReference)` alone — note that an empty-quote,
+   `null`-supportReference hint suppresses **every** no-supportReference note
+   at that verse, then replaces them with the single pinned note.
+2. **Inject** — add a synthetic prepared row carrying `rowId` (→ TSV `ID`),
+   `quote` (→ `OrigWords`), `supportReference`, and `seed`. `tn-writer`
+   expands `seed` into a complete, house-style note.
+
+**Dropped hints are not an error.** A hint whose `verse` falls outside the
+chapter's actual scope is skipped and the run still succeeds. Dropped hints
+are reported in the bot's run log, not as a request error. Design for "N
+hints in, ≤ N rows pinned" and reconcile by `rowId` presence (§6).
+
+---
+
+## 6. Reconciling the result
+
+There is **no per-hint result in the API** (v1). The `GET /api/pipeline/{jobId}`
+status does not echo which hints applied / suppressed / dropped — that detail
+is only in the bot's run log.
+
+The observable outcome is the produced TSV (pulled from Door43 `master`; see
+`pipeline-api-contract.md` §6). Reconcile by matching the `rowId`s you sent
+against the column-1 `ID`s in the pulled `tn_{BOOK}.tsv`:
+
+- `rowId` present → the hint was expanded into that row; `UPDATE … WHERE id = rowId`.
+- `rowId` absent → the hint was dropped (out-of-scope verse) or never applied.
+
+Because the whole-book TSV is mutated in place, import only the rows for the
+requested chapter; don't replace the whole book.
+
+---
+
+## 7. Worked rejection example
+
+bible-editor sent (HOS 7):
+
+```json
+"hints": [
+  { "rowId": "sych", "verse": 12, "quote": null, "supportReference": null, "seed": "" },
+  { "rowId": "4mte", "verse": 13, "quote": "And I, I would redeem them,", "supportReference": "rc://*/ta/man/translate/writing-pronouns", "seed": "explicit" }
+]
+```
+
+Response — `400 validation_failed`, full `issues[]`:
+
+```json
+[
+  { "code":"invalid_type", "expected":"string",
+    "path":["options","hints",0,"quote"],
+    "message":"Invalid input: expected string, received null" },
+  { "code":"invalid_format", "format":"regex",
+    "pattern":"/^[a-z][a-z0-9]{3}$/",
+    "path":["options","hints",1,"rowId"],
+    "message":"Invalid string: must match pattern /^[a-z][a-z0-9]{3}$/" }
+]
+```
+
+Two independent failures: hint 0's `quote` was `null` (must be a string;
+send `""`), and hint 1's `rowId` `"4mte"` is digit-first (must be
+letter-first). Note also that after fixing the `quote` to `""`, hint 0 would
+*then* fail the §4 rule because its `seed` is also `""` — a general note
+needs a non-empty seed.
+
+---
+
+## 8. Versioning
+
+This contract tracks pipeline API v1. Non-breaking additions (new optional
+hint fields, new validation that only tightens an already-ambiguous case)
+won't bump the version. Breaking changes land alongside the pipeline API's
+own v2.

--- a/src/api/pipeline.js
+++ b/src/api/pipeline.js
@@ -37,7 +37,20 @@ const HintSchema = z.object({
   quote: z.string().max(500),                   // source-language; may be ''
   supportReference: z.string().max(200).nullable(),
   seed: z.string().max(4000).nullable(),
-}).strict();
+}).strict().refine(
+  // A hint must carry signal: either a quote to anchor the note to a specific
+  // source phrase, or a seed framing what the note should say (a general-
+  // information note). With both empty, tn-writer has no phrase and no framing
+  // — nothing to produce — so reject it as a client error rather than
+  // emitting an empty/arbitrary note. quote OR seed may be empty, never both.
+  (h) => (typeof h.quote === 'string' && h.quote.trim() !== '')
+      || (typeof h.seed === 'string' && h.seed.trim() !== ''),
+  {
+    message: 'hint must carry a non-empty quote or seed (a general-information '
+      + 'note needs a seed; a phrase-anchored note needs a quote)',
+    path: ['seed'],
+  },
+);
 
 const OptionsSchema = z.object({
   // Common — currently a no-op on the wire (model is fixed per pipeline today),
@@ -63,7 +76,8 @@ const OptionsSchema = z.object({
   // pipeline must produce, and suppresses competing notes for the same
   // (verse, supportReference, fuzzy-quote). hint.rowId is preserved as the
   // TSV ID column for the expanded row, so bible-editor can UPDATE the
-  // existing stub row in place by ID.
+  // existing stub row in place by ID. Each hint must carry a non-empty quote
+  // or seed (see HintSchema.refine).
   hints: z.array(HintSchema).max(50).optional(),
 }).strict();
 

--- a/test/pipeline-api.test.js
+++ b/test/pipeline-api.test.js
@@ -356,6 +356,28 @@ test('StartBodySchema — accepts empty hint.quote', () => {
   assert.equal(r.success, true);
 });
 
+test('StartBodySchema — accepts empty quote when seed is present (general note)', () => {
+  const r = StartBodySchema.safeParse({
+    pipelineType: 'notes', book: 'ZEC', startChapter: 7,
+    username: 'u', sessionKey: 'k',
+    options: { hints: [{ ...VALID_HINT, quote: '', seed: 'General background on this verse.' }] },
+  });
+  assert.equal(r.success, true);
+});
+
+test('StartBodySchema — rejects hint with both quote and seed empty', () => {
+  for (const seed of ['', '   ', null]) {
+    const r = StartBodySchema.safeParse({
+      pipelineType: 'notes', book: 'ZEC', startChapter: 7,
+      username: 'u', sessionKey: 'k',
+      options: { hints: [{ ...VALID_HINT, quote: '', seed }] },
+    });
+    assert.equal(r.success, false, `quote:'' + seed:${JSON.stringify(seed)} should fail`);
+    const issue = r.error.issues.find((i) => i.path.join('.') === 'options.hints.0.seed');
+    assert.ok(issue, 'expected an issue on options.hints.0.seed');
+  }
+});
+
 test('StartBodySchema — rejects hints on generate and tqs pipelines', () => {
   for (const pt of ['generate', 'tqs']) {
     const r = StartBodySchema.safeParse({

--- a/test/tn-tools.test.js
+++ b/test/tn-tools.test.js
@@ -1447,6 +1447,33 @@ test('applyHintsToPreparedNotes — empty hint.quote suppresses on (verse, sref)
   assert.ok(data.items.find((it) => it.id === 'bbbb'), 'bbbb should survive');
 });
 
+test('applyHintsToPreparedNotes — empty quote + seed injects a general note (orig_quote empty, seed preserved)', () => {
+  const prepRel = tempPreparedPath();
+  writePrepared(prepRel, { book: 'ZEC', chapter: '7', items: [
+    { id: 'aaaa', reference: '7:12', sref: 'figs-other', orig_quote: 'something', ult_verse: 'Verse 12 text' },
+  ]});
+  const r = applyHintsToPreparedNotes({
+    preparedJson: prepRel,
+    hints: [{
+      rowId: 'sych', verse: 12, quote: '',
+      supportReference: null,
+      seed: 'General background: this continues the indictment from verse 11.',
+    }],
+    chapter: 7,
+  });
+  assert.equal(r.hintsApplied, 1);
+  const data = readPrepared(prepRel);
+  const injected = data.items.find((it) => it.id === 'sych');
+  assert.ok(injected, 'general-note hint item missing');
+  assert.equal(injected.fromHint, true);
+  assert.equal(injected.note_type, 'hint');
+  assert.equal(injected.orig_quote, '');           // no source phrase — whole-verse note
+  assert.equal(injected.sref, '');                 // null supportReference normalizes to ''
+  assert.equal(injected.reference, '7:12');
+  assert.equal(injected.seed, 'General background: this continues the indictment from verse 11.');
+  assert.equal(injected.ult_verse, 'Verse 12 text'); // borrowed from sibling item at same verse
+});
+
 test('applyHintsToPreparedNotes — drops hint whose verse is outside chapter scope', () => {
   const prepRel = tempPreparedPath();
   writePrepared(prepRel, { book: 'ZEC', chapter: '7', items: [


### PR DESCRIPTION
## What
Tighten TN note-hint validation and add the shared bible-editor ↔ bp-assistant hint contract doc.

## Why
bible-editor sent three `notes` pipeline requests for HOS 7 with `options.hints`; all three were rejected `400 validation_failed`. Reproducing their exact payload through the live `StartBodySchema` showed **two** independent failures:
- `hints[0].quote: null` — must be a string (client is coercing null → `""`).
- `hints[1].rowId: "4mte"` — digit-first, but the TN TSV `ID` grammar is letter-first (`^[a-z][a-z0-9]{3}$`). Verified against production data: 0 of 8,666 real TN IDs start with a digit. Client-side fix.

That surfaced a real gap on our side: a hint with **both** `quote: ""` and an empty/null `seed` (exactly bible-editor's verse-12 hint after the null→`""` fix) passed validation but leaves `tn-writer` with no phrase to anchor and no framing to expand — a silently empty note.

## Changes
- `src/api/pipeline.js`: `HintSchema.refine()` rejects empty-quote + empty-seed with a clear message. A general-information note (empty quote) must carry a `seed`.
- Tests (+3, all passing): empty-quote-with-seed accepted; both-empty rejected (`""`/`"   "`/`null`); general-note injection behavior (`orig_quote` empty, seed preserved, `id = rowId`, `note_type: "hint"`).
- `docs/bp-assistant-tn-hints-contract.md`: created the shared hint contract (was absent from this repo) — wire shape, validation rules (incl. letter-first `rowId` grammar and the quote/seed rule), suppress/inject semantics, `rowId` reconciliation, worked HOS 7 rejection example.

## Verification
`npm test` on this branch (rebased onto current main): the 3 new tests pass, no regressions. Note: 3 failures (`check_tn_quality`, 2× `fillOrigQuotes`) are **pre-existing on main** (present at `beb3766` independent of this change) — flagged separately, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
