### PR TITLE
fix(notes): fail empty issue/note output instead of silently succeeding

### DIFF
--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -1067,6 +1067,23 @@ function isMalformedIssuesShape(shape) {
   return shape.blankSrefRatio >= 0.8 && shape.blankQuoteRatio >= 0.8 && shape.blankBothRatio >= 0.8;
 }
 
+// Count actual verse-note rows in a notes TSV, excluding the header and any
+// chapter-intro row. Used to detect a notes file that contains nothing but an
+// intro (or nothing at all).
+function countNoteRows(notesPath) {
+  const absPath = path.resolve(CSKILLBP_DIR, notesPath);
+  if (!fs.existsSync(absPath)) return 0;
+  const lines = fs.readFileSync(absPath, 'utf8').split('\n').filter((line) => line.trim());
+  let count = 0;
+  for (const line of lines) {
+    const col0 = String(line.split('\t')[0] || '').trim();
+    if (col0.toLowerCase() === 'reference') continue; // header
+    if (/:intro$/i.test(col0)) continue;              // chapter-intro row
+    count++;
+  }
+  return count;
+}
+
 function backupIssuesFile({ issuesPath, pipeDir }) {
   if (!issuesPath || !pipeDir) return null;
   const absIssues = path.resolve(CSKILLBP_DIR, issuesPath);
@@ -1873,6 +1890,11 @@ async function notesPipeline(route, message) {
     // --- Build skill chain based on prerequisite availability ---
     const skills = [];
     const issueProducerSkillNames = new Set(['deep-issue-id', 'post-edit-review']);
+    // Fresh issue identification (always expected to yield issue rows). Unlike
+    // post-edit-review — which can legitimately leave issues unchanged or empty
+    // when the editor already resolved everything — an empty result from these
+    // is always a silent failure, so a zero-row output hard-fails the chapter.
+    const FRESH_ISSUE_PRODUCERS = new Set(['deep-issue-id', 'issue-identification']);
 
     if (resumeIssueProducer) {
       // Placeholder for cached issue-producer output — never invoked at
@@ -2492,7 +2514,16 @@ async function notesPipeline(route, message) {
       if (skill.expectedOutput) {
         const outDir = path.dirname(skill.expectedOutput);
         const outExt = path.extname(skill.expectedOutput).replace('.', '\\.');
-        const discoverPat = new RegExp(`^${book}-0*${ch}(-.*)?${outExt}$`);
+        // For a verse-range (partial-chapter) run the expected output is a verse
+        // shard (e.g. ISA-38-v9-20.tsv for issues, ISA-38-vv9-20.tsv for notes).
+        // Match that exact shard only: the loose chapter pattern below also
+        // matches the full-chapter file (ISA-38.tsv), which let an empty shard
+        // pass verification while a stray full-chapter write satisfied the check
+        // (ISA 38:9-20 incident).
+        const escapedBase = path.basename(skill.expectedOutput).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const discoverPat = hasVerseRange
+          ? new RegExp(`^${escapedBase}$`)
+          : new RegExp(`^${book}-0*${ch}(-.*)?${outExt}$`);
         const resolved = discoverFreshOutput(outDir, book, discoverPat, skillStart)
           || resolveOutputFile(skill.expectedOutput, book);
         if (!resolved) {
@@ -2544,6 +2575,27 @@ async function notesPipeline(route, message) {
             if (s.prompt && s.prompt.includes('--issues ')) {
               s.prompt = s.prompt.replace(/--issues\s+\S+/, `--issues ${issuesPath}`);
             }
+          }
+        }
+        // Non-empty guard for fresh issue identification. deep-issue-id can
+        // report success yet leave its issues shard empty (or write the issues
+        // to a different path). Existence + freshness alone then pass, and the
+        // run silently degrades to an intro-only/empty chapter while still
+        // reporting success (ISA 38:9-20 incident). Refuse to continue when a
+        // fresh producer resolves to zero issue rows.
+        if (FRESH_ISSUE_PRODUCERS.has(skill.name) && !isDryRun) {
+          const shape = analyzeIssuesTsvShape(resolved);
+          if (!shape.exists || shape.rowCount === 0) {
+            failedSkill = skill.name;
+            await status(`**${skill.name}** failed for ${ref} — produced no issue rows (resolved: ${resolved}). Refusing to continue with an empty issues file.`);
+            setCheckpoint(checkpointRef, {
+              state: 'failed',
+              totalSuccess,
+              totalFail,
+              current: { chapter: ch, skill: skill.name, status: 'failed', errorKind: 'empty_issues', outputStatus: 'empty', outputPath: resolved },
+              resume: { chapter: ch, skill: skill.name },
+            });
+            break;
           }
         }
         if (issueProducerSkillNames.has(skill.name)) {
@@ -2603,6 +2655,22 @@ async function notesPipeline(route, message) {
             skill.resolvedOutput = notesShardRel;
             skillOutputs[ch]['tn-writer'] = notesShardRel;
             console.log(`[notes] Wrote verse shard: ${notesShardRel}`);
+            // A verse-range request must yield at least one verse note. Zero
+            // note rows means upstream generation silently produced nothing —
+            // fail rather than pushing an empty/intro-only shard and reporting
+            // success (ISA 38:9-20 incident).
+            if (!isDryRun && countNoteRows(notesShardRel) === 0) {
+              failedSkill = skill.name;
+              await status(`**${skill.name}** failed for ${ref} — verse-range run produced no verse notes (${notesShardRel}). Refusing to push an empty shard.`);
+              setCheckpoint(checkpointRef, {
+                state: 'failed',
+                totalSuccess,
+                totalFail,
+                current: { chapter: ch, skill: skill.name, status: 'failed', errorKind: 'empty_notes', outputStatus: 'empty', outputPath: notesShardRel },
+                resume: { chapter: ch, skill: skill.name },
+              });
+              break;
+            }
             // Keep a chapter-level assembled view up-to-date for future checks/runs.
             const assembledRel = refreshChapterNotesFromShards(book, tag, notesChapterRel);
             if (assembledRel) {
@@ -3051,6 +3119,7 @@ module.exports = {
   _getSkillToolConfig: getSkillToolConfig,
   _appendIssueTagsToTsv: appendIssueTagsToTsv,
   _analyzeIssuesTsvShape: analyzeIssuesTsvShape,
+  _countNoteRows: countNoteRows,
   _collectUnresolvedQuoteFindings: collectUnresolvedQuoteFindings,
   _isMalformedIssuesShape: isMalformedIssuesShape,
   _postProcessNotesTsv: postProcessNotesTsv,

--- a/test/pipeline-regressions.test.js
+++ b/test/pipeline-regressions.test.js
@@ -366,6 +366,80 @@ test('malformed issues TSV shape is detected when issue type and quote are blank
   }
 });
 
+test('empty issues shard is detected as zero rows (deep-issue-id non-empty guard)', () => {
+  // Reproduces the ISA 38:9-20 incident: deep-issue-id reported success but the
+  // verse-range issues shard was effectively empty. analyzeIssuesTsvShape must
+  // report rowCount 0 so the producer-stage guard can hard-fail.
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'issues-empty-'));
+  const oldBaseDir = process.env.CSKILLBP_DIR;
+  process.env.CSKILLBP_DIR = tempDir;
+
+  // CSKILLBP_DIR is a load-time constant in pipeline-utils, so clear its cache
+  // (not just notes-pipeline's) to rebind it to this temp dir.
+  const notesPipelinePath = require.resolve('../src/notes-pipeline');
+  const utilsPath = require.resolve('../src/pipeline-utils');
+  delete require.cache[notesPipelinePath];
+  delete require.cache[utilsPath];
+  const { _analyzeIssuesTsvShape } = require('../src/notes-pipeline');
+
+  try {
+    const issuesRel = 'output/issues/ISA/ISA-38-v9-20.tsv';
+    const issuesAbs = path.join(tempDir, issuesRel);
+    fs.mkdirSync(path.dirname(issuesAbs), { recursive: true });
+    fs.writeFileSync(issuesAbs, '\n\n'); // blank lines only, as seen in the incident
+
+    const shape = _analyzeIssuesTsvShape(issuesRel);
+    assert.equal(shape.exists, true);
+    assert.equal(shape.rowCount, 0);
+  } finally {
+    if (oldBaseDir == null) delete process.env.CSKILLBP_DIR;
+    else process.env.CSKILLBP_DIR = oldBaseDir;
+    delete require.cache[notesPipelinePath];
+    delete require.cache[utilsPath];
+  }
+});
+
+test('countNoteRows counts verse notes but not header or intro rows', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notes-count-'));
+  const oldBaseDir = process.env.CSKILLBP_DIR;
+  process.env.CSKILLBP_DIR = tempDir;
+
+  const notesPipelinePath = require.resolve('../src/notes-pipeline');
+  const utilsPath = require.resolve('../src/pipeline-utils');
+  delete require.cache[notesPipelinePath];
+  delete require.cache[utilsPath];
+  const { _countNoteRows } = require('../src/notes-pipeline');
+
+  try {
+    const dir = path.join(tempDir, 'output/notes/ISA');
+    fs.mkdirSync(dir, { recursive: true });
+
+    // Intro-only shard (the incident's final state) must count as zero notes.
+    const introOnly = 'output/notes/ISA/ISA-38-vv9-20-intro.tsv';
+    fs.writeFileSync(path.join(tempDir, introOnly),
+      'Reference\tID\tTags\tSupportReference\tQuote\tOccurrence\tNote\n' +
+      '38:intro\tcgq6\t\t\t\t\t# Isaiah 38 Introduction\n');
+    assert.equal(_countNoteRows(introOnly), 0);
+
+    // Real verse notes are counted; header and intro are excluded.
+    const withNotes = 'output/notes/ISA/ISA-38-vv9-20.tsv';
+    fs.writeFileSync(path.join(tempDir, withNotes),
+      'Reference\tID\tTags\tSupportReference\tQuote\tOccurrence\tNote\n' +
+      '38:intro\tcgq6\t\t\t\t\t# Isaiah 38 Introduction\n' +
+      '38:9\tab12\t\t\tכתב\t1\tNote one\n' +
+      '38:10\tcd34\t\t\tאני\t1\tNote two\n');
+    assert.equal(_countNoteRows(withNotes), 2);
+
+    // Missing file counts as zero.
+    assert.equal(_countNoteRows('output/notes/ISA/does-not-exist.tsv'), 0);
+  } finally {
+    if (oldBaseDir == null) delete process.env.CSKILLBP_DIR;
+    else process.env.CSKILLBP_DIR = oldBaseDir;
+    delete require.cache[notesPipelinePath];
+    delete require.cache[utilsPath];
+  }
+});
+
 test('runMechanicalQualityPrep forwards Hebrew USFM into quality checks', async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notes-quality-prep-'));
   const oldBaseDir = process.env.CSKILLBP_DIR;


### PR DESCRIPTION
## Background

Follow-up to #138. That PR stopped partial-chapter runs from emitting a whole-chapter intro, but the **deeper hole** remained: `deep-issue-id` reported "52 issues" for `ISA 38:9-20` while the verse-range issues shard was actually empty, and the pipeline still reported success after pushing an intro-only chapter.

## Root cause

The post-skill output check (`notes-pipeline.js`) only verified the resolved file **existed** and was **fresh** — never that it contained issue rows. Two things compounded it:

1. The discovery regex `^${book}-0*${ch}(-.*)?${outExt}$` also matches the full-chapter file (`ISA-38.tsv`), so for a verse-range run a stray full-chapter write could satisfy the check while the shard the rest of the pipeline reads stayed empty.
2. Nothing downstream failed on zero issues / zero notes — every step degraded gracefully, so the run reported success.

## Changes

Three guards, all targeting silent-empty failures:

1. **Exact-shard discovery for verse ranges** — when `hasVerseRange`, output discovery matches the exact expected shard basename (e.g. `ISA-38-v9-20.tsv`), so the full-chapter file can no longer satisfy a partial-chapter check.
2. **Non-empty issues guard** — a fresh issue producer (`deep-issue-id` / `issue-identification`) that resolves to zero issue rows hard-fails the chapter (`errorKind: empty_issues`). `post-edit-review` is intentionally excluded — it can legitimately leave issues unchanged or empty.
3. **Non-empty notes guard** — a verse-range run whose `tn-writer` shard has zero verse-note rows (excluding header and any intro row) hard-fails (`errorKind: empty_notes`) instead of pushing an empty shard.

Adds a `countNoteRows` helper and regression tests for empty-issue detection and note counting.

## Tests

Full suite green: `301 pass / 0 fail` (2 new tests). All guards skip in dry-run mode.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
