### PR TITLE
fix: pin Node to 22.22.3 and disable Zulip keep-alive (Premature close crash)

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,4 +1,7 @@
-FROM node:22-slim
+# Pinned: the floating node:22-slim moved to 22.23.0, whose http.Agent keep-alive
+# change poisons reused sockets and breaks the zulip-js fetch ("Premature close").
+# 22.22.3 is the last-good (the running v178 image). Bump deliberately + test.
+FROM node:22.22.3-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates python3 \

--- a/src/zulip-client.js
+++ b/src/zulip-client.js
@@ -1,4 +1,12 @@
 require('dotenv').config();
+// Defense-in-depth for the Node 22.23.0 http.Agent keep-alive regression that
+// severs reused sockets mid-response (zulip-js -> node-fetch -> "Premature
+// close"). Disable keep-alive on the global agents so each request uses a fresh
+// socket; lets us safely lift the Dockerfile Node pin later.
+const http = require('node:http');
+const https = require('node:https');
+http.globalAgent = new http.Agent({ keepAlive: false });
+https.globalAgent = new https.Agent({ keepAlive: false });
 const zulip = require('zulip-js');
 const fs = require('fs');
 const { readSecret } = require('./secrets');


### PR DESCRIPTION
## What

Fixes the production crash-loop where the bot died on startup with `fetch .../users/me: Premature close`, by pinning the Node base image and disabling keep-alive on the Zulip HTTP path.

## Root cause

`Dockerfile.fly` used the floating `node:22-slim`. The last rebuild pulled **Node 22.23.0** (Jun 18), whose `http.Agent` keep-alive change severs reused sockets mid-response. `zulip-js` (→ isomorphic-fetch → node-fetch) uses the global agent with keep-alive on, so its `/users/me` call failed with `Premature close`, which the bot treats as fatal → crash-loop. The healthy v178 image runs Node **22.22.3**; no app dependency changed the Zulip HTTP chain (root-caused with Codex).

## Changes

- **`Dockerfile.fly`**: `FROM node:22.22.3-slim` (was `node:22-slim`) — the confirmed-good version running in v178.
- **`src/zulip-client.js`**: set `http`/`https` `globalAgent` to `{ keepAlive: false }` before `require('zulip-js')`, so each request uses a fresh socket.

## Why both

The pin restores service immediately; the keep-alive guard fixes the actual bug mechanism so a future Node bump doesn't reintroduce it (and lets us lift the pin deliberately later).

## Testing

`npm test` → **298/298**. Confirmed the running v178 bot is Node 22.22.3 and healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
