### PR TITLE
fix(notes): skip chapter-intro for partial-chapter (verse-range) requests

### DIFF
--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -1,7 +1,8 @@
 // notes-pipeline.js — Multi-skill sequential pipeline for translation note writing
 // Triggered by: "write notes <book> <chapter>" or "write notes <book> <start>-<end>"
 // Skills: [post-edit-review OR deep-issue-id] -> [chapter-intro] -> tn-writer (Opus) -> tn-quality-check (Sonnet) -> repo-insert (Haiku)
-// chapter-intro runs by default; disabled when the user opts out or auto-excluded.
+// chapter-intro runs by default; disabled when the user opts out, for a
+// verse-range (partial-chapter) request, or when auto-excluded.
 //
 // Each chapter is fully processed (skills + repo-insert + repo-verify) before
 // moving to the next, so the editor gets access as soon as a chapter merges.
@@ -101,8 +102,13 @@ function isIntroAutoExcluded(book, chapter) {
   return SKIP_INTRO_RANGES.some(r => r.book === book && chapter >= r.start && chapter <= r.end);
 }
 
-function shouldRunIntro(book, chapter, withIntroFlag) {
+function shouldRunIntro(book, chapter, withIntroFlag, hasVerseRange) {
   if (!withIntroFlag) return false;
+  // A chapter intro describes the whole chapter, so it makes no sense for a
+  // partial-chapter (verse-range) request like "write notes ISA 38:9-20".
+  // Skipping it also prevents a run whose verse notes come up empty from
+  // pushing an intro-only chapter and reporting that as success.
+  if (hasVerseRange) return false;
   if (isIntroAutoExcluded(book, chapter)) return false;
   return true;
 }
@@ -1947,8 +1953,9 @@ async function notesPipeline(route, message) {
       });
     }
 
-    // chapter-intro: only runs when "with intro" is requested (and not in auto-exclusion range)
-    if (shouldRunIntro(book, ch, withIntro)) {
+    // chapter-intro: only runs when "with intro" is requested, for a full
+    // chapter (not a verse range), and not in an auto-exclusion range.
+    if (shouldRunIntro(book, ch, withIntro, hasVerseRange)) {
       skills.push({
         name: 'chapter-intro',
         prompt: buildChapterIntroPrompt(skillRef, issuesPath, ctxFlag, chapterIntroHintArgs),
@@ -1956,6 +1963,8 @@ async function notesPipeline(route, message) {
         skipPreClean: true, // expectedOutput is also input; do not delete verse issues before intro insertion
         ops: 1,
       });
+    } else if (withIntro && hasVerseRange) {
+      await status(`**${ref}**: skipping chapter-intro (partial-chapter request)`);
     } else if (withIntro && isIntroAutoExcluded(book, ch)) {
       await status(`**${ref}**: skipping chapter-intro (auto-excluded range)`);
     }

--- a/test/pipeline-regressions.test.js
+++ b/test/pipeline-regressions.test.js
@@ -147,6 +147,14 @@ test('chapter intro is auto-skipped for Psalms', () => {
   assert.equal(shouldRunIntro('ISA', 51, true), true);
 });
 
+test('chapter intro is skipped for partial-chapter (verse-range) requests', () => {
+  // Full chapter: intro runs.
+  assert.equal(shouldRunIntro('ISA', 38, true, false), true);
+  // Verse range (e.g. "write notes ISA 38:9-20"): intro is skipped even though
+  // the book/chapter would otherwise qualify.
+  assert.equal(shouldRunIntro('ISA', 38, true, true), false);
+});
+
 test('chapter intro prompt includes high parallelism hint when signal is high', () => {
   const hint = buildParallelismIntroHintArgs({
     parallelism_signal: 'high',


### PR DESCRIPTION
## Problem

A `write notes ISA 38:9-20` run reported **success** but pushed only a chapter introduction — no verse notes — to `en_tn/AI-ISA-38`.

Root cause, from the Fly logs:
1. `deep-issue-id` reported "52 issues" but the verse-range issues shard (`output/issues/ISA/ISA-38-v9-20.tsv`) was actually **empty** when the next step read it.
2. With 0 issue items, every downstream step degraded gracefully: `chapter-intro` prepended a `38:intro` row, `tn-writer` wrote no verse notes, `tn-quality-check` saw only the intro, and `door43-push` pushed intro-only. No step errored, so the run reported success.

## This change

A chapter intro describes the whole chapter, so it should never run for a partial-chapter (verse-range) request.

- `shouldRunIntro(book, chapter, withIntroFlag, hasVerseRange)` now returns `false` for verse ranges, before the auto-exclusion check.
- The chapter loop passes `hasVerseRange` and emits a `skipping chapter-intro (partial-chapter request)` status so it's visible in logs.
- Added a regression test asserting the intro runs for a full chapter (`ISA 38`) but is skipped for the verse-range case.

## Scope / follow-up

This removes the misleading whole-chapter intro from partial-chapter runs. It does **not** fix the deeper bug that let an empty/mislocated issues shard pass `deep-issue-id`'s output verification (the discovery regex matches the full-chapter file and only checks existence + mtime, never non-emptiness). That is tracked as a separate follow-up.

## Tests

Full suite green: `299 pass / 0 fail`, including the new partial-chapter assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
