### PR TITLE
Overnight Sensor + TN comparator + Phase 3 platform hardening

### DIFF
--- a/model-provider-config.json
+++ b/model-provider-config.json
@@ -9,6 +9,14 @@
                 "sonnet": "claude-sonnet-4-6",
                 "haiku": "claude-haiku-4-5-20251001"
             },
+            "autoModelByThinking": {
+                "none": "claude-haiku-4-5-20251001",
+                "low": "claude-haiku-4-5-20251001",
+                "medium": "claude-sonnet-4-6",
+                "high": "claude-opus-4-8",
+                "xhigh": "claude-opus-4-8",
+                "max": "claude-opus-4-8"
+            },
             "models": {
                 "claude-opus-4-8": {
                     "label": "Claude Opus 4.8",

--- a/src/api-runner/provider-config.js
+++ b/src/api-runner/provider-config.js
@@ -4,15 +4,27 @@ const fs = require('fs');
 
 const DEFAULT_PROVIDER_CONFIGS = {
   claude: {
-    defaultModel: 'claude-opus-4-7',
+    defaultModel: 'claude-opus-4-8',
     secretName: 'anthropic_api_key',
     envName: 'ANTHROPIC_API_KEY',
     modelAliases: {
-      opus: 'claude-opus-4-7',
+      opus: 'claude-opus-4-8',
       sonnet: 'claude-sonnet-4-6',
       haiku: 'claude-haiku-4-5-20251001',
     },
+    // Effort/thinking-level -> Claude tier (cost routing): low-effort phases to
+    // Haiku, validation to Sonnet, generation to Opus. The JSON config overrides
+    // this at runtime; kept in sync so a missing config file still routes.
+    autoModelByThinking: {
+      none: 'claude-haiku-4-5-20251001',
+      low: 'claude-haiku-4-5-20251001',
+      medium: 'claude-sonnet-4-6',
+      high: 'claude-opus-4-8',
+      xhigh: 'claude-opus-4-8',
+      max: 'claude-opus-4-8',
+    },
     models: {
+      'claude-opus-4-8': { label: 'Claude Opus 4.8', inputPer1M: 5.0, outputPer1M: 25.0 },
       'claude-opus-4-7': { label: 'Claude Opus 4.7', inputPer1M: 5.0, outputPer1M: 25.0 },
       'claude-sonnet-4-6': { label: 'Claude Sonnet 4.6', inputPer1M: 3.0, outputPer1M: 15.0 },
       'claude-haiku-4-5-20251001': { label: 'Claude Haiku 4.5', inputPer1M: 0.8, outputPer1M: 4.0 },
@@ -258,6 +270,19 @@ function resolveXaiModel(model, thinking) {
   return cfg.autoModelByThinking[thinking || 'medium'] || cfg.defaultModel;
 }
 
+// Provider-agnostic auto-model resolver (Phase 3 cost routing). An explicit
+// model always wins (alias-resolved). Otherwise map the effort/thinking level
+// via the provider's `autoModelByThinking`, falling back to `defaultModel`.
+// Null-safe (unlike resolveXaiModel's hard index) so a provider without the map
+// just uses its default.
+function resolveAutoModel(provider, model, thinking) {
+  const cfg = getProviderConfig(provider);
+  if (model) return cfg.modelAliases?.[model] || model;
+  const map = cfg.autoModelByThinking;
+  if (!map) return cfg.defaultModel;
+  return map[thinking || 'medium'] || cfg.defaultModel;
+}
+
 function resolveProviderModel(provider, model) {
   const cfg = getProviderConfig(provider);
   const candidate = model || cfg.defaultModel;
@@ -305,6 +330,7 @@ module.exports = {
   getProviderNames,
   resolveProviderModel,
   resolveXaiModel,
+  resolveAutoModel,
   isConfiguredModel,
   assertProviderModel,
   getFallbackModel,

--- a/src/check-ult-edits.js
+++ b/src/check-ult-edits.js
@@ -152,4 +152,15 @@ async function checkUltEdits({ book, chapter, workspaceDir, pipeDir }) {
   return { hasEdits: true, masterPath };
 }
 
-module.exports = { checkUltEdits };
+// Primitives exported for reuse by the overnight Sensor (overnight-watcher.js):
+// USFM chapter extraction, alignment-marker stripping, whitespace normalization,
+// the redirect-following text fetcher, and the book→number map.
+module.exports = {
+  checkUltEdits,
+  extractChapter,
+  stripAlignmentMarkers,
+  normalizeWhitespace,
+  fetchText,
+  BOOK_NUMBERS,
+  DOOR43_BASE,
+};

--- a/src/claude-runner.js
+++ b/src/claude-runner.js
@@ -129,6 +129,8 @@ function buildOptions({
   abortController,
   mcpServers,
   thinking,
+  hooks,
+  compaction,
 }) {
   const options = {
     cwd: cwd || process.cwd(),
@@ -169,6 +171,22 @@ function buildOptions({
   if (appendSystemPrompt) {
     options.systemPrompt = appendSystemPrompt;
   }
+  // Phase 3: declarative guard/observability hooks (PreToolUse/PostToolUse/…).
+  // Optional + additive — when no caller passes `hooks`, options are byte-identical.
+  if (hooks) {
+    options.hooks = hooks;
+  }
+  // Phase 3 (pilot): opt-in Agent-SDK auto-compaction, default OFF. This is the
+  // Agent SDK's CLI auto-compact (settings.autoCompactEnabled), NOT the raw
+  // Messages-API `compact-2026-01-12` beta. Spread-merge so we don't clobber the
+  // sandbox `settings` set by forceNoAutoBashSandbox above.
+  if (compaction && compaction.enabled) {
+    options.settings = {
+      ...(options.settings || {}),
+      autoCompactEnabled: true,
+      ...(compaction.window ? { autoCompactWindow: compaction.window } : {}),
+    };
+  }
   return options;
 }
 
@@ -192,6 +210,8 @@ async function runClaudeOnce({
   onProgress,
   guardrails,
   thinking,
+  hooks,
+  compaction,
 }) {
   await ensureFreshToken();
   const query = await getQuery();
@@ -260,6 +280,8 @@ async function runClaudeOnce({
     abortController,
     mcpServers: { 'workspace-tools': wsTools },
     thinking,
+    hooks,
+    compaction,
   });
 
   console.log(`${runnerPrefix} Starting query in ${cwd}`);
@@ -593,6 +615,8 @@ async function runClaudeStream({
   timeoutMs,
   appendSystemPrompt,
   thinking,
+  hooks,
+  compaction,
 }) {
   await ensureFreshToken();
   const query = await getQuery();
@@ -620,6 +644,8 @@ async function runClaudeStream({
     abortController,
     mcpServers: { 'workspace-tools': wsTools },
     thinking,
+    hooks,
+    compaction,
   });
 
   console.log(`${streamPrefix} Starting stream in ${cwd}${resume ? ` (resume: ${resume.slice(0, 8)}…)` : ''}`);

--- a/src/guard-hooks.js
+++ b/src/guard-hooks.js
@@ -49,10 +49,35 @@ function isWriteTool(toolName) {
 }
 
 // Pull a filesystem path out of a tool's input, across the common shapes.
+// (Kept for back-compat; collectWritePaths is the comprehensive version.)
 function extractPathFromToolInput(toolName, toolInput) {
   if (!toolInput || typeof toolInput !== 'object') return null;
   return toolInput.file_path || toolInput.path || toolInput.notebook_path
     || toolInput.filePath || toolInput.file || null;
+}
+
+// Input fields that name a WRITE destination. Deliberately excludes read-source
+// fields (input/inputTsv/source/src/globPattern) so the guard never blocks a
+// legitimate READ of a protected file (skills must read issues_resolved.txt and
+// the glossaries). Covers the MCP write tools the name-regex misses
+// (assemble_notes/curly_quotes/etc. use output/preparedJson/generatedJson/tsvFile).
+const WRITE_FIELDS = new Set([
+  'file_path', 'filepath', 'path', 'notebook_path', 'output', 'outputfile', 'outputpath',
+  'out', 'dest', 'destination', 'generatedjson', 'preparedjson', 'tsvfile', 'target', 'targetfile', 'file',
+]);
+
+// All write-destination path strings referenced by a tool call. Core editor
+// tools and any MCP tool are inspected; pure read tools (Read/Grep/Glob) are not.
+function collectWritePaths(toolName, toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return [];
+  const isCoreWrite = WRITE_TOOLS.has(toolName);
+  const isMcp = /^mcp__/.test(String(toolName || ''));
+  if (!isCoreWrite && !isMcp) return [];
+  const out = [];
+  for (const [k, v] of Object.entries(toolInput)) {
+    if (typeof v === 'string' && WRITE_FIELDS.has(k.toLowerCase())) out.push(v);
+  }
+  return out;
 }
 
 function isProtectedPath(targetPath, protectedPaths = DEFAULT_PROTECTED) {
@@ -76,8 +101,9 @@ function decidePreToolUse(input, policy = {}) {
   if (policy.allowedTools && !policy.allowedTools.has(tool)) {
     return denyDecision(`tool '${tool}' is not on the allowlist for this run`);
   }
-  if (isWriteTool(tool)) {
-    const target = extractPathFromToolInput(tool, input.tool_input);
+  // Deny a write whose destination is a protected canonical file — across core
+  // editors AND MCP write tools, while never blocking reads of those files.
+  for (const target of collectWritePaths(tool, input.tool_input)) {
     if (isProtectedPath(target, policy.protectedPaths || DEFAULT_PROTECTED)) {
       return denyDecision(`write to protected canonical file is not allowed: ${target}`);
     }
@@ -148,6 +174,7 @@ module.exports = {
   createGuardHooks,
   decidePreToolUse,
   extractPathFromToolInput,
+  collectWritePaths,
   isProtectedPath,
   isWriteTool,
   WRITE_TOOLS,

--- a/src/guard-hooks.js
+++ b/src/guard-hooks.js
@@ -1,0 +1,156 @@
+// guard-hooks.js — declarative guard + observability layer for the Claude Agent
+// SDK, built on the SDK's `options.hooks` choke point (Phase 3).
+//
+// Folds scattered, imperative per-call tool gating into one place and adds two
+// things the ad-hoc guards never did: (1) a hard PreToolUse block on writes to
+// the protected canonical files (issues_resolved.txt, the 5 Drive-managed
+// glossaries, any SKILL.md body) — defense-in-depth so even a buggy skill run
+// can't clobber them; (2) observability — denied tool calls (and, opt-in, tool
+// failures) are published to admin-status.js and surface at /admin.
+//
+// Additive + opt-in: a call site enables it by passing
+// `hooks: createGuardHooks({...})` to runClaude. Callers that pass nothing are
+// unaffected. The existing in-loop guardrails (claude-runner.js) stay intact.
+'use strict';
+
+const { publishAdminStatus } = require('./admin-status');
+
+// Tools that write to the filesystem (subject to protected-path checks). Covers
+// the core editor tools plus MCP append/write/insert tools (matched by name).
+const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit']);
+const MCP_WRITE_RE = /^mcp__.*(append|write|insert|save|update)/i;
+
+// The canonical files no automated run may write. Entries match by exact path,
+// repo-relative suffix, basename, or RegExp against the normalized path.
+const DEFAULT_PROTECTED = [
+  'data/issues_resolved.txt',
+  'data/glossary/hebrew_ot_glossary.csv',
+  'data/glossary/psalms_reference.csv',
+  'data/glossary/sacrifice_terminology.csv',
+  'data/glossary/biblical_phrases.csv',
+  'data/glossary/biblical_measurements.csv',
+  /(^|\/)SKILL\.md$/i,
+];
+
+const ALLOW = Object.freeze({});
+
+function denyDecision(reason) {
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+function isWriteTool(toolName) {
+  return WRITE_TOOLS.has(toolName) || MCP_WRITE_RE.test(String(toolName || ''));
+}
+
+// Pull a filesystem path out of a tool's input, across the common shapes.
+function extractPathFromToolInput(toolName, toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  return toolInput.file_path || toolInput.path || toolInput.notebook_path
+    || toolInput.filePath || toolInput.file || null;
+}
+
+function isProtectedPath(targetPath, protectedPaths = DEFAULT_PROTECTED) {
+  if (!targetPath) return false;
+  const norm = String(targetPath).replace(/\\/g, '/');
+  const base = norm.split('/').pop();
+  for (const p of protectedPaths) {
+    if (p instanceof RegExp) { if (p.test(norm)) return true; continue; }
+    if (norm === p || norm.endsWith('/' + p) || base === p) return true;
+  }
+  return false;
+}
+
+// Pure decision function (unit-tested). Returns ALLOW or a deny decision.
+function decidePreToolUse(input, policy = {}) {
+  const tool = input && input.tool_name;
+  if (!tool) return ALLOW;
+  if (policy.blockedTools && policy.blockedTools.has(tool)) {
+    return denyDecision(`tool '${tool}' is not permitted in this run`);
+  }
+  if (policy.allowedTools && !policy.allowedTools.has(tool)) {
+    return denyDecision(`tool '${tool}' is not on the allowlist for this run`);
+  }
+  if (isWriteTool(tool)) {
+    const target = extractPathFromToolInput(tool, input.tool_input);
+    if (isProtectedPath(target, policy.protectedPaths || DEFAULT_PROTECTED)) {
+      return denyDecision(`write to protected canonical file is not allowed: ${target}`);
+    }
+  }
+  return ALLOW;
+}
+
+// Build an SDK `options.hooks` object enforcing the policy.
+//   allowedTools / blockedTools : optional Set sources (arrays)
+//   protectedPaths              : override DEFAULT_PROTECTED
+//   pipelineType, scope         : admin-status facets
+//   publish                     : publish denials to admin-status (default true)
+//   observeFailures             : also publish tool failures (default false — avoids flooding)
+function createGuardHooks({
+  allowedTools,
+  blockedTools,
+  protectedPaths = DEFAULT_PROTECTED,
+  pipelineType = 'system',
+  scope,
+  publish = true,
+  observeFailures = false,
+} = {}) {
+  const policy = {
+    allowedTools: allowedTools ? new Set(allowedTools) : null,
+    blockedTools: blockedTools ? new Set(blockedTools) : null,
+    protectedPaths,
+  };
+  const pub = publish
+    ? async (severity, message) => {
+        try {
+          await publishAdminStatus({ source: 'guard-hooks', pipelineType, phase: 'guard', severity, scope, message });
+        } catch (err) {
+          console.warn(`[guard-hooks] publish failed: ${err.message}`);
+        }
+      }
+    : async () => {};
+
+  const hooks = {
+    PreToolUse: [{
+      hooks: [async (input) => {
+        let decision;
+        try {
+          decision = decidePreToolUse(input, policy);
+        } catch (err) {
+          // A guard must never crash the turn — fail open, but record it.
+          console.warn(`[guard-hooks] PreToolUse error: ${err.message}`);
+          return ALLOW;
+        }
+        if (decision !== ALLOW) {
+          await pub('warn', `[guard] blocked ${input && input.tool_name}: ${decision.hookSpecificOutput.permissionDecisionReason}`);
+        }
+        return decision;
+      }],
+    }],
+  };
+  if (observeFailures) {
+    hooks.PostToolUseFailure = [{
+      hooks: [async (input) => {
+        await pub('warn', `[guard] tool ${input && input.tool_name} failed: ${String((input && input.error) || '').slice(0, 200)}`);
+        return {};
+      }],
+    }];
+  }
+  return hooks;
+}
+
+module.exports = {
+  createGuardHooks,
+  decidePreToolUse,
+  extractPathFromToolInput,
+  isProtectedPath,
+  isWriteTool,
+  WRITE_TOOLS,
+  MCP_WRITE_RE,
+  DEFAULT_PROTECTED,
+};

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -1572,7 +1572,9 @@ async function runParallelTnWriter({
         prompt,
         label: `${book} ${ch} tn-writer shard ${i}${vRange ? ` v${vRange}` : ''}`,
         cwd: CSKILLBP_DIR,
-        model: model || undefined,
+        // tn-writer is generation -> high effort -> Opus (BP_AUTO_MODEL on);
+        // explicit model still wins; flag off -> buildOptions' opus default.
+        model: model || (process.env.BP_AUTO_MODEL === '1' ? resolveAutoModel('claude', null, 'high') : undefined),
         skill: 'tn-writer',
         tools: toolConfig.tools,
         disallowedTools: toolConfig.disallowedTools,
@@ -1582,6 +1584,9 @@ async function runParallelTnWriter({
         maxTurns: guardrails.maxTurns,
         appendSystemPrompt,
         guardrails,
+        hooks: process.env.BP_GUARD_HOOKS === '1'
+          ? createGuardHooks({ pipelineType: 'notes', scope: `${book} ${ch}`, publish: true })
+          : undefined,
       }).then(r => ({ ...r, _shardIdx: i }))
         .catch(err => ({ _shardIdx: i, _error: err, subtype: 'error' }));
     });
@@ -2822,6 +2827,9 @@ async function notesPipeline(route, message) {
               maxConsecutiveToolErrors: Math.min(3, rescueGuardrails.maxConsecutiveToolErrors || 3),
               maxRepeatedToolErrorSignature: Math.min(2, rescueGuardrails.maxRepeatedToolErrorSignature || 2),
             },
+            hooks: process.env.BP_GUARD_HOOKS === '1'
+              ? createGuardHooks({ pipelineType: 'notes', scope: ref, publish: true })
+              : undefined,
           });
         } catch (err) {
           console.warn(`[notes] bounded rescue pass failed for ${ref}: ${err.message}`);

--- a/src/notes-pipeline.js
+++ b/src/notes-pipeline.js
@@ -14,6 +14,8 @@ const config = require('./config');
 const { spawn } = require("child_process");
 const { sendMessage, sendDM, addReaction, removeReaction } = require('./zulip-client');
 const { runClaude, DEFAULT_RESTRICTED_TOOLS, isTransientOutageError, isGuardrailStop } = require('./claude-runner');
+const { createGuardHooks } = require('./guard-hooks');
+const { resolveAutoModel } = require('./api-runner/provider-config');
 const { getDoor43Username, emailToFallbackUsername, buildBranchName, resolveOutputFile, discoverFreshOutput, checkPrerequisites, calcSkillTimeout, normalizeBookName, resolveConflictMention, parsePartialTsv, truncatePartialTsv, parseChunkRange, CSKILLBP_DIR } = require('./pipeline-utils');
 const { splitTsv, fixTrailingNewlines } = require('./workspace-tools/tsv-tools');
 const { fillTsvIds, generateIds, prepareNotes, fillOrigQuotes, resolveGlQuotes, flagNarrowQuotes, extractAlignmentData, prepareATContext, substituteAT, fixUnicodeQuotes, verifyBoldMatches, syncCanonicalHebrewQuotes, applyHintsToPreparedNotes, _stripAlternateTranslation: stripAlternateTranslation } = require('./workspace-tools/tn-tools');
@@ -2387,7 +2389,13 @@ async function notesPipeline(route, message) {
             prompt: skill.prompt,
             label: `${ref} ${skill.name}`,
             cwd: CSKILLBP_DIR,
-            model: model || skill.model, // TEST_FAST haiku overrides per-skill model
+            // Explicit model (TEST_FAST / per-skill) always wins. When neither is
+            // set and BP_AUTO_MODEL=1, route by effort tier (low->Haiku,
+            // medium->Sonnet, high+->Opus); unset effort defaults to 'high' so
+            // generation stays on Opus. Flag off (default) -> buildOptions' opus default.
+            model: model || skill.model || (process.env.BP_AUTO_MODEL === '1'
+              ? resolveAutoModel('claude', null, skill.thinking || 'high')
+              : undefined),
             thinking: skill.thinking, // per-stage effort (e.g. deep-issue-id: xhigh); undefined -> high default
             skill: skill.name,
             tools: toolConfig.tools,
@@ -2399,6 +2407,13 @@ async function notesPipeline(route, message) {
             appendSystemPrompt: skill.appendSystemPrompt,
             mcpToolSet: skill.mcpTools,
             guardrails,
+            // Opt-in (BP_GUARD_HOOKS=1) declarative PreToolUse guard: hard-blocks
+            // writes to the protected canonical files (issues_resolved.txt, the 5
+            // glossary CSVs, any SKILL.md) and publishes denials to admin-status.
+            // Default off so behavior is unchanged until validated.
+            hooks: process.env.BP_GUARD_HOOKS === '1'
+              ? createGuardHooks({ pipelineType: 'notes', scope: ref, publish: true })
+              : undefined,
             onProgress: ({ turnCount, lastTool, elapsedMs, timedOut }) => {
               const elapsed = Math.round(elapsedMs / 60000);
               const suffix = timedOut ? ' — **timed out**, aborting' : '';

--- a/src/overnight-review-state.js
+++ b/src/overnight-review-state.js
@@ -1,0 +1,87 @@
+// overnight-review-state.js — idempotent state for the overnight Sensor.
+//
+// Each review unit is keyed by MERGED-PR id + content headSha (a re-push of the
+// same PR gets a new sha → a new unit), so re-running the Sensor never
+// double-reviews. Live `-be-` branches are keyed by branch + tip sha. State is
+// committed to bp-assistant-skills/data/overnight-review/state.json (the wake
+// machine's disk is ephemeral). Cold start (no state yet) records all current
+// HEADs as "seen" and reviews NOTHING on night 1 — otherwise the first run would
+// try to review the entire merge history.
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const STATE_VERSION = 1;
+const DEFAULT_STATE_REL = 'data/overnight-review/state.json';
+
+function defaultState() {
+  return { version: STATE_VERSION, initialized: false, lastRun: null, reviewed: {}, branchTips: {} };
+}
+
+function loadState(stateFile, readImpl = fs.readFileSync) {
+  let raw;
+  try { raw = readImpl(stateFile, 'utf8'); } catch { return defaultState(); }
+  try {
+    const s = JSON.parse(raw);
+    return {
+      version: s.version || STATE_VERSION,
+      initialized: !!s.initialized,
+      lastRun: s.lastRun || null,
+      reviewed: s.reviewed && typeof s.reviewed === 'object' ? s.reviewed : {},
+      branchTips: s.branchTips && typeof s.branchTips === 'object' ? s.branchTips : {},
+    };
+  } catch { return defaultState(); }
+}
+
+function saveState(stateFile, state, { writeImpl = fs.writeFileSync, mkdirImpl } = {}) {
+  const mkdir = mkdirImpl || ((p) => fs.mkdirSync(p, { recursive: true }));
+  mkdir(path.dirname(stateFile));
+  writeImpl(stateFile, JSON.stringify(state, null, 2) + '\n');
+}
+
+// Stable unit key for a merged PR: repo#prId@headSha.
+function prUnitKey(repo, prId, headSha) {
+  return `${repo}#${prId}@${String(headSha || '').slice(0, 12)}`;
+}
+
+// Stable unit key for a live (unmerged) branch: repo:branch@tipSha.
+function branchUnitKey(repo, branch, tipSha) {
+  return `${repo}:${branch}@${String(tipSha || '').slice(0, 12)}`;
+}
+
+function isReviewed(state, key) {
+  return Object.prototype.hasOwnProperty.call(state.reviewed, key);
+}
+
+function markReviewed(state, key, now = new Date()) {
+  state.reviewed[key] = now.toISOString();
+  return state;
+}
+
+function isColdStart(state) {
+  return !state.initialized;
+}
+
+// On cold start, record every current unit as already-seen (so night 1 reviews
+// nothing) and flip initialized. Subsequent runs only see genuinely new units.
+function primeColdStart(state, unitKeys, now = new Date()) {
+  for (const k of unitKeys) state.reviewed[k] = now.toISOString();
+  state.initialized = true;
+  state.lastRun = now.toISOString();
+  return state;
+}
+
+module.exports = {
+  STATE_VERSION,
+  DEFAULT_STATE_REL,
+  defaultState,
+  loadState,
+  saveState,
+  prUnitKey,
+  branchUnitKey,
+  isReviewed,
+  markReviewed,
+  isColdStart,
+  primeColdStart,
+};

--- a/src/overnight-watcher.js
+++ b/src/overnight-watcher.js
@@ -1,0 +1,338 @@
+// overnight-watcher.js — the Overnight Sensor's detection core.
+//
+// Detects human edits merged overnight into the `-be-` branches of ULT/UST/TN
+// on Door43 (self-hosted Gitea), attributes them to editors, and emits an
+// attributed, read-only proposal feed that the Dreamer consumes
+// (output/overnight-review/<date>/proposals.jsonl). It does NOT write the
+// preference store — it only surfaces signal.
+//
+// Detection is robust to overnight branch deletion:
+//   1. PRIMARY — closed+merged PRs whose head ref matches `<BOOK>-be-<editor>`.
+//      The PR record persists after the branch is deleted and still carries the
+//      book + editor + base/head shas + a files/diff endpoint.
+//   2. SECONDARY — live `-be-` branches for in-flight, not-yet-merged work.
+//
+// Idempotent (keyed by PR id + headSha) and cold-start-safe via
+// overnight-review-state.js. HTTP is injectable for tests.
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { apiGet, GITEA_API } = require('./repo-verify');
+const {
+  extractChapter, normalizeWhitespace, stripAlignmentMarkers, fetchText, BOOK_NUMBERS, DOOR43_BASE,
+} = require('./check-ult-edits');
+const { prepareCompareTn } = require('./workspace-tools/tsv-tools');
+const state = require('./overnight-review-state');
+
+const ORG = 'unfoldingWord';
+const WATCHED = [
+  { repo: 'en_ult', resource: 'ult' },
+  { repo: 'en_ust', resource: 'ust' },
+  { repo: 'en_tn', resource: 'tn' },
+];
+
+// --- pure helpers ------------------------------------------------------------
+// `<BOOK>-be-<editor>` → { book, editor }. Book may carry a numeric prefix
+// (1KI, 2SA, …). Returns null for refs that aren't `-be-` branches.
+function parseBeRef(ref) {
+  if (!ref || typeof ref !== 'string') return null;
+  const m = ref.match(/^(.+?)-be-(.+)$/);
+  if (!m) return null;
+  const book = m[1].toUpperCase();
+  if (!BOOK_NUMBERS[book]) return null;
+  return { book, editor: m[2] };
+}
+
+function isBotAuthor(login) {
+  const l = String(login || '').toLowerCase();
+  if (!l) return true; // unknown author → treat as non-editor, skip
+  return /\bbot\b|\[bot\]|github-actions|deferredreward-bot|-bot$/.test(l);
+}
+
+function resourceForRepo(repo) {
+  const w = WATCHED.find((x) => x.repo === repo);
+  return w ? w.resource : null;
+}
+
+function tnFileForBook(book) { return `tn_${book.toUpperCase()}.tsv`; }
+function usfmFileForBook(book) {
+  const num = BOOK_NUMBERS[book.toUpperCase()];
+  return num ? `${num}-${book.toUpperCase()}.usfm` : null;
+}
+
+// List chapters whose stripped, whitespace-normalized text differs between two
+// USFM versions (reuses the post-edit-review primitives).
+function changedChaptersFromUsfm(oldUsfm, newUsfm) {
+  const chapters = new Set();
+  const re = /\\c\s+(\d+)/g;
+  let m;
+  while ((m = re.exec(newUsfm)) !== null) chapters.add(parseInt(m[1], 10));
+  const changed = [];
+  for (const ch of [...chapters].sort((a, b) => a - b)) {
+    const o = extractChapter(oldUsfm, ch);
+    const n = extractChapter(newUsfm, ch);
+    if (!n) continue;
+    if (o == null) { changed.push(ch); continue; }
+    if (normalizeWhitespace(stripAlignmentMarkers(o)) !== normalizeWhitespace(stripAlignmentMarkers(n))) {
+      changed.push(ch);
+    }
+  }
+  return changed;
+}
+
+// Map a prepareCompareTn result to proposal-feed rows (the shape the Dreamer's
+// select-dream-candidates gatherProposalsFeed reads).
+function tnChangesToProposals(compare, { repo, book, editor, prId, headSha }) {
+  return (compare.changes || []).map((c) => {
+    const [chapter, verse] = String(c.reference).split(':');
+    return {
+      source: 'overnight-review',
+      kind: 'tn-edit',
+      resource: 'tn',
+      repo, book, editor,
+      prId: prId || null,
+      headSha: headSha || null,
+      reference: c.reference,
+      supportReference: c.supportReference || null,
+      key: c.supportReference || c.reference,
+      category: c.changeType,
+      chapter: chapter || null,
+      verse: verse || null,
+      before: c.before,
+      after: c.after,
+      text: `editor ${editor} ${c.changeType} TN note at ${c.reference}`
+        + (c.supportReference ? ` (${c.supportReference})` : ''),
+    };
+  });
+}
+
+function usfmChangesToProposals(changedChapters, { repo, resource, book, editor, prId, headSha }) {
+  return changedChapters.map((ch) => ({
+    source: 'overnight-review',
+    kind: `${resource}-edit`,
+    resource,
+    repo, book, editor,
+    prId: prId || null,
+    headSha: headSha || null,
+    category: 'chapter-edited',
+    chapter: String(ch),
+    verse: null,
+    key: `${book}-${ch}`,
+    before: null, after: null,
+    text: `editor ${editor} edited ${resource.toUpperCase()} ${book} ${ch} — run editor-compare`,
+  }));
+}
+
+// --- raw fetch (injectable) --------------------------------------------------
+function rawUrl(repo, ref, filePath) {
+  // ref is e.g. "commit/<sha>" or "branch/master"; DOOR43_BASE already ends in /unfoldingWord
+  return `${DOOR43_BASE.replace(/\/unfoldingWord$/, '')}/${ORG}/${repo}/raw/${ref}/${filePath}`;
+}
+
+// --- enumeration -------------------------------------------------------------
+async function enumerateUnits({ apiGetImpl, token, sinceIso }) {
+  const get = apiGetImpl || apiGet;
+  const units = [];
+  for (const { repo, resource } of WATCHED) {
+    // PRIMARY: merged -be- PRs (persist after branch deletion).
+    let page = 1;
+    let keepPaging = true;
+    while (keepPaging && page <= 10) {
+      const res = await get(`/repos/${ORG}/${repo}/pulls?state=closed&sort=recentupdate&limit=50&page=${page}`, token);
+      const list = Array.isArray(res && res.data) ? res.data : [];
+      if (list.length === 0) break;
+      for (const pr of list) {
+        if (!pr || !pr.merged) continue;
+        const be = parseBeRef(pr.head && pr.head.ref);
+        if (!be) continue;
+        const mergedAt = pr.merged_at || pr.updated_at;
+        if (sinceIso && mergedAt && mergedAt < sinceIso) { keepPaging = false; continue; }
+        units.push({
+          kind: 'merged-pr', repo, resource, book: be.book, editor: be.editor,
+          prId: pr.number,
+          baseSha: pr.base && pr.base.sha,
+          headSha: (pr.head && pr.head.sha) || pr.merge_commit_sha,
+          mergedAt,
+          author: (pr.user && pr.user.login) || be.editor,
+        });
+      }
+      // recentupdate desc — once we pass the cutoff we can stop.
+      if (sinceIso && list.some((pr) => (pr.merged_at || pr.updated_at || '') < sinceIso)) keepPaging = false;
+      page += 1;
+    }
+    // SECONDARY: live -be- branches (in-flight work).
+    try {
+      const res = await get(`/repos/${ORG}/${repo}/branches?limit=100`, token);
+      const branches = Array.isArray(res && res.data) ? res.data : [];
+      for (const b of branches) {
+        const be = parseBeRef(b && b.name);
+        if (!be) continue;
+        units.push({
+          kind: 'live-branch', repo, resource, book: be.book, editor: be.editor,
+          branch: b.name,
+          tipSha: b.commit && b.commit.id,
+          author: (b.commit && b.commit.author && b.commit.author.username) || be.editor,
+        });
+      }
+    } catch { /* branch listing is best-effort */ }
+  }
+  return units;
+}
+
+function unitKeyFor(u) {
+  return u.kind === 'merged-pr'
+    ? state.prUnitKey(u.repo, u.prId, u.headSha)
+    : state.branchUnitKey(u.repo, u.branch, u.tipSha);
+}
+
+// Review one new unit → array of proposal rows. Fetches old/new content.
+async function reviewUnit(u, { fetchTextImpl }) {
+  const fetch = fetchTextImpl || fetchText;
+  const oldRef = u.kind === 'merged-pr' ? `commit/${u.baseSha}` : 'branch/master';
+  const newRef = u.kind === 'merged-pr' ? `commit/${u.headSha}` : `branch/${u.branch}`;
+  const headSha = u.kind === 'merged-pr' ? u.headSha : u.tipSha;
+  try {
+    if (u.resource === 'tn') {
+      const file = tnFileForBook(u.book);
+      const [oldTsv, newTsv] = await Promise.all([
+        fetch(rawUrl(u.repo, oldRef, file)).catch(() => ''),
+        fetch(rawUrl(u.repo, newRef, file)).catch(() => ''),
+      ]);
+      const compare = prepareCompareTn({ oldTsv, newTsv, book: u.book });
+      return tnChangesToProposals(compare, { repo: u.repo, book: u.book, editor: u.editor, prId: u.prId, headSha });
+    }
+    const file = usfmFileForBook(u.book);
+    if (!file) return [];
+    const [oldUsfm, newUsfm] = await Promise.all([
+      fetch(rawUrl(u.repo, oldRef, file)).catch(() => ''),
+      fetch(rawUrl(u.repo, newRef, file)).catch(() => ''),
+    ]);
+    const changed = changedChaptersFromUsfm(oldUsfm, newUsfm);
+    return usfmChangesToProposals(changed, { repo: u.repo, resource: u.resource, book: u.book, editor: u.editor, prId: u.prId, headSha });
+  } catch {
+    return [];
+  }
+}
+
+// --- orchestration -----------------------------------------------------------
+function dateStamp(now) { return now.toISOString().slice(0, 10); }
+
+async function runOvernightReview({
+  skillsRepo,
+  token = process.env.DCS_TOKEN || process.env.DOOR43_TOKEN || '',
+  now = new Date(),
+  dryRun = false,
+  deps = {},
+} = {}) {
+  const log = deps.log || ((m) => process.stderr.write(`${m}\n`));
+  const writeImpl = deps.writeFileSync || fs.writeFileSync;
+  const mkdir = deps.mkdirSync || ((p) => fs.mkdirSync(p, { recursive: true }));
+  const stateFile = path.join(skillsRepo, state.DEFAULT_STATE_REL);
+
+  const st = state.loadState(stateFile, deps.readFileSync);
+  const units = await enumerateUnits({ apiGetImpl: deps.apiGetImpl, token, sinceIso: st.lastRun });
+  const allKeys = units.map(unitKeyFor);
+
+  if (state.isColdStart(st)) {
+    state.primeColdStart(st, allKeys, now);
+    if (!dryRun) state.saveState(stateFile, st, { writeImpl, mkdirImpl: mkdir });
+    log(`[overnight] cold start — ${dryRun ? 'would record' : 'recorded'} ${allKeys.length} current HEAD(s); reviewing nothing tonight.`);
+    return { coldStart: true, dryRun, units: units.length, reviewed: 0, proposals: 0, proposalsPath: null };
+  }
+
+  const fresh = units.filter((u) => !state.isReviewed(st, unitKeyFor(u)) && !isBotAuthor(u.author));
+  const proposals = [];
+  const reviewTasks = [];
+  for (const u of fresh) {
+    const rows = await reviewUnit(u, { fetchTextImpl: deps.fetchTextImpl });
+    proposals.push(...rows);
+    reviewTasks.push({
+      repo: u.repo, resource: u.resource, book: u.book, editor: u.editor,
+      kind: u.kind, prId: u.prId || null, branch: u.branch || null,
+      changes: rows.length,
+      chapters: [...new Set(rows.map((r) => r.chapter).filter(Boolean))],
+    });
+    state.markReviewed(st, unitKeyFor(u), now);
+  }
+
+  // Write under data/ (tracked) — NOT output/ (runtime, ephemeral on the wake
+  // machine). The feed must persist (committed alongside state.json) so the
+  // next Dreamer wake can read it after a fresh clone.
+  const outDir = path.join(skillsRepo, 'data/overnight-review', dateStamp(now));
+  let proposalsPath = null;
+  let tasksPath = null;
+  if (!dryRun) {
+    mkdir(outDir);
+    proposalsPath = path.join(outDir, 'proposals.jsonl');
+    writeImpl(proposalsPath, proposals.map((p) => JSON.stringify(p)).join('\n') + (proposals.length ? '\n' : ''));
+    tasksPath = path.join(outDir, 'review-tasks.jsonl');
+    writeImpl(tasksPath, reviewTasks.map((t) => JSON.stringify(t)).join('\n') + (reviewTasks.length ? '\n' : ''));
+    st.lastRun = now.toISOString();
+    state.saveState(stateFile, st, { writeImpl, mkdirImpl: mkdir });
+  }
+
+  log(`[overnight] ${dryRun ? 'would review' : 'reviewed'} ${fresh.length} unit(s) → ${proposals.length} proposal row(s), ${reviewTasks.length} review task(s).`);
+  return {
+    coldStart: false, dryRun, units: units.length, reviewed: fresh.length,
+    proposals: proposals.length, proposalsPath, tasksPath, reviewTasks,
+    sampleProposals: proposals.slice(0, 12),
+  };
+}
+
+// --- CLI ---------------------------------------------------------------------
+// node src/overnight-watcher.js --skills-repo <dir> [--dry-run]
+// Prints a digest between OVERNIGHT_DIGEST markers for the cron wrapper.
+function parseArgs(argv) {
+  const out = { dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dry-run') out.dryRun = true;
+    else if (a === '--skills-repo') out.skillsRepo = argv[++i];
+  }
+  return out;
+}
+
+async function cliMain(argv) {
+  const args = parseArgs(argv);
+  const skillsRepo = args.skillsRepo || process.env.BP_SKILLS_REPO;
+  if (!skillsRepo) { process.stderr.write('[overnight] BP_SKILLS_REPO not set\n'); process.exit(2); }
+  const res = await runOvernightReview({ skillsRepo, dryRun: args.dryRun });
+  const lines = [];
+  if (res.coldStart) {
+    lines.push(`Cold start — recorded current HEADs; reviewed nothing this run${res.dryRun ? ' (dry-run)' : ''}.`);
+  } else {
+    lines.push(`Reviewed ${res.reviewed} new \`-be-\` unit(s) across ${res.units} watched → ${res.proposals} attributed proposal row(s)${res.dryRun ? ' (dry-run, not persisted)' : ''}.`);
+    for (const t of res.reviewTasks || []) {
+      lines.push(`- ${t.repo} ${t.book} (${t.resource}) by ${t.editor}: ${t.changes} change(s)${t.chapters.length ? ` [ch ${t.chapters.join(',')}]` : ''}`);
+    }
+  }
+  process.stdout.write('OVERNIGHT_DIGEST_BEGIN\n' + lines.join('\n') + '\nOVERNIGHT_DIGEST_END\n');
+  if (res.proposalsPath) process.stdout.write(`OVERNIGHT_PROPOSALS_PATH: ${res.proposalsPath}\n`);
+}
+
+if (require.main === module) {
+  cliMain(process.argv.slice(2)).catch((err) => {
+    process.stderr.write(`[overnight] fatal: ${err.stack || err.message}\n`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  ORG,
+  WATCHED,
+  parseBeRef,
+  isBotAuthor,
+  resourceForRepo,
+  tnFileForBook,
+  usfmFileForBook,
+  changedChaptersFromUsfm,
+  tnChangesToProposals,
+  usfmChangesToProposals,
+  rawUrl,
+  enumerateUnits,
+  unitKeyFor,
+  reviewUnit,
+  runOvernightReview,
+};

--- a/src/overnight-watcher.js
+++ b/src/overnight-watcher.js
@@ -131,42 +131,105 @@ function rawUrl(repo, ref, filePath) {
   return `${DOOR43_BASE.replace(/\/unfoldingWord$/, '')}/${ORG}/${repo}/raw/${ref}/${filePath}`;
 }
 
+// --- editor attribution ------------------------------------------------------
+function loadEditorMap() {
+  try {
+    const raw = fs.readFileSync(path.resolve(__dirname, '../door43-users.json'), 'utf8');
+    const obj = JSON.parse(raw);
+    const byUser = {};
+    for (const [email, user] of Object.entries(obj)) {
+      byUser[String(user).toLowerCase()] = user;
+      byUser[String(email).toLowerCase()] = user;
+    }
+    return byUser;
+  } catch { return {}; }
+}
+
+// Strict: only resolves KNOWN editors (used to gate the merged+deleted fallback
+// so we never review arbitrary merged PRs by unknown authors).
+function attributeKnownEditor(editorMap, value) {
+  if (!value) return null;
+  const key = String(value).trim().toLowerCase();
+  return editorMap[key] || null;
+}
+
+// Map a changed filename to a book code for the resource (tn_<BOOK>.tsv / NN-<BOOK>.usfm).
+function bookFromFilename(name, resource) {
+  const base = String(name || '').split('/').pop();
+  if (resource === 'tn') {
+    const m = base.match(/^tn_([A-Za-z0-9]{3})\.tsv$/);
+    return m ? m[1].toUpperCase() : null;
+  }
+  const m = base.match(/^\d{2}-([A-Za-z0-9]{3})\.usfm$/);
+  return m ? m[1].toUpperCase() : null;
+}
+
+// Changed files of a PR — reliable even after the source branch is deleted
+// (Gitea strips head.ref but the files endpoint still resolves). Mirrors
+// door43-push.checkConflictingBranches.
+async function fetchPrFiles(get, repo, prNumber, token) {
+  const res = await get(`/repos/${ORG}/${repo}/pulls/${prNumber}/files?limit=100`, token);
+  if (!res || res.status !== 200 || !Array.isArray(res.data)) return [];
+  return res.data.map((f) => f && f.filename).filter(Boolean);
+}
+
 // --- enumeration -------------------------------------------------------------
-async function enumerateUnits({ apiGetImpl, token, sinceIso }) {
+async function enumerateUnits({ apiGetImpl, token, sinceIso, editorMap = {} }) {
   const get = apiGetImpl || apiGet;
   const units = [];
   for (const { repo, resource } of WATCHED) {
-    // PRIMARY: merged -be- PRs (persist after branch deletion).
+    // PRIMARY: merged PRs. Identify -be- editor edits two ways:
+    //   (a) head.ref still present -> parse <BOOK>-be-<editor> directly.
+    //   (b) head.ref stripped (Gitea drops it once the branch is deleted — see
+    //       repo-verify.js) -> derive BOOK from the PR's changed files and
+    //       attribute to the PR author, but ONLY when the author is a known editor.
     let page = 1;
     let keepPaging = true;
     while (keepPaging && page <= 10) {
       const res = await get(`/repos/${ORG}/${repo}/pulls?state=closed&sort=recentupdate&limit=50&page=${page}`, token);
-      const list = Array.isArray(res && res.data) ? res.data : [];
+      // Status guard: a 401/403/5xx must NOT be mistaken for "no PRs" — that
+      // would let runOvernightReview advance lastRun and permanently skip this
+      // interval. Abort the whole run so state is left untouched and retried.
+      if (!res || res.status !== 200) {
+        throw new Error(`Gitea pulls query failed for ${repo}: status=${res && res.status}`);
+      }
+      const list = Array.isArray(res.data) ? res.data : [];
       if (list.length === 0) break;
       for (const pr of list) {
         if (!pr || !pr.merged) continue;
-        const be = parseBeRef(pr.head && pr.head.ref);
-        if (!be) continue;
         const mergedAt = pr.merged_at || pr.updated_at;
         if (sinceIso && mergedAt && mergedAt < sinceIso) { keepPaging = false; continue; }
+        const author = (pr.user && pr.user.login) || null;
+        const be = parseBeRef(pr.head && pr.head.ref);
+        let book = be && be.book;
+        let editor = be && be.editor;
+        if (!book) {
+          // Fallback path (deleted branch): require a known editor + a touched resource file.
+          const known = attributeKnownEditor(editorMap, author);
+          if (!known || isBotAuthor(author)) continue;
+          const files = await fetchPrFiles(get, repo, pr.number, token);
+          book = files.map((f) => bookFromFilename(f, resource)).find(Boolean);
+          if (!book) continue; // PR didn't touch this resource's file
+          editor = known;
+        }
         units.push({
-          kind: 'merged-pr', repo, resource, book: be.book, editor: be.editor,
+          kind: 'merged-pr', repo, resource, book, editor: editor || author,
           prId: pr.number,
           baseSha: pr.base && pr.base.sha,
           headSha: (pr.head && pr.head.sha) || pr.merge_commit_sha,
           mergedAt,
-          author: (pr.user && pr.user.login) || be.editor,
+          author,
         });
       }
       // recentupdate desc — once we pass the cutoff we can stop.
       if (sinceIso && list.some((pr) => (pr.merged_at || pr.updated_at || '') < sinceIso)) keepPaging = false;
       page += 1;
     }
-    // SECONDARY: live -be- branches (in-flight work).
-    try {
-      const res = await get(`/repos/${ORG}/${repo}/branches?limit=100`, token);
-      const branches = Array.isArray(res && res.data) ? res.data : [];
-      for (const b of branches) {
+    // SECONDARY: live -be- branches (in-flight work). Best-effort — a non-200
+    // here is non-fatal (the branch list is the secondary signal).
+    const bres = await get(`/repos/${ORG}/${repo}/branches?limit=100`, token);
+    if (bres && bres.status === 200 && Array.isArray(bres.data)) {
+      for (const b of bres.data) {
         const be = parseBeRef(b && b.name);
         if (!be) continue;
         units.push({
@@ -176,7 +239,7 @@ async function enumerateUnits({ apiGetImpl, token, sinceIso }) {
           author: (b.commit && b.commit.author && b.commit.author.username) || be.editor,
         });
       }
-    } catch { /* branch listing is best-effort */ }
+    }
   }
   return units;
 }
@@ -187,33 +250,43 @@ function unitKeyFor(u) {
     : state.branchUnitKey(u.repo, u.branch, u.tipSha);
 }
 
-// Review one new unit → array of proposal rows. Fetches old/new content.
+// Fetch that tolerates a genuinely-absent file (HTTP 404 -> '') but RE-THROWS
+// any other failure (network/timeout/5xx). This is what lets the caller tell
+// "fetched, no edits" (safe to mark reviewed) apart from "transient failure"
+// (must NOT mark reviewed, so the unit is retried next run).
+async function fetchAllowMissing(fetch, url) {
+  try {
+    return await fetch(url);
+  } catch (err) {
+    if (/HTTP 404\b/.test(String((err && err.message) || ''))) return '';
+    throw err;
+  }
+}
+
+// Review one new unit → array of proposal rows. THROWS on transient fetch
+// failure so the orchestrator does not mark the unit reviewed.
 async function reviewUnit(u, { fetchTextImpl }) {
   const fetch = fetchTextImpl || fetchText;
   const oldRef = u.kind === 'merged-pr' ? `commit/${u.baseSha}` : 'branch/master';
   const newRef = u.kind === 'merged-pr' ? `commit/${u.headSha}` : `branch/${u.branch}`;
   const headSha = u.kind === 'merged-pr' ? u.headSha : u.tipSha;
-  try {
-    if (u.resource === 'tn') {
-      const file = tnFileForBook(u.book);
-      const [oldTsv, newTsv] = await Promise.all([
-        fetch(rawUrl(u.repo, oldRef, file)).catch(() => ''),
-        fetch(rawUrl(u.repo, newRef, file)).catch(() => ''),
-      ]);
-      const compare = prepareCompareTn({ oldTsv, newTsv, book: u.book });
-      return tnChangesToProposals(compare, { repo: u.repo, book: u.book, editor: u.editor, prId: u.prId, headSha });
-    }
-    const file = usfmFileForBook(u.book);
-    if (!file) return [];
-    const [oldUsfm, newUsfm] = await Promise.all([
-      fetch(rawUrl(u.repo, oldRef, file)).catch(() => ''),
-      fetch(rawUrl(u.repo, newRef, file)).catch(() => ''),
+  if (u.resource === 'tn') {
+    const file = tnFileForBook(u.book);
+    const [oldTsv, newTsv] = await Promise.all([
+      fetchAllowMissing(fetch, rawUrl(u.repo, oldRef, file)),
+      fetchAllowMissing(fetch, rawUrl(u.repo, newRef, file)),
     ]);
-    const changed = changedChaptersFromUsfm(oldUsfm, newUsfm);
-    return usfmChangesToProposals(changed, { repo: u.repo, resource: u.resource, book: u.book, editor: u.editor, prId: u.prId, headSha });
-  } catch {
-    return [];
+    const compare = prepareCompareTn({ oldTsv, newTsv, book: u.book });
+    return tnChangesToProposals(compare, { repo: u.repo, book: u.book, editor: u.editor, prId: u.prId, headSha });
   }
+  const file = usfmFileForBook(u.book);
+  if (!file) return [];
+  const [oldUsfm, newUsfm] = await Promise.all([
+    fetchAllowMissing(fetch, rawUrl(u.repo, oldRef, file)),
+    fetchAllowMissing(fetch, rawUrl(u.repo, newRef, file)),
+  ]);
+  const changed = changedChaptersFromUsfm(oldUsfm, newUsfm);
+  return usfmChangesToProposals(changed, { repo: u.repo, resource: u.resource, book: u.book, editor: u.editor, prId: u.prId, headSha });
 }
 
 // --- orchestration -----------------------------------------------------------
@@ -232,7 +305,11 @@ async function runOvernightReview({
   const stateFile = path.join(skillsRepo, state.DEFAULT_STATE_REL);
 
   const st = state.loadState(stateFile, deps.readFileSync);
-  const units = await enumerateUnits({ apiGetImpl: deps.apiGetImpl, token, sinceIso: st.lastRun });
+  const editorMap = deps.editorMap || loadEditorMap();
+  // If enumeration throws (e.g. a Gitea auth/5xx error), it propagates here and
+  // aborts the run BEFORE any state write — lastRun is not advanced, so the
+  // interval is retried rather than silently skipped.
+  const units = await enumerateUnits({ apiGetImpl: deps.apiGetImpl, token, sinceIso: st.lastRun, editorMap });
   const allKeys = units.map(unitKeyFor);
 
   if (state.isColdStart(st)) {
@@ -245,8 +322,17 @@ async function runOvernightReview({
   const fresh = units.filter((u) => !state.isReviewed(st, unitKeyFor(u)) && !isBotAuthor(u.author));
   const proposals = [];
   const reviewTasks = [];
+  let failed = 0;
   for (const u of fresh) {
-    const rows = await reviewUnit(u, { fetchTextImpl: deps.fetchTextImpl });
+    let rows;
+    try {
+      rows = await reviewUnit(u, { fetchTextImpl: deps.fetchTextImpl });
+    } catch (err) {
+      // Transient fetch/compare failure — do NOT mark reviewed; retry next run.
+      failed += 1;
+      log(`[overnight] review failed for ${unitKeyFor(u)} (${(err && err.message) || err}) — not marking reviewed; will retry.`);
+      continue;
+    }
     proposals.push(...rows);
     reviewTasks.push({
       repo: u.repo, resource: u.resource, book: u.book, editor: u.editor,
@@ -269,13 +355,17 @@ async function runOvernightReview({
     writeImpl(proposalsPath, proposals.map((p) => JSON.stringify(p)).join('\n') + (proposals.length ? '\n' : ''));
     tasksPath = path.join(outDir, 'review-tasks.jsonl');
     writeImpl(tasksPath, reviewTasks.map((t) => JSON.stringify(t)).join('\n') + (reviewTasks.length ? '\n' : ''));
-    st.lastRun = now.toISOString();
+    // Persist the reviewed-set always (so successful units are never re-reviewed),
+    // but only advance the lastRun watermark on a clean run — otherwise a deferred
+    // unit would fall outside the next window and never be retried.
+    if (failed === 0) st.lastRun = now.toISOString();
     state.saveState(stateFile, st, { writeImpl, mkdirImpl: mkdir });
   }
 
-  log(`[overnight] ${dryRun ? 'would review' : 'reviewed'} ${fresh.length} unit(s) → ${proposals.length} proposal row(s), ${reviewTasks.length} review task(s).`);
+  const reviewed = fresh.length - failed;
+  log(`[overnight] ${dryRun ? 'would review' : 'reviewed'} ${reviewed} unit(s)${failed ? ` (${failed} deferred on transient failure)` : ''} → ${proposals.length} proposal row(s), ${reviewTasks.length} review task(s).`);
   return {
-    coldStart: false, dryRun, units: units.length, reviewed: fresh.length,
+    coldStart: false, dryRun, units: units.length, reviewed, failed,
     proposals: proposals.length, proposalsPath, tasksPath, reviewTasks,
     sampleProposals: proposals.slice(0, 12),
   };

--- a/src/quickref-cache.js
+++ b/src/quickref-cache.js
@@ -1,0 +1,113 @@
+// quickref-cache.js — Phase 3 memory PILOT (opt-in, default OFF).
+//
+// Builds a DERIVED, read-only "memory" index from the git-versioned decision
+// stores (data/quick-ref/*_decisions.csv + data/glossary/project_glossary.md).
+// The CSVs/glossary remain the single source of truth and the only writable
+// path (via the append_quickref MCP tool); this is a downstream, regenerated
+// read replica — a compact index of the human rulings an agent can load instead
+// of grepping the full CSVs. It is content-hash keyed so it only rebuilds when
+// the sources change, and it is never written by the model.
+//
+// Nothing calls this automatically. Enable it per environment by running the CLI
+// (e.g. after append_quickref, or at pipeline start) and pointing a run at the
+// derived index. Keeping it opt-in avoids making a derived artifact load-bearing.
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const { loadHumanDecisions, resolveSkillsRoot } = require('./human-decision-conflicts');
+
+const DERIVED_HEADER = [
+  '# Quick-Ref Memory Index (DERIVED — do not edit)',
+  '',
+  '> Regenerated from `data/quick-ref/*_decisions.csv` + `data/glossary/project_glossary.md`',
+  '> (the source of truth). Edits here are overwritten on the next rebuild. The',
+  '> canonical write path is the `append_quickref` MCP tool → the CSVs.',
+  '',
+].join('\n');
+
+// Stable hash of the decision set — drives rebuild-only-when-changed.
+function hashDecisions(decisions) {
+  const stable = decisions
+    .map((d) => `${d.type}|${d.resource}|${d.strong}|${d.hebrew}|${d.rendering}|${d.book}|${d.context}|${d.notes}`)
+    .sort();
+  return crypto.createHash('sha256').update(stable.join('\n')).digest('hex').slice(0, 16);
+}
+
+// Render the human-friendly index grouped by resource. Pure (testable).
+function renderIndex(decisions, { hash } = {}) {
+  const groups = new Map();
+  for (const d of decisions) {
+    const g = d.resource || d.type || 'other';
+    if (!groups.has(g)) groups.set(g, []);
+    groups.get(g).push(d);
+  }
+  const lines = [DERIVED_HEADER, `_${decisions.length} human ruling(s); index hash \`${hash || hashDecisions(decisions)}\`._`, ''];
+  for (const g of [...groups.keys()].sort()) {
+    lines.push(`## ${g}`, '');
+    for (const d of groups.get(g).sort((a, b) => String(a.strong).localeCompare(String(b.strong)))) {
+      const id = [d.strong, d.hebrew].filter(Boolean).join(' ');
+      const scope = d.book && d.book !== 'ALL' ? ` [${d.book}]` : '';
+      const detail = [d.context, d.notes].filter(Boolean).join(' — ');
+      lines.push(`- ${id || '(no key)'} → "${d.rendering}"${scope}${detail ? ` — ${detail}` : ''}`);
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function defaultOutDir() {
+  return process.env.QUICKREF_CACHE_DIR || path.resolve(__dirname, '../data/quick-ref-cache');
+}
+
+// Build (or refresh) the derived index. Returns { built, path, hash, entries, reason? }.
+function buildQuickRefCache({ skillsRoot, outDir = defaultOutDir(), deps = {} } = {}) {
+  const read = deps.loadHumanDecisions || loadHumanDecisions;
+  const writeFile = deps.writeFileSync || fs.writeFileSync;
+  const readFile = deps.readFileSync || fs.readFileSync;
+  const mkdir = deps.mkdirSync || ((p) => fs.mkdirSync(p, { recursive: true }));
+  const exists = deps.existsSync || fs.existsSync;
+
+  const root = resolveSkillsRoot(skillsRoot);
+  const decisions = read(root);
+  const hash = hashDecisions(decisions);
+  const indexPath = path.join(outDir, 'quick-ref-index.md');
+  const hashPath = path.join(outDir, '.cache-hash');
+
+  if (exists(hashPath)) {
+    let prev = '';
+    try { prev = String(readFile(hashPath, 'utf8')).trim(); } catch { /* ignore */ }
+    if (prev === hash && exists(indexPath)) {
+      return { built: false, reason: 'unchanged', path: indexPath, hash, entries: decisions.length };
+    }
+  }
+  mkdir(outDir);
+  writeFile(indexPath, renderIndex(decisions, { hash }) + '\n');
+  writeFile(hashPath, hash + '\n');
+  return { built: true, path: indexPath, hash, entries: decisions.length };
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--skills-root') out.skillsRoot = argv[++i];
+    else if (argv[i] === '--out-dir') out.outDir = argv[++i];
+  }
+  return out;
+}
+
+if (require.main === module) {
+  const args = parseArgs(process.argv.slice(2));
+  const res = buildQuickRefCache({ skillsRoot: args.skillsRoot, outDir: args.outDir });
+  process.stdout.write(`${res.built ? 'built' : 'unchanged'} ${res.path} (${res.entries} rulings, hash ${res.hash})\n`);
+}
+
+module.exports = {
+  buildQuickRefCache,
+  renderIndex,
+  hashDecisions,
+  defaultOutDir,
+  DERIVED_HEADER,
+};

--- a/src/repo-verify.js
+++ b/src/repo-verify.js
@@ -227,4 +227,6 @@ async function verifyDcsToken() {
   }
 }
 
-module.exports = { verifyRepoPush, verifyDcsToken };
+// apiGet + GITEA_API are reused by the overnight Sensor (overnight-watcher.js)
+// for read-only PR/branch enumeration against Door43.
+module.exports = { verifyRepoPush, verifyDcsToken, apiGet, GITEA_API };

--- a/src/self-diagnosis.js
+++ b/src/self-diagnosis.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const { runClaude, isGuardrailStop } = require('./claude-runner');
+const { createGuardHooks } = require('./guard-hooks');
 const { publishAdminStatus, readAdminStatus } = require('./admin-status');
 const { readSecret } = require('./secrets');
 const {
@@ -286,6 +287,11 @@ async function runDiagnosisAgent({ contextSummary, runClaudeImpl }) {
     maxTurns: 40,
     timeoutMs: 5 * 60 * 1000,
     guardrails: { maxToolCalls: 40, tokenBudget: 200000 },
+    // Declarative defense-in-depth: the diagnosis sub-agent is read-only, so a
+    // PreToolUse guard denies anything outside Read/Grep and publishes any
+    // anomalous attempt to admin-status (observability for a sub-agent that
+    // should never write).
+    hooks: createGuardHooks({ allowedTools: ['Read', 'Grep'], pipelineType: 'system', publish: true }),
   });
   return {
     subtype: result?.subtype || 'unknown',

--- a/src/self-diagnosis.js
+++ b/src/self-diagnosis.js
@@ -287,11 +287,13 @@ async function runDiagnosisAgent({ contextSummary, runClaudeImpl }) {
     maxTurns: 40,
     timeoutMs: 5 * 60 * 1000,
     guardrails: { maxToolCalls: 40, tokenBudget: 200000 },
-    // Declarative defense-in-depth: the diagnosis sub-agent is read-only, so a
-    // PreToolUse guard denies anything outside Read/Grep and publishes any
-    // anomalous attempt to admin-status (observability for a sub-agent that
-    // should never write).
-    hooks: createGuardHooks({ allowedTools: ['Read', 'Grep'], pipelineType: 'system', publish: true }),
+    // Declarative defense-in-depth (opt-in, BP_GUARD_HOOKS=1): the diagnosis
+    // sub-agent is read-only, so a PreToolUse guard denies anything outside
+    // Read/Grep and publishes any anomalous attempt to admin-status. Default
+    // OFF so options stay byte-identical until the hook layer is validated.
+    hooks: process.env.BP_GUARD_HOOKS === '1'
+      ? createGuardHooks({ allowedTools: ['Read', 'Grep'], pipelineType: 'system', publish: true })
+      : undefined,
   });
   return {
     subtype: result?.subtype || 'unknown',

--- a/src/workspace-tools/tsv-tools.js
+++ b/src/workspace-tools/tsv-tools.js
@@ -255,6 +255,7 @@ function _tnColIndices(headerLine) {
     reference: find('reference', 0),
     supportReference: find('supportreference', 3),
     quote: find('quote', 4),
+    occurrence: find('occurrence', 5),
     note: find('note', 6),
   };
 }
@@ -276,6 +277,7 @@ function _parseTnRows(content, chapterFilter) {
       reference,
       supportReference: (cols[idx.supportReference] || '').trim(),
       quote: (cols[idx.quote] || '').trim(),
+      occurrence: (cols[idx.occurrence] || '').trim(),
       note: (cols[idx.note] || '').trim(),
     });
   }
@@ -301,8 +303,8 @@ function prepareCompareTn({ oldTsv, newTsv, oldPath, newPath, book = null, chapt
   const oldRows = _parseTnRows(oldContent, chapter);
   const newRows = _parseTnRows(newContent, chapter);
 
-  const fullKey = (r) => `${r.reference} ${r.supportReference} ${r.quote}`;
-  const pairKey = (r) => `${r.reference} ${r.supportReference}`;
+  const fullKey = (r) => [r.reference, r.supportReference, r.quote, r.occurrence].join("|");
+  const pairKey = (r) => [r.reference, r.supportReference].join("|");
   const oldByFull = new Map();
   for (const r of oldRows) if (!oldByFull.has(fullKey(r))) oldByFull.set(fullKey(r), r);
   const newByFull = new Map();
@@ -316,7 +318,7 @@ function prepareCompareTn({ oldTsv, newTsv, oldPath, newPath, book = null, chapt
       const newR = newByFull.get(k);
       if (_normNote(oldR.note) !== _normNote(newR.note)) {
         changes.push({ changeType: 'reworded', reference: oldR.reference, supportReference: oldR.supportReference,
-          before: { quote: oldR.quote, note: oldR.note }, after: { quote: newR.quote, note: newR.note } });
+          before: { quote: oldR.quote, occurrence: oldR.occurrence, note: oldR.note }, after: { quote: newR.quote, occurrence: newR.occurrence, note: newR.note } });
       }
     } else { oldOnly.push(oldR); }
   }
@@ -334,12 +336,12 @@ function prepareCompareTn({ oldTsv, newTsv, oldPath, newPath, book = null, chapt
     if (oArr.length === 1 && nArr && nArr.length === 1) {
       const o = oArr[0]; const n = nArr[0];
       changes.push({ changeType: 'quote-changed', reference: o.reference, supportReference: o.supportReference,
-        before: { quote: o.quote, note: o.note }, after: { quote: n.quote, note: n.note } });
+        before: { quote: o.quote, occurrence: o.occurrence, note: o.note }, after: { quote: n.quote, occurrence: n.occurrence, note: n.note } });
       usedOld.add(o); usedNew.add(n);
     }
   }
-  for (const r of oldOnly) if (!usedOld.has(r)) changes.push({ changeType: 'dropped', reference: r.reference, supportReference: r.supportReference, before: { quote: r.quote, note: r.note }, after: null });
-  for (const r of newOnly) if (!usedNew.has(r)) changes.push({ changeType: 'added', reference: r.reference, supportReference: r.supportReference, before: null, after: { quote: r.quote, note: r.note } });
+  for (const r of oldOnly) if (!usedOld.has(r)) changes.push({ changeType: 'dropped', reference: r.reference, supportReference: r.supportReference, before: { quote: r.quote, occurrence: r.occurrence, note: r.note }, after: null });
+  for (const r of newOnly) if (!usedNew.has(r)) changes.push({ changeType: 'added', reference: r.reference, supportReference: r.supportReference, before: null, after: { quote: r.quote, occurrence: r.occurrence, note: r.note } });
 
   changes.sort((a, b) => (parseVerseNum(a.reference) || 0) - (parseVerseNum(b.reference) || 0));
   const summary = { reworded: 0, 'quote-changed': 0, dropped: 0, added: 0, total: changes.length };

--- a/src/workspace-tools/tsv-tools.js
+++ b/src/workspace-tools/tsv-tools.js
@@ -242,4 +242,109 @@ function fixTrailingNewlines({ file }) {
   return `Fixed ${fixed} trailing \\n in ${path.basename(filePath)}`;
 }
 
-module.exports = { splitTsv, mergeTsvs, fixTrailingNewlines };
+// --- TN edit comparator (Phase 2 overnight Sensor) ---------------------------
+// TN is TSV, not USFM, so prepare_compare (USFM) can't parse it. This diffs two
+// versions of a book's notes TSV row-by-row, keyed by Reference+SupportReference
+// (the stable identity; the random ID column is ignored entirely, and Quote can
+// drift). Classifies each change as reworded / quote-changed / dropped / added
+// and ignores cosmetic (whitespace-only) Note edits. Returns a plain object.
+function _tnColIndices(headerLine) {
+  const cols = headerLine.split('\t').map((c) => c.trim().toLowerCase());
+  const find = (name, dflt) => { const i = cols.indexOf(name); return i >= 0 ? i : dflt; };
+  return {
+    reference: find('reference', 0),
+    supportReference: find('supportreference', 3),
+    quote: find('quote', 4),
+    note: find('note', 6),
+  };
+}
+
+function _parseTnRows(content, chapterFilter) {
+  const lines = String(content || '').split(/\r?\n/);
+  let idx = { reference: 0, supportReference: 3, quote: 4, note: 6 };
+  let start = 0;
+  if (lines.length && /^reference\t/i.test(lines[0])) { idx = _tnColIndices(lines[0]); start = 1; }
+  const rows = [];
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    const cols = line.split('\t');
+    const reference = (cols[idx.reference] || '').trim();
+    if (!reference) continue;
+    if (chapterFilter != null && String(reference.split(':')[0]) !== String(chapterFilter)) continue;
+    rows.push({
+      reference,
+      supportReference: (cols[idx.supportReference] || '').trim(),
+      quote: (cols[idx.quote] || '').trim(),
+      note: (cols[idx.note] || '').trim(),
+    });
+  }
+  return rows;
+}
+
+function _normNote(s) { return String(s || '').replace(/\s+/g, ' ').trim(); }
+
+/**
+ * Row-keyed diff of two TN notes-TSV versions.
+ * @param {object} opts
+ * @param {string} [opts.oldTsv]  - old TSV content (inline)
+ * @param {string} [opts.newTsv]  - new TSV content (inline)
+ * @param {string} [opts.oldPath] - old TSV path (relative to CSKILLBP_DIR)
+ * @param {string} [opts.newPath] - new TSV path
+ * @param {string} [opts.book]    - book code (label only)
+ * @param {number|string} [opts.chapter] - restrict to one chapter (Reference prefix)
+ * @returns {{ book, chapter, summary, changes }}
+ */
+function prepareCompareTn({ oldTsv, newTsv, oldPath, newPath, book = null, chapter = null } = {}) {
+  const oldContent = oldTsv != null ? oldTsv : (oldPath ? fs.readFileSync(path.resolve(CSKILLBP_DIR, oldPath), 'utf8') : '');
+  const newContent = newTsv != null ? newTsv : (newPath ? fs.readFileSync(path.resolve(CSKILLBP_DIR, newPath), 'utf8') : '');
+  const oldRows = _parseTnRows(oldContent, chapter);
+  const newRows = _parseTnRows(newContent, chapter);
+
+  const fullKey = (r) => `${r.reference} ${r.supportReference} ${r.quote}`;
+  const pairKey = (r) => `${r.reference} ${r.supportReference}`;
+  const oldByFull = new Map();
+  for (const r of oldRows) if (!oldByFull.has(fullKey(r))) oldByFull.set(fullKey(r), r);
+  const newByFull = new Map();
+  for (const r of newRows) if (!newByFull.has(fullKey(r))) newByFull.set(fullKey(r), r);
+
+  const changes = [];
+  const oldOnly = [];
+  const newOnly = [];
+  for (const [k, oldR] of oldByFull) {
+    if (newByFull.has(k)) {
+      const newR = newByFull.get(k);
+      if (_normNote(oldR.note) !== _normNote(newR.note)) {
+        changes.push({ changeType: 'reworded', reference: oldR.reference, supportReference: oldR.supportReference,
+          before: { quote: oldR.quote, note: oldR.note }, after: { quote: newR.quote, note: newR.note } });
+      }
+    } else { oldOnly.push(oldR); }
+  }
+  for (const [k, newR] of newByFull) if (!oldByFull.has(k)) newOnly.push(newR);
+
+  // Pair a single dropped + single added on the same (Reference, SupportReference)
+  // as a quote-changed; leftovers are genuine drops/adds.
+  const groupBy = (arr) => { const m = new Map(); for (const r of arr) { const p = pairKey(r); if (!m.has(p)) m.set(p, []); m.get(p).push(r); } return m; };
+  const oldG = groupBy(oldOnly);
+  const newG = groupBy(newOnly);
+  const usedOld = new Set();
+  const usedNew = new Set();
+  for (const [p, oArr] of oldG) {
+    const nArr = newG.get(p);
+    if (oArr.length === 1 && nArr && nArr.length === 1) {
+      const o = oArr[0]; const n = nArr[0];
+      changes.push({ changeType: 'quote-changed', reference: o.reference, supportReference: o.supportReference,
+        before: { quote: o.quote, note: o.note }, after: { quote: n.quote, note: n.note } });
+      usedOld.add(o); usedNew.add(n);
+    }
+  }
+  for (const r of oldOnly) if (!usedOld.has(r)) changes.push({ changeType: 'dropped', reference: r.reference, supportReference: r.supportReference, before: { quote: r.quote, note: r.note }, after: null });
+  for (const r of newOnly) if (!usedNew.has(r)) changes.push({ changeType: 'added', reference: r.reference, supportReference: r.supportReference, before: null, after: { quote: r.quote, note: r.note } });
+
+  changes.sort((a, b) => (parseVerseNum(a.reference) || 0) - (parseVerseNum(b.reference) || 0));
+  const summary = { reworded: 0, 'quote-changed': 0, dropped: 0, added: 0, total: changes.length };
+  for (const c of changes) summary[c.changeType] = (summary[c.changeType] || 0) + 1;
+  return { book, chapter, summary, changes };
+}
+
+module.exports = { splitTsv, mergeTsvs, fixTrailingNewlines, prepareCompareTn };

--- a/test/overnight-sensor.test.js
+++ b/test/overnight-sensor.test.js
@@ -1,0 +1,179 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { prepareCompareTn } = require('../src/workspace-tools/tsv-tools');
+const stateLib = require('../src/overnight-review-state');
+const watcher = require('../src/overnight-watcher');
+
+const TN_HEADER = 'Reference\tID\tTags\tSupportReference\tQuote\tOccurrence\tNote';
+
+// --- prepareCompareTn --------------------------------------------------------
+test('prepareCompareTn classifies reworded / dropped / added and ignores the ID column', () => {
+  const oldTsv = [
+    TN_HEADER,
+    '1:1\tabc1\t\tfigs-metaphor\tthe LORD\t1\tOld note text',
+    '1:2\tabc2\t\tfigs-explicit\tcovenant\t1\tDrop me',
+  ].join('\n');
+  const newTsv = [
+    TN_HEADER,
+    '1:1\tZZZ9\t\tfigs-metaphor\tthe LORD\t1\tNew reworded note', // ID changed (ignored), note changed
+    '1:3\tabc3\t\ttranslate-names\tBob\t1\tAdded note',
+  ].join('\n');
+  const r = prepareCompareTn({ oldTsv, newTsv, book: 'PSA' });
+  const byType = {};
+  for (const c of r.changes) (byType[c.changeType] ||= []).push(c);
+  assert.equal(r.summary.reworded, 1);
+  assert.equal(r.summary.dropped, 1);
+  assert.equal(r.summary.added, 1);
+  assert.equal(byType.reworded[0].reference, '1:1');
+  assert.equal(byType.dropped[0].reference, '1:2');
+  assert.equal(byType.added[0].reference, '1:3');
+});
+
+test('prepareCompareTn detects quote-changed when only the Quote moves on a (ref, support) pair', () => {
+  const oldTsv = [TN_HEADER, '2:5\ta\t\tfigs-idiom\told quote\t1\tSame note'].join('\n');
+  const newTsv = [TN_HEADER, '2:5\tb\t\tfigs-idiom\tnew quote\t1\tSame note'].join('\n');
+  const r = prepareCompareTn({ oldTsv, newTsv });
+  assert.equal(r.summary['quote-changed'], 1);
+  assert.equal(r.changes[0].before.quote, 'old quote');
+  assert.equal(r.changes[0].after.quote, 'new quote');
+});
+
+test('prepareCompareTn ignores cosmetic (whitespace-only) Note edits', () => {
+  const oldTsv = [TN_HEADER, '1:1\ta\t\tfigs-metaphor\tx\t1\tthe  note'].join('\n');
+  const newTsv = [TN_HEADER, '1:1\ta\t\tfigs-metaphor\tx\t1\tthe note'].join('\n');
+  const r = prepareCompareTn({ oldTsv, newTsv });
+  assert.equal(r.summary.total, 0);
+});
+
+test('prepareCompareTn restricts to a chapter when asked', () => {
+  const oldTsv = [TN_HEADER, '1:1\ta\t\ts\tq\t1\tn1', '2:1\tb\t\ts\tq\t1\tn2'].join('\n');
+  const newTsv = [TN_HEADER, '1:1\ta\t\ts\tq\t1\tn1-changed', '2:1\tb\t\ts\tq\t1\tn2-changed'].join('\n');
+  const r = prepareCompareTn({ oldTsv, newTsv, chapter: 1 });
+  assert.equal(r.summary.total, 1);
+  assert.equal(r.changes[0].reference, '1:1');
+});
+
+// --- overnight-review-state --------------------------------------------------
+test('state cold-start primes all current HEADs and reviews nothing', () => {
+  const st = stateLib.defaultState();
+  assert.equal(stateLib.isColdStart(st), true);
+  const keys = ['en_tn#5@abc', 'en_ult#6@def'];
+  stateLib.primeColdStart(st, keys, new Date('2026-06-24T00:00:00Z'));
+  assert.equal(st.initialized, true);
+  assert.ok(keys.every((k) => stateLib.isReviewed(st, k)));
+});
+
+test('state is idempotent on PR id + headSha', () => {
+  const st = stateLib.defaultState();
+  st.initialized = true;
+  const k = stateLib.prUnitKey('en_tn', 5, 'abcdef1234567890');
+  assert.equal(stateLib.isReviewed(st, k), false);
+  stateLib.markReviewed(st, k);
+  assert.equal(stateLib.isReviewed(st, k), true);
+  // A new head sha for the same PR is a new unit.
+  assert.equal(stateLib.isReviewed(st, stateLib.prUnitKey('en_tn', 5, 'differentsha999')), false);
+});
+
+test('loadState falls back to default on missing/garbage', () => {
+  assert.equal(stateLib.loadState('/x', () => { throw new Error('enoent'); }).initialized, false);
+  assert.equal(stateLib.loadState('/x', () => 'not json').initialized, false);
+});
+
+// --- watcher pure helpers ----------------------------------------------------
+test('parseBeRef extracts book + editor (incl. numeric-prefixed books) and rejects non-be refs', () => {
+  assert.deepEqual(watcher.parseBeRef('PSA-be-pjoakes'), { book: 'PSA', editor: 'pjoakes' });
+  assert.deepEqual(watcher.parseBeRef('1KI-be-Grant_Ailie'), { book: '1KI', editor: 'Grant_Ailie' });
+  assert.equal(watcher.parseBeRef('main'), null);
+  assert.equal(watcher.parseBeRef('ZZZ-be-x'), null); // not a real book
+});
+
+test('isBotAuthor filters bot logins, keeps humans', () => {
+  assert.equal(watcher.isBotAuthor('deferredreward-bot'), true);
+  assert.equal(watcher.isBotAuthor('github-actions[bot]'), true);
+  assert.equal(watcher.isBotAuthor(''), true);
+  assert.equal(watcher.isBotAuthor('pjoakes'), false);
+});
+
+test('file naming helpers', () => {
+  assert.equal(watcher.tnFileForBook('psa'), 'tn_PSA.tsv');
+  assert.equal(watcher.usfmFileForBook('PSA'), '19-PSA.usfm');
+  assert.equal(watcher.usfmFileForBook('1KI'), '11-1KI.usfm');
+});
+
+test('changedChaptersFromUsfm reports only chapters whose stripped text differs', () => {
+  const oldU = '\\c 1\n\\v 1 the word\n\\c 2\n\\v 1 same\n';
+  const newU = '\\c 1\n\\v 1 the changed word\n\\c 2\n\\v 1 same\n';
+  assert.deepEqual(watcher.changedChaptersFromUsfm(oldU, newU), [1]);
+});
+
+test('rawUrl builds a Gitea raw-by-commit URL', () => {
+  assert.equal(
+    watcher.rawUrl('en_tn', 'commit/abc123', 'tn_PSA.tsv'),
+    'https://git.door43.org/unfoldingWord/en_tn/raw/commit/abc123/tn_PSA.tsv',
+  );
+});
+
+// --- runOvernightReview (injected HTTP) -------------------------------------
+function fakeApiGet(prsByRepo, branchesByRepo) {
+  return async (p) => {
+    const mPulls = p.match(/\/repos\/unfoldingWord\/([^/]+)\/pulls/);
+    if (mPulls) {
+      if (/page=1/.test(p)) return { status: 200, data: prsByRepo[mPulls[1]] || [] };
+      return { status: 200, data: [] };
+    }
+    const mBr = p.match(/\/repos\/unfoldingWord\/([^/]+)\/branches/);
+    if (mBr) return { status: 200, data: branchesByRepo[mBr[1]] || [] };
+    return { status: 404, data: [] };
+  };
+}
+
+test('runOvernightReview cold-start reviews nothing and writes state', async () => {
+  const writes = [];
+  const prs = { en_tn: [{ number: 5, merged: true, merged_at: '2026-06-23T10:00:00Z', head: { ref: 'PSA-be-pjoakes', sha: 'head5' }, base: { sha: 'base5' }, user: { login: 'pjoakes' } }] };
+  const res = await watcher.runOvernightReview({
+    skillsRepo: '/skills', now: new Date('2026-06-24T07:00:00Z'),
+    deps: {
+      readFileSync: () => { throw new Error('no state'); },
+      writeFileSync: (pth, content) => writes.push({ pth, content }),
+      mkdirSync: () => {},
+      apiGetImpl: fakeApiGet(prs, {}),
+      fetchTextImpl: async () => '',
+      log: () => {},
+    },
+  });
+  assert.equal(res.coldStart, true);
+  assert.equal(res.reviewed, 0);
+  const stateWrite = writes.find((w) => /state\.json$/.test(w.pth));
+  assert.ok(stateWrite);
+  assert.ok(JSON.parse(stateWrite.content).initialized);
+});
+
+test('runOvernightReview reviews a fresh merged TN PR and emits proposals', async () => {
+  const writes = [];
+  const initState = JSON.stringify({ version: 1, initialized: true, lastRun: '2026-06-20T00:00:00Z', reviewed: {}, branchTips: {} });
+  const prs = { en_tn: [{ number: 9, merged: true, merged_at: '2026-06-23T22:00:00Z', head: { ref: 'PSA-be-pjoakes', sha: 'newhead' }, base: { sha: 'oldbase' }, user: { login: 'pjoakes' } }] };
+  const oldTsv = [TN_HEADER, '1:1\ta\t\tfigs-metaphor\tx\t1\told note'].join('\n');
+  const newTsv = [TN_HEADER, '1:1\tb\t\tfigs-metaphor\tx\t1\trewritten note'].join('\n');
+  const res = await watcher.runOvernightReview({
+    skillsRepo: '/skills', now: new Date('2026-06-24T07:00:00Z'),
+    deps: {
+      readFileSync: () => initState,
+      writeFileSync: (pth, content) => writes.push({ pth, content }),
+      mkdirSync: () => {},
+      apiGetImpl: fakeApiGet(prs, {}),
+      fetchTextImpl: async (url) => (/commit\/oldbase/.test(url) ? oldTsv : (/commit\/newhead/.test(url) ? newTsv : '')),
+      log: () => {},
+    },
+  });
+  assert.equal(res.coldStart, false);
+  assert.equal(res.reviewed, 1);
+  assert.equal(res.proposals, 1);
+  const proposalsWrite = writes.find((w) => /proposals\.jsonl$/.test(w.pth));
+  assert.ok(proposalsWrite);
+  const row = JSON.parse(proposalsWrite.content.trim());
+  assert.equal(row.resource, 'tn');
+  assert.equal(row.category, 'reworded');
+  assert.equal(row.editor, 'pjoakes');
+  assert.equal(row.book, 'PSA');
+});

--- a/test/overnight-sensor.test.js
+++ b/test/overnight-sensor.test.js
@@ -149,6 +149,73 @@ test('runOvernightReview cold-start reviews nothing and writes state', async () 
   assert.ok(JSON.parse(stateWrite.content).initialized);
 });
 
+test('prepareCompareTn detects an occurrence retarget (Occurrence column not ignored)', () => {
+  const oldTsv = ['Reference\tID\tTags\tSupportReference\tQuote\tOccurrence\tNote', '3:2\ta\t\tfigs-x\tword\t1\tsame note'].join('\n');
+  const newTsv = ['Reference\tID\tTags\tSupportReference\tQuote\tOccurrence\tNote', '3:2\tb\t\tfigs-x\tword\t2\tsame note'].join('\n');
+  const r = prepareCompareTn({ oldTsv, newTsv });
+  assert.equal(r.summary.total, 1); // occurrence 1 -> 2 is a real change, not "unchanged"
+});
+
+test('enumerateUnits derives book+editor from PR files when head.ref is stripped (deleted branch)', async () => {
+  const get = async (p) => {
+    const repo = (p.match(/repos\/unfoldingWord\/([^/]+)\//) || [])[1];
+    if (/\/pulls\/12\/files/.test(p)) return { status: 200, data: [{ filename: 'tn_PSA.tsv' }] };
+    if (/\/pulls\?/.test(p)) {
+      const data = (repo === 'en_tn' && /page=1/.test(p))
+        ? [
+            { number: 12, merged: true, merged_at: '2026-06-23T10:00:00Z', head: {}, base: { sha: 'b' }, user: { login: 'pjoakes' } },
+            { number: 13, merged: true, merged_at: '2026-06-23T11:00:00Z', head: {}, base: { sha: 'b' }, user: { login: 'randouser' } },
+          ]
+        : [];
+      return { status: 200, data };
+    }
+    return { status: 200, data: [] };
+  };
+  const units = await watcher.enumerateUnits({ apiGetImpl: get, sinceIso: '2026-06-20T00:00:00Z', editorMap: { pjoakes: 'pjoakes' } });
+  const merged = units.filter((u) => u.kind === 'merged-pr');
+  assert.equal(merged.length, 1); // PR 13 by unknown author is skipped
+  assert.equal(merged[0].book, 'PSA');
+  assert.equal(merged[0].editor, 'pjoakes');
+});
+
+test('runOvernightReview throws on a non-200 pulls response (does not silently advance state)', async () => {
+  const badGet = async (p) => (/\/pulls\?/.test(p) ? { status: 403, data: { message: 'forbidden' } } : { status: 200, data: [] });
+  await assert.rejects(
+    () => watcher.runOvernightReview({
+      skillsRepo: '/skills', now: new Date('2026-06-24T07:00:00Z'),
+      deps: {
+        readFileSync: () => JSON.stringify({ version: 1, initialized: true, lastRun: '2026-06-20T00:00:00Z', reviewed: {}, branchTips: {} }),
+        writeFileSync: () => { throw new Error('should not write on enumeration failure'); },
+        mkdirSync: () => {}, editorMap: {}, apiGetImpl: badGet, fetchTextImpl: async () => '', log: () => {},
+      },
+    }),
+    /pulls query failed/,
+  );
+});
+
+test('runOvernightReview defers a unit on transient fetch failure (not marked reviewed, lastRun held)', async () => {
+  const writes = [];
+  const initState = JSON.stringify({ version: 1, initialized: true, lastRun: '2026-06-20T00:00:00Z', reviewed: {}, branchTips: {} });
+  const prs = { en_tn: [{ number: 9, merged: true, merged_at: '2026-06-23T22:00:00Z', head: { ref: 'PSA-be-pjoakes', sha: 'newhead' }, base: { sha: 'oldbase' }, user: { login: 'pjoakes' } }] };
+  const res = await watcher.runOvernightReview({
+    skillsRepo: '/skills', now: new Date('2026-06-24T07:00:00Z'),
+    deps: {
+      readFileSync: () => initState,
+      writeFileSync: (pth, content) => writes.push({ pth, content }),
+      mkdirSync: () => {}, editorMap: { pjoakes: 'pjoakes' },
+      apiGetImpl: fakeApiGet(prs, {}),
+      fetchTextImpl: async () => { throw new Error('HTTP 500 for x'); }, // transient (not 404)
+      log: () => {},
+    },
+  });
+  assert.equal(res.reviewed, 0);
+  assert.equal(res.failed, 1);
+  const stateWrite = writes.find((w) => /state\.json$/.test(w.pth));
+  const saved = JSON.parse(stateWrite.content);
+  assert.equal(Object.keys(saved.reviewed).length, 0); // failed unit NOT recorded
+  assert.equal(saved.lastRun, '2026-06-20T00:00:00Z'); // watermark held (not advanced)
+});
+
 test('runOvernightReview reviews a fresh merged TN PR and emits proposals', async () => {
   const writes = [];
   const initState = JSON.stringify({ version: 1, initialized: true, lastRun: '2026-06-20T00:00:00Z', reviewed: {}, branchTips: {} });

--- a/test/phase3.test.js
+++ b/test/phase3.test.js
@@ -1,0 +1,141 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createGuardHooks, decidePreToolUse, isProtectedPath, extractPathFromToolInput, isWriteTool,
+} = require('../src/guard-hooks');
+const { resolveAutoModel } = require('../src/api-runner/provider-config');
+const { renderIndex, hashDecisions, buildQuickRefCache } = require('../src/quickref-cache');
+const { buildOptions } = require('../src/claude-runner');
+
+// --- guard-hooks -------------------------------------------------------------
+test('isProtectedPath matches the canonical files (suffix/basename/SKILL.md regex), not the writable decision CSVs', () => {
+  assert.ok(isProtectedPath('data/issues_resolved.txt'));
+  assert.ok(isProtectedPath('/abs/skills/data/issues_resolved.txt'));
+  assert.ok(isProtectedPath('data/glossary/hebrew_ot_glossary.csv'));
+  assert.ok(isProtectedPath('.claude/skills/ULT-gen/SKILL.md'));
+  assert.equal(isProtectedPath('data/quick-ref/ult_decisions.csv'), false);
+  assert.equal(isProtectedPath('data/glossary/project_glossary.md'), false);
+  assert.equal(isProtectedPath(null), false);
+});
+
+test('extractPathFromToolInput pulls the path across common tool input shapes', () => {
+  assert.equal(extractPathFromToolInput('Write', { file_path: 'a.txt' }), 'a.txt');
+  assert.equal(extractPathFromToolInput('Edit', { path: 'b.txt' }), 'b.txt');
+  assert.equal(extractPathFromToolInput('NotebookEdit', { notebook_path: 'n.ipynb' }), 'n.ipynb');
+  assert.equal(extractPathFromToolInput('Read', {}), null);
+});
+
+test('isWriteTool recognizes core editors and MCP write/append tools', () => {
+  assert.ok(isWriteTool('Write'));
+  assert.ok(isWriteTool('Edit'));
+  assert.ok(isWriteTool('mcp__workspace-tools__append_quickref'));
+  assert.equal(isWriteTool('Read'), false);
+  assert.equal(isWriteTool('mcp__workspace-tools__prepare_compare'), false);
+});
+
+test('decidePreToolUse: allowlist, blocklist, and protected-write denial', () => {
+  // allowlist: deny anything not listed
+  const allowPolicy = { allowedTools: new Set(['Read', 'Grep']) };
+  assert.equal(decidePreToolUse({ tool_name: 'Read' }, allowPolicy), require('../src/guard-hooks').decidePreToolUse({ tool_name: 'Read' }, allowPolicy)); // ALLOW sentinel is stable
+  assert.equal(decidePreToolUse({ tool_name: 'Read' }, allowPolicy).hookSpecificOutput, undefined);
+  const denied = decidePreToolUse({ tool_name: 'Bash' }, allowPolicy);
+  assert.equal(denied.hookSpecificOutput.permissionDecision, 'deny');
+  // blocklist
+  const blockPolicy = { blockedTools: new Set(['Bash']) };
+  assert.equal(decidePreToolUse({ tool_name: 'Bash' }, blockPolicy).hookSpecificOutput.permissionDecision, 'deny');
+  assert.equal(decidePreToolUse({ tool_name: 'Read' }, blockPolicy).hookSpecificOutput, undefined);
+  // protected write
+  const w = decidePreToolUse({ tool_name: 'Write', tool_input: { file_path: 'data/issues_resolved.txt' } }, {});
+  assert.equal(w.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(w.hookSpecificOutput.permissionDecisionReason, /protected canonical/);
+  // writable decision CSV is allowed
+  assert.equal(decidePreToolUse({ tool_name: 'Write', tool_input: { file_path: 'data/quick-ref/ult_decisions.csv' } }, {}).hookSpecificOutput, undefined);
+});
+
+test('createGuardHooks returns a PreToolUse hook whose callback denies a protected write', async () => {
+  const hooks = createGuardHooks({ publish: false });
+  assert.ok(Array.isArray(hooks.PreToolUse));
+  const cb = hooks.PreToolUse[0].hooks[0];
+  const out = await cb({ tool_name: 'Write', tool_input: { file_path: 'data/glossary/hebrew_ot_glossary.csv' } });
+  assert.equal(out.hookSpecificOutput.permissionDecision, 'deny');
+  const ok = await cb({ tool_name: 'Read', tool_input: { file_path: 'x' } });
+  assert.equal(ok.hookSpecificOutput, undefined);
+  // observeFailures defaults off → no PostToolUseFailure hook
+  assert.equal(hooks.PostToolUseFailure, undefined);
+  assert.ok(createGuardHooks({ publish: false, observeFailures: true }).PostToolUseFailure);
+});
+
+// --- model routing -----------------------------------------------------------
+test('resolveAutoModel maps Claude effort tiers to the right model family and honors explicit model', () => {
+  // Assert family (robust to the exact deployed version: /config may pin a
+  // different Opus/Sonnet/Haiku point release than the repo defaults).
+  assert.match(resolveAutoModel('claude', null, 'high'), /opus/);
+  assert.match(resolveAutoModel('claude', null, 'xhigh'), /opus/);
+  assert.match(resolveAutoModel('claude', null, 'max'), /opus/);
+  assert.match(resolveAutoModel('claude', null, 'medium'), /sonnet/);
+  assert.match(resolveAutoModel('claude', null, 'low'), /haiku/);
+  assert.match(resolveAutoModel('claude', null, 'none'), /haiku/);
+  // unset effort -> medium default -> Sonnet
+  assert.match(resolveAutoModel('claude', null, undefined), /sonnet/);
+  // explicit model/alias always wins: 'opus' with low effort must NOT route to Haiku.
+  assert.match(resolveAutoModel('claude', 'opus', 'low'), /opus/);
+  // full model id passes through verbatim
+  assert.equal(resolveAutoModel('claude', 'claude-sonnet-4-6', 'high'), 'claude-sonnet-4-6');
+  // null-safe for a provider without an autoModelByThinking map -> defaultModel
+  assert.ok(resolveAutoModel('openai', null, 'high'));
+});
+
+// --- memory pilot ------------------------------------------------------------
+const SAMPLE = [
+  { type: 'quick-ref', resource: 'ult', strong: 'H727', hebrew: 'x', rendering: 'Box', book: 'ALL', context: 'ark', notes: 'cap' },
+  { type: 'glossary', resource: 'project_glossary', strong: 'H4869', hebrew: 'y', rendering: 'stronghold', book: 'ALL', context: '', notes: '' },
+];
+
+test('hashDecisions is stable and content-sensitive', () => {
+  assert.equal(hashDecisions(SAMPLE), hashDecisions([...SAMPLE].reverse()));
+  const changed = [{ ...SAMPLE[0], rendering: 'Chest' }, SAMPLE[1]];
+  assert.notEqual(hashDecisions(SAMPLE), hashDecisions(changed));
+});
+
+test('renderIndex emits the DERIVED header and groups by resource', () => {
+  const md = renderIndex(SAMPLE);
+  assert.match(md, /DERIVED — do not edit/);
+  assert.match(md, /## ult/);
+  assert.match(md, /## project_glossary/);
+  assert.match(md, /H727[^\n]*→ "Box"/);
+});
+
+test('buildQuickRefCache builds then skips when unchanged (content-hash keyed)', () => {
+  const store = {};
+  const deps = {
+    loadHumanDecisions: () => SAMPLE,
+    writeFileSync: (p, c) => { store[p] = c; },
+    readFileSync: (p) => { if (p in store) return store[p]; throw new Error('enoent'); },
+    existsSync: (p) => p in store,
+    mkdirSync: () => {},
+  };
+  const first = buildQuickRefCache({ skillsRoot: '/skills', outDir: '/out', deps });
+  assert.equal(first.built, true);
+  assert.equal(first.entries, 2);
+  const second = buildQuickRefCache({ skillsRoot: '/skills', outDir: '/out', deps });
+  assert.equal(second.built, false);
+  assert.equal(second.reason, 'unchanged');
+});
+
+// --- buildOptions threading (behavior preservation) --------------------------
+test('buildOptions threads hooks + compaction additively and is a no-op when unset', () => {
+  const SENTINEL = { PreToolUse: [] };
+  assert.equal(buildOptions({ model: 'opus', hooks: SENTINEL }).hooks, SENTINEL);
+  const withCompact = buildOptions({ model: 'opus', compaction: { enabled: true, window: 5 } });
+  assert.equal(withCompact.settings.autoCompactEnabled, true);
+  assert.equal(withCompact.settings.autoCompactWindow, 5);
+  // unset -> no hooks key, no compaction settings (byte-identical to today)
+  const plain = buildOptions({ model: 'opus' });
+  assert.equal('hooks' in plain, false);
+  assert.equal(plain.settings, undefined);
+  // compaction spread-merges with the sandbox settings, not clobbers them
+  const both = buildOptions({ model: 'opus', forceNoAutoBashSandbox: true, compaction: { enabled: true } });
+  assert.equal(both.settings.sandbox.enabled, true);
+  assert.equal(both.settings.autoCompactEnabled, true);
+});

--- a/test/phase3.test.js
+++ b/test/phase3.test.js
@@ -53,6 +53,24 @@ test('decidePreToolUse: allowlist, blocklist, and protected-write denial', () =>
   assert.equal(decidePreToolUse({ tool_name: 'Write', tool_input: { file_path: 'data/quick-ref/ult_decisions.csv' } }, {}).hookSpecificOutput, undefined);
 });
 
+test('decidePreToolUse blocks MCP writes to protected files (via write-fields) but never blocks reads', () => {
+  // MCP write tool targeting a protected file via an `output` field -> deny
+  assert.equal(
+    decidePreToolUse({ tool_name: 'mcp__workspace-tools__assemble_notes', tool_input: { output: 'data/issues_resolved.txt' } }, {}).hookSpecificOutput.permissionDecision,
+    'deny',
+  );
+  // MCP tool READING a protected file via `input` -> allowed (reads must work)
+  assert.equal(
+    decidePreToolUse({ tool_name: 'mcp__workspace-tools__some_reader', tool_input: { input: 'data/issues_resolved.txt' } }, {}).hookSpecificOutput,
+    undefined,
+  );
+  // core Read of a protected glossary -> allowed
+  assert.equal(
+    decidePreToolUse({ tool_name: 'Read', tool_input: { file_path: 'data/glossary/hebrew_ot_glossary.csv' } }, {}).hookSpecificOutput,
+    undefined,
+  );
+});
+
 test('createGuardHooks returns a PreToolUse hook whose callback denies a protected write', async () => {
   const hooks = createGuardHooks({ publish: false });
   assert.ok(Array.isArray(hooks.PreToolUse));


### PR DESCRIPTION
## Overnight Sensor + TN comparator + Phase 3 platform hardening

Part of the "managed-agent patterns" build. **Everything new is additive and default-OFF** — with the flags unset, runtime behavior is byte-identical.

### Overnight Sensor (Phase 2)
- `src/overnight-watcher.js` — detects human edits merged into Door43 `-be-` branches and emits an attributed proposal feed. Robust to overnight branch deletion: derives BOOK from the PR **files** endpoint (Gitea strips `head.ref` after deletion) + known-editor author; primary path still uses `head.ref` when present.
- `src/overnight-review-state.js` — idempotent state keyed by PR id + headSha; cold-start records HEADs and reviews nothing night 1; non-200 Gitea status aborts the run (no silent skip); transient fetch failures defer the unit (watermark held).
- `prepare_compare_tn` in `src/workspace-tools/tsv-tools.js` — row-keyed TN TSV diff (`reworded`/`quote-changed`/`dropped`/`added`), ignores the random ID column + cosmetic deltas, keys on Reference+SupportReference+Quote+Occurrence.
- Exported reuse primitives from `check-ult-edits.js` and `repo-verify.js`.

### Phase 3 (additive, gated)
- **Hooks**: `claude-runner.buildOptions` threads optional `hooks` + `compaction` (Agent-SDK `settings.autoCompactEnabled`, not the raw-API beta). `src/guard-hooks.js` blocks writes to protected canonical files (across core + MCP write tools) and publishes to admin-status; wired into self-diagnosis + notes pipeline behind `BP_GUARD_HOOKS=1`.
- **Model routing**: `resolveAutoModel` + `autoModelByThinking` (low→Haiku, medium→Sonnet, high+→Opus); notes pipeline routes unset-model skills by effort behind `BP_AUTO_MODEL=1`. Refreshed the stale opus 4.7→4.8 JS default.
- **Memory pilot**: `src/quickref-cache.js` — derived, content-hash-keyed read index from the decision CSVs (CSVs remain source of truth); opt-in.

### Verification
`node --test`: **330/330**. Sensor verified live against Door43 (cold-start). A `codex exec` second opinion was run and all High/Medium findings fixed (head.ref→files fallback, Gitea status guard, transient deferral, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
