### PR TITLE
feat: TEST_MODEL env to force the whole pipeline onto one model

### DIFF
--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -483,8 +483,9 @@ async function generatePipeline(route, message) {
   fs.mkdirSync(LOG_DIR, { recursive: true });
   const logFile = path.join(LOG_DIR, 'generate.log');
 
-  // Determine model
-  const model = isTestFast ? 'haiku' : undefined;
+  // Determine model. TEST_MODEL forces the whole pipeline onto one model (for
+  // model benchmarks, e.g. opus vs sonnet); TEST_FAST is shorthand for haiku.
+  const model = process.env.TEST_MODEL || (isTestFast ? 'haiku' : undefined);
   const betas = undefined;
 
   // Determine skill from route config — single content type bypasses initial-pipeline

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -1728,7 +1728,9 @@ async function notesPipeline(route, message) {
   // Ensure log directory
   fs.mkdirSync(LOG_DIR, { recursive: true });
   const logFile = path.join(LOG_DIR, 'notes.log');
-  const model = isTestFast ? 'haiku' : undefined;
+  // TEST_MODEL forces the whole pipeline onto one model (model benchmarks);
+  // TEST_FAST is shorthand for haiku.
+  const model = process.env.TEST_MODEL || (isTestFast ? 'haiku' : undefined);
 
   const pipelineStart = Date.now();
   const tokensBefore = getCumulativeTokens();

--- a/src/test-pipeline.js
+++ b/src/test-pipeline.js
@@ -4,6 +4,7 @@
 // Usage:
 //   node src/test-pipeline.js "write notes LAM 2:4-5"              # real Opus run
 //   node src/test-pipeline.js "write notes LAM 2:4-5" --fast       # Haiku instead of Opus
+//   node src/test-pipeline.js "generate NAM 1" --model sonnet      # force whole pipeline onto one model
 //   node src/test-pipeline.js "write notes LAM 2:4-5" --dry-run    # no Claude calls, stub files
 //   node src/test-pipeline.js "write notes LAM 2:4-5" --fast --dry-run
 //   node src/test-pipeline.js "api generate LAM 2:4-5" --provider openai --dry-run
@@ -13,10 +14,13 @@ const messageText = process.argv.find((a, i) => i >= 2 && !a.startsWith('--'));
 const flags = new Set(process.argv.slice(2).filter(a => a.startsWith('--')));
 const providerFlagIndex = process.argv.findIndex((a) => a === '--provider');
 const providerOverride = providerFlagIndex >= 0 ? process.argv[providerFlagIndex + 1] : null;
+const modelFlagIndex = process.argv.findIndex((a) => a === '--model');
+const modelOverride = modelFlagIndex >= 0 ? process.argv[modelFlagIndex + 1] : null;
 
 if (!messageText) {
-  console.error('Usage: node src/test-pipeline.js "<message text>" [--fast] [--dry-run] [--provider <name>]');
+  console.error('Usage: node src/test-pipeline.js "<message text>" [--fast] [--model <name>] [--dry-run] [--provider <name>]');
   console.error('  --fast      Use Haiku instead of Opus (sets TEST_FAST=1)');
+  console.error('  --model     Force the whole pipeline onto one model, e.g. sonnet|opus|haiku (sets TEST_MODEL)');
   console.error('  --dry-run   Skip all Claude calls, create stub files (sets DRY_RUN=1)');
   console.error('  --provider  Run through api-runner for the given provider');
   process.exit(1);
@@ -24,6 +28,7 @@ if (!messageText) {
 
 if (flags.has('--dry-run')) process.env.DRY_RUN = '1';
 if (flags.has('--fast'))    process.env.TEST_FAST = '1';
+if (modelOverride)          process.env.TEST_MODEL = modelOverride;
 
 // --- Stub zulip-client before anything imports it ---
 const zulipStub = {
@@ -71,6 +76,7 @@ console.log(`  test-pipeline`);
 console.log(`  message: "${messageText}"`);
 console.log(`  DRY_RUN: ${process.env.DRY_RUN || '0'}`);
 console.log(`  TEST_FAST: ${process.env.TEST_FAST || '0'}`);
+console.log(`  TEST_MODEL: ${process.env.TEST_MODEL || '(default)'}`);
 console.log(`  PROVIDER: ${providerOverride || '(default route)'}`);
 console.log(`${'='.repeat(60)}\n`);
 


### PR DESCRIPTION
## What

Adds a `TEST_MODEL` env var that forces the entire pipeline onto a single model, plus a `--model <name>` flag on `test-pipeline.js`.

## Why

To benchmark **Opus 4.8 vs Sonnet 4.6** through the real pipeline (the only place with source data + the `workspace-tools` MCP). Today only `TEST_FAST` (→ Haiku) exists; there's no way to pin the whole pipeline to an arbitrary model for a clean comparison.

## Changes

- `src/generate-pipeline.js` / `src/notes-pipeline.js`: top-level `model = process.env.TEST_MODEL || (isTestFast ? 'haiku' : undefined)`. When set, it overrides per-stage model choices (each stage's `model || skill.model` resolves to the forced model).
- `src/test-pipeline.js`: `--model <name>` flag → sets `TEST_MODEL`; banner reports it; usage + header examples updated.

Precedence: `TEST_MODEL` > `TEST_FAST` (haiku) > unset (per-stage defaults). Unset = no behavior change.

## Usage

```
node src/test-pipeline.js "generate NAM 1" --model sonnet   # whole pipeline on Sonnet 4.6
node src/test-pipeline.js "generate NAM 1"                  # default (opus alias -> Opus 4.8)
```

## Testing

`npm test` → **298/298**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
