### PR TITLE
feat(generate): --text-only pushes unaligned USFM to Door43 (keeps the file too)

### DIFF
--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -1555,13 +1555,13 @@ async function generatePipeline(route, message) {
       const pushUlt = !noPush && contentTypes.includes('ult') && chData.ultAligned;
       const pushUst = !noPush && contentTypes.includes('ust') && chData.ustAligned;
       if (pushUlt && !fs.existsSync(path.resolve(CSKILLBP_DIR, chData.ultAligned))) {
-        const ultMissingEvent = await status(`**door43-push** failed (ULT) for ${book} ${chData.ch}: aligned source file missing: ${chData.ultAligned}`);
-        fireDiagnosisFor(ultMissingEvent, `Phase: door43-push (ULT)\nChapter: ${book} ${chData.ch}\nAligned source file missing at push time: ${chData.ultAligned}`);
+        const ultMissingEvent = await status(`**door43-push** failed (ULT) for ${book} ${chData.ch}: source file missing: ${chData.ultAligned}`);
+        fireDiagnosisFor(ultMissingEvent, `Phase: door43-push (ULT)\nChapter: ${book} ${chData.ch}\nSource file missing at push time: ${chData.ultAligned}`);
         chapterFailed = true;
       }
       if (!chapterFailed && pushUst && !fs.existsSync(path.resolve(CSKILLBP_DIR, chData.ustAligned))) {
-        const ustMissingEvent = await status(`**door43-push** failed (UST) for ${book} ${chData.ch}: aligned source file missing: ${chData.ustAligned}`);
-        fireDiagnosisFor(ustMissingEvent, `Phase: door43-push (UST)\nChapter: ${book} ${chData.ch}\nAligned source file missing at push time: ${chData.ustAligned}`);
+        const ustMissingEvent = await status(`**door43-push** failed (UST) for ${book} ${chData.ch}: source file missing: ${chData.ustAligned}`);
+        fireDiagnosisFor(ustMissingEvent, `Phase: door43-push (UST)\nChapter: ${book} ${chData.ch}\nSource file missing at push time: ${chData.ustAligned}`);
         chapterFailed = true;
       }
 

--- a/src/generate-pipeline.js
+++ b/src/generate-pipeline.js
@@ -191,6 +191,15 @@ function shouldUseFileResponseMode({ isFileResponse, noAlign, textOnly }) {
   return Boolean(isFileResponse || noAlign || textOnly);
 }
 
+// Whether a run also pushes generated USFM to Door43 (Phase 2). Normal aligned
+// runs always push. File-response / --no-align runs do NOT — EXCEPT --text-only,
+// which is special: it uploads the file to Zulip (file-response mode) AND pushes
+// the *unaligned* USFM to Door43 so the editor's output[] is populated. A plain
+// file-response user (no --text-only) still gets upload-only, no push.
+function shouldPushToDoor43({ useFileResponseMode, textOnly }) {
+  return !useFileResponseMode || Boolean(textOnly);
+}
+
 function hasRequiredGeneratedOutputs(contentTypes, outputs) {
   const neededTypes = Array.isArray(contentTypes) && contentTypes.length ? contentTypes : ['ult', 'ust'];
   return neededTypes.every((type) => (type === 'ult' ? outputs.hasUlt : outputs.hasUst));
@@ -452,9 +461,9 @@ async function generatePipeline(route, message) {
   const perChapter = (route.tokenEstimate && route.tokenEstimate.perChapter) || 5000000;
   const estimatedTotal = chapterCount * perChapter;
 
-  // --- Non-file-response pre-checks: Door43 username ---
+  // --- Door43 username pre-check (any run that pushes — incl. --text-only) ---
   let username = null;
-  if (!useFileResponseMode) {
+  if (shouldPushToDoor43({ useFileResponseMode, textOnly })) {
     username = getDoor43Username(message.sender_email);
     if (!username) {
       username = emailToFallbackUsername(message.sender_email);
@@ -476,7 +485,7 @@ async function generatePipeline(route, message) {
   // Signal working
   await addReaction(msgId, 'working_on_it');
   const typeLabel = contentTypes.length === 1 ? `${contentTypes[0].toUpperCase()}-only` : 'full pipeline';
-  const alignLabel = textOnly ? 'text-only uploads' : noAlign ? 'files-only' : alignOnly ? 'align-only' : 'align + repo-insert';
+  const alignLabel = textOnly ? 'text-only (upload + unaligned push)' : noAlign ? 'files-only' : alignOnly ? 'align-only' : 'align + repo-insert';
   const modeLabel = useFileResponseMode ? alignLabel : `${typeLabel} (${alignLabel})`;
   const refLabel = hasVerseRange ? `${book} ${start}:${verseStart}-${verseEnd}` : `${book} ${start}\u2013${end}`;
   await status(`Starting generation for **${refLabel}** (${chapterCount} chapter(s), mode: ${modeLabel}, ~${estimatedTotal} tokens estimated)`);
@@ -1037,6 +1046,19 @@ async function generatePipeline(route, message) {
 
       await reply(`**${book} ${ch}** \u2014 ${links.join(' \u00b7 ')}`);
       success++;
+      // --text-only uploads the file (above) AND pushes the unaligned USFM to
+      // Door43 via Phase 2 below, so the editor's output[] is populated. Record
+      // the unaligned source paths in the same ult/ustAligned slots Phase 2
+      // reads (here they hold UNaligned output). Gate by contentTypes so a stale
+      // off-type artifact from a prior run is never pushed. --no-align and plain
+      // file-response users skip this and stay upload-only.
+      if (textOnly && !completedChapters.some((c) => c.ch === ch)) {
+        completedChapters.push({
+          ch,
+          ultAligned: (contentTypes.includes('ult') && hasUlt) ? ultRel : null,
+          ustAligned: (contentTypes.includes('ust') && hasUst) ? ustRel : null,
+        });
+      }
       setCheckpoint(checkpointRef, {
         state: 'running',
         success,
@@ -1397,9 +1419,9 @@ async function generatePipeline(route, message) {
   }
 
   // =========================================================================
-  // Phase 2: Repo insert \u2014 push to master (non-file-response users only)
+  // Phase 2: Repo insert \u2014 push to master (non-file-response runs + --text-only)
   // =========================================================================
-  if (!useFileResponseMode && completedChapters.length > 0) {
+  if (shouldPushToDoor43({ useFileResponseMode, textOnly }) && completedChapters.length > 0) {
     // Pre-flight: verify DCS token before spending time on repo-insert
     const dcsCheck = await verifyDcsToken();
     if (!dcsCheck.valid) {
@@ -1689,7 +1711,7 @@ async function generatePipeline(route, message) {
   }
 
   // Final message
-  if (!useFileResponseMode && success > 0) {
+  if (shouldPushToDoor43({ useFileResponseMode, textOnly }) && success > 0) {
     const rangeLabel = hasVerseRange
       ? `${book} ${start}:${verseStart}-${verseEnd}`
       : (start === end ? `${book} ${start}` : `${book} ${start}\u2013${end}`);
@@ -1725,5 +1747,6 @@ module.exports = {
   buildParsedGenerateRequest,
   hasRequiredGeneratedOutputs,
   shouldUseFileResponseMode,
+  shouldPushToDoor43,
   resolveMergedChapterAligned,
 };

--- a/test/pipeline-regressions.test.js
+++ b/test/pipeline-regressions.test.js
@@ -11,6 +11,7 @@ const {
   buildParsedGenerateRequest,
   hasRequiredGeneratedOutputs,
   shouldUseFileResponseMode,
+  shouldPushToDoor43,
 } = require('../src/generate-pipeline');
 const {
   parseWriteNotesCommand,
@@ -86,6 +87,18 @@ test('text-only mode uses file-response delivery even for non-file users', () =>
   assert.equal(shouldUseFileResponseMode({ isFileResponse: false, noAlign: false, textOnly: false }), false);
   assert.equal(shouldUseFileResponseMode({ isFileResponse: true, noAlign: false, textOnly: false }), true);
   assert.equal(shouldUseFileResponseMode({ isFileResponse: false, noAlign: true, textOnly: false }), true);
+});
+
+test('text-only mode ALSO pushes to Door43 (upload + push), but --no-align does not', () => {
+  // Normal aligned run: pushes (not file-response).
+  assert.equal(shouldPushToDoor43({ useFileResponseMode: false, textOnly: false }), true);
+  // --text-only: file-response (uploads the file) AND pushes the unaligned USFM
+  // so the editor's output[] is populated.
+  assert.equal(shouldPushToDoor43({ useFileResponseMode: true, textOnly: true }), true);
+  // --no-align (file-response, not text-only): upload-only, no push.
+  assert.equal(shouldPushToDoor43({ useFileResponseMode: true, textOnly: false }), false);
+  // Plain file-response user, no text-only: upload-only, no push.
+  assert.equal(shouldPushToDoor43({ useFileResponseMode: true, textOnly: false }), false);
 });
 
 test('synthetic generate route preserves verse ranges from intent scopeText', () => {

--- a/test/pipeline-regressions.test.js
+++ b/test/pipeline-regressions.test.js
@@ -95,9 +95,13 @@ test('text-only mode ALSO pushes to Door43 (upload + push), but --no-align does 
   // --text-only: file-response (uploads the file) AND pushes the unaligned USFM
   // so the editor's output[] is populated.
   assert.equal(shouldPushToDoor43({ useFileResponseMode: true, textOnly: true }), true);
-  // --no-align (file-response, not text-only): upload-only, no push.
-  assert.equal(shouldPushToDoor43({ useFileResponseMode: true, textOnly: false }), false);
-  // Plain file-response user, no text-only: upload-only, no push.
+  // --no-align: composition of the two predicates — file-response (upload) but
+  // NOT a push, since noAlign drives useFileResponseMode without textOnly.
+  const noAlign = { isFileResponse: false, noAlign: true, textOnly: false };
+  const noAlignFRM = shouldUseFileResponseMode(noAlign);
+  assert.equal(noAlignFRM, true);
+  assert.equal(shouldPushToDoor43({ useFileResponseMode: noAlignFRM, textOnly: noAlign.textOnly }), false);
+  // Plain file-response user (no flags): upload-only, no push.
   assert.equal(shouldPushToDoor43({ useFileResponseMode: true, textOnly: false }), false);
 });
 


### PR DESCRIPTION
## What

`--text-only` (and the API's `{ textOnly: true }`) now **uploads the file to Zulip AND pushes the unaligned USFM to Door43**, so it lands in the pipeline API's `output[]`.

## Why

bible-editor imports pipeline results exclusively from `output[]`. A `textOnly` sub-run produced the USFM but only surfaced it as a Zulip attachment — the Door43 push was gated out by `useFileResponseMode`, so `detectLandedOutputs` found no merged PR and `output[]` stayed empty. The editor never received it.

Chris (primary `--text-only` user, increasingly for the UST) still wants the Zulip file, so this keeps the upload and *adds* the push rather than rerouting. Pushing the unedited AI USFM to master is acceptable — he overwrites it on upload anyway.

## Changes (`src/generate-pipeline.js`)

- New `shouldPushToDoor43({ useFileResponseMode, textOnly })` = `!useFileResponseMode || textOnly`. `--text-only` stays file-response (upload preserved) but is now also flagged to push; `--no-align` and plain file-response users stay upload-only.
- Door43 username pre-check now runs for `--text-only` (push needs attribution).
- Upload block records the **unaligned** source paths into `completedChapters`, gated by `contentTypes` so a stale off-type artifact is never pushed.
- Phase 2 push gate and the final "pushed to master" reply route through `shouldPushToDoor43`.

`output[]` needs **no** changes: `detectLandedOutputs` keys off the merged `AI-{BOOK}-{CHAPTER}` PR, which `door43Push` creates regardless of alignment (ULT/UST have no CI gate). So `{ contentTypes:["ust"], textOnly:true }` → one `en_ust` row; `{ textOnly:true }` → two.

## Tests

- Full suite: **331/331 pass**.
- Adds a `shouldPushToDoor43` regression (text-only pushes; `--no-align` / plain file-response don't); kept the existing "text-only still uses file-response" test.

## Notes / follow-ups

- `completedChapters[].ultAligned/ustAligned` hold *unaligned* paths in this mode — slots reused (with a comment) to avoid rippling a rename through Phase 2 + the checkpoint shape. Phase 2 treats them purely as a push source.
- Resume parity: interrupted `--text-only` resumes via the same two-phase machinery as a normal generate; if interrupted before push it may re-generate + re-upload that chapter, then Phase 2 dedups the push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
