### PR TITLE
test: import CallToolResultSchema via public subpath (worktree-safe)

### DIFF
--- a/test/quality-tools.test.js
+++ b/test/quality-tools.test.js
@@ -300,7 +300,11 @@ test('checkTnQuality flags AT scope mismatch against the exact selected span', a
 });
 
 test('check_tn_quality MCP handler always returns schema-valid text content', async () => {
-  const { CallToolResultSchema } = await import('../node_modules/@modelcontextprotocol/sdk/dist/esm/types.js');
+  // Resolve via the package's public subpath, not a hardcoded ../node_modules
+  // path: the latter only works when node_modules is a sibling of test/ (fails
+  // in git worktrees) and reaches past the SDK's public API into its dist
+  // layout. The subpath export resolves through normal module resolution.
+  const { CallToolResultSchema } = await import('@modelcontextprotocol/sdk/types.js');
   const sdk = await import('@anthropic-ai/claude-agent-sdk');
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'quality-tools-mcp-'));
   const relRoot = path.join('tmp', path.basename(tempDir));


### PR DESCRIPTION
## What
One-line test fix: `test/quality-tools.test.js` now imports `CallToolResultSchema` from the MCP SDK's public subpath (`@modelcontextprotocol/sdk/types.js`) instead of a hardcoded `../node_modules/@modelcontextprotocol/sdk/dist/esm/types.js` path.

## Why
The hardcoded `../node_modules/...` path only resolves when `node_modules` is a sibling of `test/`. That holds in CI (`npm install` at repo root) and the main checkout, but **not in git worktrees**, which have no `node_modules` of their own — normal `require('pkg')` walks up to the main checkout's copy, but a hardcoded relative path can't. The result: the "check_tn_quality MCP handler always returns schema-valid text content" test failed only when the suite was run from a worktree. The internal `dist/esm/types.js` path also reaches past the SDK's public API and would break on an SDK layout change.

The subpath export resolves through normal module resolution, fixing both issues.

## Risk
Test-only; no runtime change. Verified: the test now passes in a worktree (where it previously failed) and the full `quality-tools` suite is green (6/6). It already passed in CI/main checkout, so CI behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
