### PR TITLE
feat: --no-push flag to run the full pipeline without Door43 push

### DIFF
--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -112,7 +112,8 @@ function parseGenerateCommand(content) {
   const noAlign = /--no-align\b/i.test(String(content || ''));
   const alignOnly = /--align-only\b/i.test(String(content || ''));
   const textOnly = /--text-only\b/i.test(String(content || ''));
-  const extra = { fresh, contentTypes, noAlign, alignOnly, textOnly };
+  const noPush = /--no-push\b/i.test(String(content || ''));
+  const extra = { fresh, contentTypes, noAlign, alignOnly, textOnly, noPush };
 
   // Verse range in a single chapter: generate lam 2:1-3
   const verseMatch = input.match(/generate\s+([a-z0-9]+)\s+(\d+):(\d+)\s*[-\u2013\u2014]\s*(\d+)/);
@@ -180,6 +181,7 @@ function buildParsedGenerateRequest(route, content) {
       noAlign: /--no-align\b/i.test(String(content || '')),
       alignOnly: /--align-only\b/i.test(String(content || '')),
       textOnly: /--text-only\b/i.test(String(content || '')),
+      noPush: /--no-push\b/i.test(String(content || '')),
     };
   }
   return parseGenerateCommand(content);
@@ -423,7 +425,7 @@ async function generatePipeline(route, message) {
     return;
   }
 
-  const { book, start, end, verseStart, verseEnd, fresh, contentTypes, noAlign, alignOnly, textOnly } = parsed;
+  const { book, start, end, verseStart, verseEnd, fresh, contentTypes, noAlign, alignOnly, textOnly, noPush } = parsed;
   const useFileResponseMode = shouldUseFileResponseMode({ isFileResponse, noAlign, textOnly });
   const sessionKey = stream ? `stream-${stream}-${topic}` : `dm-${message.sender_id}`;
   const checkpointRef = {
@@ -1522,9 +1524,13 @@ async function generatePipeline(route, message) {
         resume: { chapter: chData.ch, skill: 'door43-push' },
       });
 
-      // Pre-flight: verify source files exist (only for requested content types)
-      const pushUlt = contentTypes.includes('ult') && chData.ultAligned;
-      const pushUst = contentTypes.includes('ust') && chData.ustAligned;
+      // Pre-flight: verify source files exist (only for requested content types).
+      // --no-push gates the Door43 push only; generation + alignment still run.
+      const pushUlt = !noPush && contentTypes.includes('ult') && chData.ultAligned;
+      const pushUst = !noPush && contentTypes.includes('ust') && chData.ustAligned;
+      if (noPush) {
+        await status(`**--no-push** set: generated${noAlign ? '' : ' + aligned'} ${book} ${chData.ch}; skipping Door43 push.`);
+      }
       if (pushUlt && !fs.existsSync(path.resolve(CSKILLBP_DIR, chData.ultAligned))) {
         const ultMissingEvent = await status(`**door43-push** failed (ULT) for ${book} ${chData.ch}: aligned source file missing: ${chData.ultAligned}`);
         fireDiagnosisFor(ultMissingEvent, `Phase: door43-push (ULT)\nChapter: ${book} ${chData.ch}\nAligned source file missing at push time: ${chData.ultAligned}`);

--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -1503,6 +1503,10 @@ async function generatePipeline(route, message) {
       return;
     }
 
+    if (noPush && completedChapters.length > 0) {
+      await status(`**--no-push** set: generated${noAlign ? '' : ' + aligned'} content for ${completedChapters.length} chapter(s); skipping Door43 push.`);
+    }
+
     for (const chData of completedChapters) {
       // Skip chapters whose push already completed in a previous run
       if (chData.ch < resumeChapter) continue;
@@ -1528,9 +1532,6 @@ async function generatePipeline(route, message) {
       // --no-push gates the Door43 push only; generation + alignment still run.
       const pushUlt = !noPush && contentTypes.includes('ult') && chData.ultAligned;
       const pushUst = !noPush && contentTypes.includes('ust') && chData.ustAligned;
-      if (noPush) {
-        await status(`**--no-push** set: generated${noAlign ? '' : ' + aligned'} ${book} ${chData.ch}; skipping Door43 push.`);
-      }
       if (pushUlt && !fs.existsSync(path.resolve(CSKILLBP_DIR, chData.ultAligned))) {
         const ultMissingEvent = await status(`**door43-push** failed (ULT) for ${book} ${chData.ch}: aligned source file missing: ${chData.ultAligned}`);
         fireDiagnosisFor(ultMissingEvent, `Phase: door43-push (ULT)\nChapter: ${book} ${chData.ch}\nAligned source file missing at push time: ${chData.ultAligned}`);
@@ -1647,6 +1648,18 @@ async function generatePipeline(route, message) {
           current: { chapter: chData.ch, skill: 'door43-push', status: 'failed', errorKind: 'push_failed' },
           resume: { chapter: chData.ch, skill: 'door43-push' },
         });
+      } else if (noPush) {
+        // Push intentionally skipped (--no-push): record generation as complete
+        // but do NOT mark door43-push-done, so a later resume without --no-push
+        // still performs the push. No "merged to master" reply.
+        setCheckpoint(checkpointRef, {
+          state: 'running',
+          success,
+          fail,
+          completedChapters,
+          current: { chapter: chData.ch, skill: 'door43-push', status: 'skipped' },
+          resume: { chapter: chData.ch, skill: 'door43-push' },
+        });
       } else {
         setCheckpoint(checkpointRef, {
           state: 'running',
@@ -1682,7 +1695,9 @@ async function generatePipeline(route, message) {
       : (start === end ? `${book} ${start}` : `${book} ${start}\u2013${end}`);
     const repoList = [contentTypes.includes('ult') && 'en_ult', contentTypes.includes('ust') && 'en_ust'].filter(Boolean).join(' and ');
     await reply(
-      `Content for **${rangeLabel}** pushed to master in ${repoList}.` +
+      (noPush
+        ? `Content for **${rangeLabel}** generated in ${repoList} (Door43 push skipped via --no-push).`
+        : `Content for **${rangeLabel}** pushed to master in ${repoList}.`) +
       (fail > 0 ? `\n(${fail} chapter(s) had errors \u2014 check admin DMs for details.)` : '') +
       `\nYou may need to refresh the tcCreate or gatewayEdit page to see the new content.`
     );

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -3002,16 +3002,19 @@ async function notesPipeline(route, message) {
   } else {
     await addReaction(msgId, 'check');
 
+    const tnPushLine = noPush
+      ? 'Door43 push skipped via --no-push.'
+      : 'Content pushed to master on en_tn';
     if (chapterCount === 1) {
       await reply(
         `Notes pipeline complete for **${rangeLabel}** (${totalDuration}s).\n` +
-        `Content pushed to master on en_tn\n` +
+        `${tnPushLine}\n` +
         `You may need to refresh the tcCreate or gatewayEdit page to see the new content.`
       );
     } else {
       await reply(
         `Notes pipeline complete for **${rangeLabel}**: all ${totalSuccess} chapter(s) succeeded (${totalDuration}s).\n` +
-        `Content pushed to master on en_tn\n` +
+        `${tnPushLine}\n` +
         `You may need to refresh the tcCreate or gatewayEdit page to see the new content.`
       );
     }

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -119,6 +119,10 @@ function hasFreshFlag(content) {
   return /--fresh\b/i.test(String(content || '')) || /--new\b/i.test(String(content || ''));
 }
 
+function hasNoPushFlag(content) {
+  return /--no-push\b/i.test(String(content || ''));
+}
+
 function hasPauseBeforeATsFlag(content) {
   const text = String(content || '');
   return /--pause-before-ats\b/i.test(text)
@@ -1643,6 +1647,7 @@ async function notesPipeline(route, message) {
 
   const isTestFast = process.env.TEST_FAST === '1';
   const isDryRun = process.env.DRY_RUN === '1';
+  const noPush = hasNoPushFlag(message.content);
 
   async function status(text) {
     try {
@@ -2757,6 +2762,14 @@ async function notesPipeline(route, message) {
     // Dry-run: skip the entire door43-push/verify phase
     if (isDryRun) {
       console.log(`[dry-run] Would run door43-push (TN) for ${ref}`);
+      totalSuccess++;
+      continue;
+    }
+
+    // --no-push: notes were generated normally; skip only the Door43 push
+    // (e.g. model benchmarks that must not create real PRs).
+    if (noPush) {
+      await status(`**--no-push** set: generated notes for ${ref}; skipping Door43 push.`);
       totalSuccess++;
       continue;
     }


### PR DESCRIPTION
## What

Adds a `--no-push` message flag (like `--no-align` / `--fresh`) that runs the full pipeline — generation **and alignment and notes** — but skips the Door43 push.

## Why

For the Opus 4.8 vs Sonnet 4.6 benchmark we need to run the real pipeline on the bot (the only place with source data + the `workspace-tools` MCP) without creating real PRs on the NAM repos. `--no-align` avoided the push but also skipped alignment/notes; `--no-push` keeps the full pipeline so alignment and notes are exercised too.

## Changes

- **`src/generate-pipeline.js`**: parse `--no-push` (both parse paths); `pushUlt`/`pushUst` gated on `!noPush`; status line when skipping. Alignment still runs.
- **`src/notes-pipeline.js`**: `hasNoPushFlag` + a push-phase skip (generation already done; only the Door43 push/verify is skipped).

`--no-push` unset = no behavior change.

## Usage

```
generate NAM 1 --no-push        # ULT + UST + alignment, no push
write notes NAM 1 --no-push     # issues + notes, no push
```
Combine with `TEST_MODEL` for benchmarks:
`TEST_MODEL=sonnet node src/test-pipeline.js "generate NAM 1 --no-push"`

## Testing

`npm test` → **298/298**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
